### PR TITLE
Merge reliability stabilization and release hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,3 +34,21 @@ jobs:
           TEST_SCRATCH: .build-ci-test
           RUN_DRBENCH: "1"
         run: ./Scripts/check.sh
+
+  app-acceptance:
+    # Unit tests exercise the package graph without an activated NSApplication.
+    # Keep this as a separate required lane so a green headless run cannot hide
+    # a stale bundle, missing nested code, or a broken real window.
+    runs-on: macos-26
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+      - name: Select and verify the Swift toolchain
+        run: ./Scripts/select-toolchain.sh
+      - name: Install xcodegen
+        run: brew install xcodegen
+      - name: Build and run the activated-app acceptance suite
+        env:
+          APP_ACCEPTANCE_SCRATCH: .build-ci-app
+          SPOTLIGHT_SCRATCH: .build-ci-app-spm
+        run: ./Scripts/check-app.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,6 +170,11 @@ jobs:
           done < <(find "$APP" -type d -name "*.bundle")
           # The manual embed above put Sparkle in place; prove it.
           test -d "$APP/Contents/Frameworks/Sparkle.framework"
+          # A classic MDImporter is nested code too. Build it from the same
+          # source as local bundles before the signing step seals the archive.
+          APP="$APP" SPOTLIGHT_SCRATCH=.build-release-spm \
+            SPOTLIGHT_CONFIGURATION=release \
+            Scripts/bundle-spotlight.sh
 
       # ---------------------------------------------------------------- signing
       - name: Import Developer ID into ephemeral keychain
@@ -223,6 +228,11 @@ jobs:
           sign "$SPARKLE_VERSION/Autoupdate"
           sign "$SPARKLE_VERSION/Updater.app"
           sign "$SPARKLE"
+          # Spotlight importer: sign the Mach-O bundle first, then its
+          # containing .mdimporter bundle, before the host resource envelope.
+          SPOTLIGHT="$APP/Contents/Library/Spotlight/DownrightSpotlight.mdimporter"
+          sign "$SPOTLIGHT/Contents/MacOS/DownrightSpotlight"
+          sign "$SPOTLIGHT"
           # Quick Look extensions.
           for appex in "$APP"/Contents/PlugIns/*.appex; do
             sign_quicklook "$appex"
@@ -233,6 +243,8 @@ jobs:
           sign "$APP"
           # Verify each individually.
           for item in "$APP" "$APP/Contents/Frameworks/Sparkle.framework" \
+              "$APP/Contents/Library/Spotlight/DownrightSpotlight.mdimporter" \
+              "$APP/Contents/Library/Spotlight/DownrightSpotlight.mdimporter/Contents/MacOS/DownrightSpotlight" \
               "$APP"/Contents/Frameworks/Sparkle.framework/Versions/*/XPCServices/*.xpc \
               "$APP"/Contents/Frameworks/Sparkle.framework/Versions/*/Autoupdate \
               "$APP"/Contents/Frameworks/Sparkle.framework/Versions/*/Updater.app \

--- a/Config/DownrightSpotlight-Info.plist
+++ b/Config/DownrightSpotlight-Info.plist
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDisplayName</key>
+	<string>Downright Spotlight Importer</string>
+	<key>CFBundleExecutable</key>
+	<string>DownrightSpotlight</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.ezzy.downright.spotlight</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>DownrightSpotlight</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>LSMinimumSystemVersion</key>
+	<string>14.0</string>
+	<key>CFPlugInDynamicRegistration</key>
+	<false/>
+	<key>CFPlugInDynamicRegisterFunction</key>
+	<string></string>
+	<key>CFPlugInUnloadFunction</key>
+	<string></string>
+	<key>CFPlugInFactories</key>
+	<dict>
+		<key>E55A6D2B-5C76-4E83-9C13-6F4BF1D98D77</key>
+		<string>MetadataImporterPluginFactory</string>
+	</dict>
+	<key>CFPlugInTypes</key>
+	<dict>
+		<key>8B08C4BF-415B-11D8-B3F9-0003936726FC</key>
+		<array>
+			<string>E55A6D2B-5C76-4E83-9C13-6F4BF1D98D77</string>
+		</array>
+	</dict>
+	<key>CFBundleDocumentTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>Markdown Document</string>
+			<key>CFBundleTypeRole</key>
+			<string>MDImporter</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>net.daringfireball.markdown</string>
+				<string>com.ezzy.downright.markdown</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/Docs/ARCHITECTURE.md
+++ b/Docs/ARCHITECTURE.md
@@ -20,12 +20,15 @@ Sources/
   DownrightApp/     windows, commands, panels, file and agent workflows
   DownrightQL/      Quick Look preview extension
   DownrightThumb/   Quick Look thumbnail extension
+  DownrightSpotlightMetadata/  shared parser-backed metadata extraction
+  DownrightSpotlightImporter/  classic macOS MDImporter plug-in
   down/             terminal launcher
 ```
 
 `MarkdownCore` has no UI dependency. `MarkdownRender` owns AppKit rendering.
 The app owns windows, file access, and user actions. Quick Look uses the same
-core and render contracts as the app.
+core and render contracts as the app. The Spotlight targets share only the
+parser-backed metadata contract and never start an AppKit surface.
 
 ## Document pipeline
 
@@ -103,7 +106,13 @@ watcher, save, or navigation work.
 No remote model, telemetry, or background prompt runs in the core path. A
 future provider must be explicit, opt-in, and separately reviewed.
 
-## Quick Look
+## Quick Look and Spotlight
+
+The filesystem Spotlight importer lives at
+`Downright.app/Contents/Library/Spotlight`. Its `schema.xml` declares only
+title, text content, keywords, and kind. It extracts metadata from unopened
+Markdown files, while `CoreSpotlight` remains the fast path for documents the
+app has already opened.
 
 Quick Look and thumbnail targets share parser, theme, and render contracts but
 have strict limits:
@@ -114,7 +123,8 @@ have strict limits:
 - Keep preview work below 400 ms and 60 MB peak.
 
 The host app must be launched once before the extensions register. Xcode is
-needed to bundle the `.appex` targets.
+needed to bundle the `.appex` targets; the Spotlight importer is bundled by
+both the SwiftPM and Xcode paths.
 
 ## Concurrency and effects
 

--- a/Docs/FEATURE-MATRIX.md
+++ b/Docs/FEATURE-MATRIX.md
@@ -40,7 +40,7 @@ not public releases.
 | Preferences | Appearance, typography, editor, keys, advanced | P8 | Settings round-trip and apply live |
 | Accessibility | VoiceOver, keyboard, contrast, motion, transparency | P8 | Accessibility audit has no release blocker |
 | CLI | `down` and `md` open files and stdin | P8 | Terminal launch opens the target document |
-| System integration | Quick Look, Spotlight, Services, Share, App Intents | P8 | Each entry opens the exact file or command |
+| System integration | Quick Look, unopened-file Spotlight metadata, Services, Share, App Intents | P8 | Each entry opens or indexes the exact file or command |
 | AI | Optional on-device Apple Intelligence tools only | P9 | Core path works with AI absent or disabled |
 
 ## Explicitly out of scope

--- a/Docs/RELEASE.md
+++ b/Docs/RELEASE.md
@@ -14,11 +14,11 @@ no Xcode project involved. What it cannot do:
 | Needs Xcode | Why |
 |---|---|
 | Quick Look `.appex` bundles | Use `Scripts/bundle-xcode-app.sh`. It generates the Xcode project and embeds both signed extension targets. See [QUICKLOOK.md](QUICKLOOK.md). |
-| Production Sparkle packaging | Release builds sign every nested helper and the framework separately, notarise, and staple. |
+| Production Sparkle and Spotlight packaging | Release builds sign every nested helper, the classic Spotlight importer, and the framework separately, then notarise and staple. |
 | Developer ID signing and notarisation | Requires a certificate in the login keychain and an App Store Connect API key. |
 
-Everything else — the app, the render packages, the CLI, the tests — builds with
-the Command Line Tools alone. `swift build` fetches the Sparkle 2.9.5 binary
+Everything else — the app, the render packages, the CLI, the tests, and the
+Spotlight importer — builds with the Command Line Tools alone. `swift build` fetches the Sparkle 2.9.5 binary
 XCFramework (pinned exactly in `Package.swift`), so building the app needs
 network access the first time.
 
@@ -86,7 +86,7 @@ Scripts/sign-and-notarize.sh                     # sign, notarise, staple (+ DMG
 
 `Scripts/sign-and-notarize.sh` is the manual twin of the workflow's signing
 steps: it signs every nested executable individually (Sparkle framework and its
-XPC helpers, both Quick Look extensions, the `down` CLI, then the host — never
+XPC helpers, the Spotlight importer, both Quick Look extensions, the `down` CLI, then the host — never
 `codesign --deep`), verifies each, notarises with `notarytool`, staples, and
 runs the `codesign`/`spctl`/`stapler validate` battery. Set `NO_NOTARIZE=1` to
 sign with a real identity without submitting, and `MAKE_DMG=1` to additionally

--- a/Docs/STATUS.md
+++ b/Docs/STATUS.md
@@ -87,8 +87,8 @@ tags (`<Foo` still colours as a type); Ruby and shell heredocs are not tracked.
 `Vendor/SwiftMath`; see its `PATCHES.md`),
 `beautiful-mermaid-swift` for diagrams, `NLTokenizer` for sentence segmentation,
 and FSEvents (directory-level) for watching. No WebView is used. The Xcode
-release path includes Quick Look. It does not include a metadata importer, a
-Share extension, or Sparkle.
+release path includes Quick Look and the classic filesystem Spotlight
+importer. It does not include a Share extension.
 
 ## Open questions from §15, decided
 
@@ -195,9 +195,11 @@ Approximate:
   `Downright.app` locally, but the signed, notarised, stapled pipeline around it
   has never run end to end — that needs a tagged CI run, and until one happens
   the release path is unproven.
-- **Spotlight coverage for files that have not been opened.** Downright adds
-  each opened document to Core Spotlight. The metadata extractor for a full
-  importer exists, but the signed importer bundle does not.
+- **Spotlight acceptance on a clean installed artifact.** The classic
+  `MDImporter` target, schema, shared metadata extractor, bundle embedding, and
+  release signing hooks now exist. The remaining release gate is a live
+  `mdimport` run against a freshly installed signed/notarised artifact; local
+  source and bundle checks do not substitute for that OS registration proof.
 - **A dedicated Share extension.** The app provides a macOS Service and an App
   Intent. Finder's Share menu does not yet contain a Downright extension.
 - **System document versions.** Downright has undo, atomic saves, external

--- a/Package.swift
+++ b/Package.swift
@@ -59,6 +59,12 @@ let package = Package(
         .library(name: "MarkdownCore", targets: ["MarkdownCore"]),
         .library(name: "MarkdownRender", targets: ["MarkdownRender"]),
         .library(name: "drdownright", targets: ["drdownright"]),
+        .library(name: "DownrightSpotlightMetadata", targets: ["DownrightSpotlightMetadata"]),
+        .library(
+            name: "DownrightSpotlightImporter",
+            type: .dynamic,
+            targets: ["DownrightSpotlightImporter"]
+        ),
         .executable(name: "Downright", targets: ["DownrightApp"]),
         .executable(name: "down", targets: ["down"]),
         .executable(name: "drbench", targets: ["drbench"]),
@@ -99,11 +105,35 @@ let package = Package(
             resources: [.copy("Themes")],
             swiftSettings: [.swiftLanguageMode(.v5)]
         ),
+        // The app and the filesystem importer must derive Spotlight metadata
+        // from one parser-backed implementation. Keeping this target free of
+        // AppKit also lets mdworker load it without starting the application.
+        .target(
+            name: "DownrightSpotlightMetadata",
+            dependencies: ["MarkdownCore"],
+            swiftSettings: [.swiftLanguageMode(.v5)]
+        ),
+        // The CFPlugIn bridge is intentionally a tiny C target. It owns the
+        // ABI Spotlight loads; DownrightSpotlightMetadata owns all Markdown
+        // interpretation and is linked into this dynamic bundle.
+        .target(
+            name: "DownrightSpotlightImporter",
+            dependencies: ["DownrightSpotlightMetadata"],
+            path: "Sources/DownrightSpotlightImporter",
+            linkerSettings: [
+                .linkedFramework("CoreServices"),
+                // Spotlight's CFPlugIn loader expects an MH_BUNDLE image,
+                // which is distinct from the MH_DYLIB produced by a normal
+                // dynamic library product.
+                .unsafeFlags(["-Xlinker", "-bundle"]),
+            ]
+        ),
         .executableTarget(
             name: "DownrightApp",
             dependencies: [
                 "MarkdownCore",
                 "MarkdownRender",
+                "DownrightSpotlightMetadata",
                 // The app and `down` share one definition of the agent hook, so
                 // the Settings toggle and the CLI can never disagree about what
                 // is installed.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ account requirement, and never uses a WebView.
 |---|---|
 | Optional folder workspace and sibling-file search without a vault | Quick Look previews and Finder thumbnails |
 | Clickable `file.swift:42` references and editor handoff | `down` and `md` terminal commands |
-| Themes that follow macOS Light/Dark mode | HTML/PDF export, Services, Spotlight, and App Intents |
+| Themes that follow macOS Light/Dark mode | HTML/PDF export, Services, Spotlight metadata, and App Intents |
 | First-run setup for app association, CLI, and Quick Look | Optional on-device Apple Intelligence |
 
 Supported files: `.md`, `.markdown`, `.mdown`, `.mkd`, `.mdx`, `.mdc`, `.qmd`,
@@ -127,6 +127,8 @@ MarkdownRender   native decoration and layout
 DownrightApp     windows, commands, panels, file watching
 DownrightQL      Quick Look preview
 DownrightThumb   Finder thumbnails
+DownrightSpotlightMetadata  shared unopened-file metadata extraction
+DownrightSpotlightImporter  macOS filesystem Spotlight importer
 drdownright      shared CLI and integration support
 down             terminal entry point
 ```
@@ -158,6 +160,7 @@ Bundle verification:
 
 ```bash
 Scripts/verify-bundle.sh .build-main/bundle/Downright.app
+Scripts/check-app.sh
 ```
 
 ## Privacy

--- a/Resources/Spotlight/schema.xml
+++ b/Resources/Spotlight/schema.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema version="1.0"
+        xmlns="http://www.apple.com/metadata"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.apple.com/metadata file:///System/Library/Frameworks/CoreServices.framework/Frameworks/Metadata.framework/Resources/MetadataSchema.xsd">
+    <types>
+        <type name="net.daringfireball.markdown">
+            <allattrs>kMDItemTitle kMDItemTextContent kMDItemKeywords kMDItemKind</allattrs>
+            <displayattrs>kMDItemTitle kMDItemKeywords kMDItemKind</displayattrs>
+        </type>
+        <type name="com.ezzy.downright.markdown">
+            <allattrs>kMDItemTitle kMDItemTextContent kMDItemKeywords kMDItemKind</allattrs>
+            <displayattrs>kMDItemTitle kMDItemKeywords kMDItemKind</displayattrs>
+        </type>
+    </types>
+</schema>

--- a/Scripts/bundle-app.sh
+++ b/Scripts/bundle-app.sh
@@ -191,6 +191,11 @@ else
     echo "    updater disabled: no Sparkle Info.plist keys in this dev bundle"
 fi
 
+echo "==> Embedding Spotlight importer"
+APP="$APP" SPOTLIGHT_SCRATCH="$SCRATCH" \
+    SPOTLIGHT_CONFIGURATION="$CONFIGURATION" \
+    "$ROOT/Scripts/bundle-spotlight.sh"
+
 echo "==> Signing (ad-hoc)"
 # Sign Sparkle separately first (its XPC helpers are nested code), then the
 # app without --deep so the framework's signature is preserved.  --deep is a

--- a/Scripts/bundle-spotlight.sh
+++ b/Scripts/bundle-spotlight.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# Build and embed Downright's macOS Spotlight importer.
+#
+# A Spotlight importer is a classic CFPlugIn, not an app extension. The SwiftPM
+# target type-checks and links the importer ABI; this script supplies the
+# bundle layout that mdworker discovers inside a macOS app.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+APP="${APP:?APP must point to the Downright.app being assembled}"
+SPOTLIGHT_SCRATCH="${SPOTLIGHT_SCRATCH:-${SCRATCH:-.build-main}}"
+SPOTLIGHT_CONFIGURATION="${SPOTLIGHT_CONFIGURATION:-release}"
+
+[ -d "$APP/Contents" ] || {
+    echo "error: not an app bundle: $APP" >&2
+    exit 1
+}
+
+PLIST_VALUE() {
+    /usr/libexec/PlistBuddy -c "Print :$1" "$APP/Contents/Info.plist"
+}
+
+VERSION="$(PLIST_VALUE CFBundleShortVersionString)"
+BUILD="$(PLIST_VALUE CFBundleVersion)"
+
+echo "==> Building Spotlight importer ($SPOTLIGHT_CONFIGURATION)"
+swift build \
+    -c "$SPOTLIGHT_CONFIGURATION" \
+    --scratch-path "$SPOTLIGHT_SCRATCH" \
+    --product DownrightSpotlightImporter
+BIN_DIR="$(swift build \
+    -c "$SPOTLIGHT_CONFIGURATION" \
+    --scratch-path "$SPOTLIGHT_SCRATCH" \
+    --product DownrightSpotlightImporter \
+    --show-bin-path)"
+SOURCE="$BIN_DIR/libDownrightSpotlightImporter.dylib"
+[ -f "$SOURCE" ] || {
+    echo "error: SwiftPM did not produce $SOURCE" >&2
+    exit 1
+}
+
+IMPORTER="$APP/Contents/Library/Spotlight/DownrightSpotlight.mdimporter"
+EXECUTABLE="$IMPORTER/Contents/MacOS/DownrightSpotlight"
+RESOURCES="$IMPORTER/Contents/Resources"
+rm -rf "$IMPORTER"
+mkdir -p "$(dirname "$EXECUTABLE")" "$RESOURCES"
+
+cp "$SOURCE" "$EXECUTABLE"
+sed \
+    -e 's|\$(MARKETING_VERSION)|'"$VERSION"'|g' \
+    -e 's|\$(CURRENT_PROJECT_VERSION)|'"$BUILD"'|g' \
+    "$ROOT/Config/DownrightSpotlight-Info.plist" \
+    > "$IMPORTER/Contents/Info.plist"
+cp "$ROOT/Resources/Spotlight/schema.xml" "$RESOURCES/schema.xml"
+
+# The importer is nested code. Seal it before the host is sealed so both
+# ad-hoc development bundles and the production workflow have the same order.
+codesign --force --sign - \
+    --identifier com.ezzy.downright.spotlight.binary \
+    "$EXECUTABLE" 2>/dev/null \
+    || echo "    (codesign unavailable, continuing unsigned)"
+codesign --force --sign - \
+    --identifier com.ezzy.downright.spotlight \
+    "$IMPORTER" 2>/dev/null \
+    || echo "    (codesign unavailable, continuing unsigned)"
+
+echo "    embedded $IMPORTER"

--- a/Scripts/bundle-xcode-app.sh
+++ b/Scripts/bundle-xcode-app.sh
@@ -96,6 +96,11 @@ while IFS= read -r bundle; do
     rm -rf "$bundle/Contents"
 done < <(find "$APP" -type d -name "*.bundle")
 
+echo "==> Embedding Spotlight importer"
+APP="$APP" SPOTLIGHT_SCRATCH="$SWIFTPM_SCRATCH" \
+    SPOTLIGHT_CONFIGURATION=release \
+    "$ROOT/Scripts/bundle-spotlight.sh"
+
 # Sign inside-out, even for the ad-hoc QA bundle.  Re-sealing a child after its
 # parent invalidates the parent's resource envelope and hides release-only bugs.
 if [ -d "$APP/Contents/Frameworks/Sparkle.framework" ]; then

--- a/Scripts/check-app.sh
+++ b/Scripts/check-app.sh
@@ -1,0 +1,136 @@
+#!/bin/bash
+# Build the Xcode app bundle, embed the filesystem Spotlight importer, and run
+# the activated-app acceptance suite against that exact bundle.
+#
+# SwiftPM proves the parser and renderer in isolation. This lane proves the
+# user-visible boundary: a signed app launches, opens a real file, completes a
+# TextKit display cycle, exposes the mode controls to accessibility, and keeps
+# source editing live. It intentionally uses a separate derived-data path so a
+# stale installed app cannot satisfy the test.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+command -v xcodegen >/dev/null || {
+    echo "check-app: xcodegen is required (brew install xcodegen)" >&2
+    exit 1
+}
+command -v xcodebuild >/dev/null || {
+    echo "check-app: xcodebuild is required" >&2
+    exit 1
+}
+
+APP_ACCEPTANCE_SCRATCH="${APP_ACCEPTANCE_SCRATCH:-.build-app-acceptance}"
+SPOTLIGHT_SCRATCH="${SPOTLIGHT_SCRATCH:-.build-app-acceptance-spm}"
+CONFIGURATION="${APP_ACCEPTANCE_CONFIGURATION:-Debug}"
+LOG_TAG="$(printf '%s' "$APP_ACCEPTANCE_SCRATCH" | tr -c 'A-Za-z0-9._-' '-')"
+LOG_DIR="${TMPDIR:-/tmp}"
+BUILD_LOG="$LOG_DIR/downright-app-build-$LOG_TAG.log"
+TEST_LOG="$LOG_DIR/downright-app-test-$LOG_TAG.log"
+HOST_ARCH="$(uname -m)"
+DESTINATION="platform=macOS,arch=$HOST_ARCH"
+
+# shellcheck disable=SC1091
+source "$ROOT/Config/version.env"
+BUILD_NUMBER="$("$ROOT/Scripts/build-number.sh")"
+
+echo "==> Generating Downright.xcodeproj"
+xcodegen generate --spec project.yml
+
+echo "==> Building the activated-app host and UI test bundle"
+xcodebuild \
+    -project Downright.xcodeproj \
+    -scheme Downright \
+    -configuration "$CONFIGURATION" \
+    -derivedDataPath "$APP_ACCEPTANCE_SCRATCH" \
+    -clonedSourcePackagesDirPath "$APP_ACCEPTANCE_SCRATCH/SourcePackages" \
+    -destination "$DESTINATION" \
+    -disableAutomaticPackageResolution \
+    -skipPackageUpdates \
+    CODE_SIGN_IDENTITY="-" \
+    CODE_SIGNING_ALLOWED=YES \
+    CODE_SIGNING_REQUIRED=NO \
+    MARKETING_VERSION="$MARKETING_VERSION" \
+    CURRENT_PROJECT_VERSION="$BUILD_NUMBER" \
+    DOWNRIGHT_HOST_BUNDLE_IDENTIFIER="com.ezzy.downright.acceptance" \
+    build-for-testing 2>&1 | tee "$BUILD_LOG"
+
+APP="$ROOT/$APP_ACCEPTANCE_SCRATCH/Build/Products/$CONFIGURATION/Downright.app"
+[ -d "$APP" ] || {
+    echo "check-app: expected app bundle was not produced: $APP" >&2
+    exit 1
+}
+
+echo "==> Embedding the CLI and flattening Xcode resource bundles"
+swift build -c release --scratch-path "$SPOTLIGHT_SCRATCH" --product down
+CLI_BIN="$(swift build -c release --scratch-path "$SPOTLIGHT_SCRATCH" --product down --show-bin-path)/down"
+[ -x "$CLI_BIN" ] || {
+    echo "check-app: SwiftPM did not produce the down CLI: $CLI_BIN" >&2
+    exit 1
+}
+cp "$CLI_BIN" "$APP/Contents/MacOS/down"
+
+# Xcode places SwiftPM resources at bundle/Contents/Resources, while the
+# runtime resolvers and the shared bundle verifier use the flat layout. Lift
+# every nested resource bundle before re-signing the modified app.
+while IFS= read -r bundle; do
+    deep="$bundle/Contents/Resources"
+    [ -d "$deep" ] || continue
+    ditto "$deep" "$bundle"
+    rm -rf "$bundle/Contents"
+done < <(find "$APP" -type d -name "*.bundle")
+
+echo "==> Embedding the filesystem Spotlight importer"
+APP="$APP" \
+    SPOTLIGHT_SCRATCH="$SPOTLIGHT_SCRATCH" \
+    SPOTLIGHT_CONFIGURATION=debug \
+    "$ROOT/Scripts/bundle-spotlight.sh"
+
+# Flattening invalidated the Xcode extension seals, and build-for-testing signed
+# the host before the importer and CLI existed. Re-seal children first and the
+# host last; no nested code is changed after this point.
+for appex in "$APP"/Contents/PlugIns/*.appex; do
+    [ -e "$appex" ] || continue
+    codesign --force --sign - --entitlements "$ROOT/Config/QuickLook.entitlements" "$appex"
+done
+echo "==> Re-sealing the acceptance host"
+codesign --force --sign - "$APP"
+
+echo "==> Verifying the exact acceptance bundle"
+"$ROOT/Scripts/verify-bundle.sh" "$APP"
+
+echo "==> Running activated-app acceptance tests"
+XCTESTRUN="$(find "$ROOT/$APP_ACCEPTANCE_SCRATCH/Build/Products" -maxdepth 1 -name '*.xctestrun' -print -quit)"
+[ -n "$XCTESTRUN" ] || {
+    echo "check-app: build-for-testing did not produce an xctestrun manifest" >&2
+    exit 1
+}
+UI_TARGET_PATH="$(/usr/libexec/PlistBuddy -c 'Print :DownrightUITests:UITargetAppPath' "$XCTESTRUN" 2>/dev/null || true)"
+# Xcode 26 can omit UITargetAppPath when a macOS UI-test target is generated
+# from XcodeGen, even though the target's build settings contain the value.
+# The test manifest is the final contract consumed by test-without-building;
+# repair the missing key from the exact bundle we just built, then validate it
+# before launching XCTest. A present but different path remains a hard failure.
+EXPECTED_UI_TARGET_PATH="__TESTROOT__/$CONFIGURATION/Downright.app"
+if [ -z "$UI_TARGET_PATH" ]; then
+    /usr/libexec/PlistBuddy -c "Add :DownrightUITests:UITargetAppPath string $EXPECTED_UI_TARGET_PATH" "$XCTESTRUN"
+    UI_TARGET_PATH="$(/usr/libexec/PlistBuddy -c 'Print :DownrightUITests:UITargetAppPath' "$XCTESTRUN")"
+fi
+[ "$UI_TARGET_PATH" = "$EXPECTED_UI_TARGET_PATH" ] || {
+    echo "check-app: xctestrun manifest has no exact UI target app path: $XCTESTRUN" >&2
+    exit 1
+}
+xcodebuild \
+    test-without-building \
+    -xctestrun "$XCTESTRUN" \
+    -destination "$DESTINATION" \
+    -only-testing:DownrightUITests/DownrightActivatedAppTests \
+    -parallel-testing-enabled NO \
+    -test-timeouts-enabled YES 2>&1 | tee "$TEST_LOG"
+
+echo
+echo "Activated-app acceptance passed"
+echo "    app: $APP"
+echo "    build log: $BUILD_LOG"
+echo "    test log: $TEST_LOG"

--- a/Scripts/check.sh
+++ b/Scripts/check.sh
@@ -40,6 +40,15 @@ if ! swift build --scratch-path "$SCRATCH" > "$LOG_DIR/downright-build-$LOG_TAG.
 fi
 echo "    ok"
 
+echo "==> Spotlight importer build"
+if ! swift build --scratch-path "$SCRATCH" --product DownrightSpotlightImporter \
+    > "$LOG_DIR/downright-spotlight-build-$LOG_TAG.log" 2>&1; then
+    echo "    FAILED"
+    grep "error:" "$LOG_DIR/downright-spotlight-build-$LOG_TAG.log" | sort -u | head -40
+    exit 1
+fi
+echo "    ok"
+
 echo "==> Tests"
 TEST_LOG="$LOG_DIR/downright-test-$LOG_TAG.log"
 if [ "${#TEST_FLAGS[@]}" -gt 0 ]; then

--- a/Scripts/sign-and-notarize.sh
+++ b/Scripts/sign-and-notarize.sh
@@ -77,6 +77,9 @@ sign_preserving_entitlements "$SPARKLE_VERSION/XPCServices/Downloader.xpc"
 sign "$SPARKLE_VERSION/Autoupdate"
 sign "$SPARKLE_VERSION/Updater.app"
 sign "$SPARKLE"
+SPOTLIGHT="$APP/Contents/Library/Spotlight/DownrightSpotlight.mdimporter"
+sign "$SPOTLIGHT/Contents/MacOS/DownrightSpotlight"
+sign "$SPOTLIGHT"
 for appex in "$APP"/Contents/PlugIns/*.appex; do
     [ -d "$appex" ] && sign_quicklook "$appex"
 done
@@ -85,6 +88,8 @@ sign "$APP"
 
 echo "==> Verifying signatures"
 for item in "$APP" "$APP/Contents/Frameworks/Sparkle.framework" \
+            "$APP/Contents/Library/Spotlight/DownrightSpotlight.mdimporter" \
+            "$APP/Contents/Library/Spotlight/DownrightSpotlight.mdimporter/Contents/MacOS/DownrightSpotlight" \
             "$APP/Contents/Frameworks/Sparkle.framework"/Versions/*/XPCServices/*.xpc \
             "$APP/Contents/Frameworks/Sparkle.framework"/Versions/*/Autoupdate \
             "$APP/Contents/Frameworks/Sparkle.framework"/Versions/*/Updater.app \

--- a/Scripts/verify-bundle.sh
+++ b/Scripts/verify-bundle.sh
@@ -90,6 +90,30 @@ check "$([ -f "$CONTENTS/Resources/Downright_MarkdownRender.bundle/Themes/paper-
 check "$([ -f "$CONTENTS/Resources/SwiftMath_SwiftMath.bundle/mathFonts.bundle/latinmodern-math.otf" ] && echo 1 || echo 0)" \
       "host carries the SwiftMath math fonts"
 
+# --- Spotlight importer -----------------------------------------------------
+# macOS discovers classic MDImporter bundles at this exact location. Keep the
+# importer in the same bundle contract as Quick Look: the binary, schema, and
+# metadata version must all travel with the app that owns them.
+SPOTLIGHT="$CONTENTS/Library/Spotlight/DownrightSpotlight.mdimporter"
+SPOTLIGHT_PLIST="$SPOTLIGHT/Contents/Info.plist"
+SPOTLIGHT_BIN="$SPOTLIGHT/Contents/MacOS/DownrightSpotlight"
+check "$([ -d "$SPOTLIGHT" ] && echo 1 || echo 0)" "Spotlight importer embedded"
+check "$([ -x "$SPOTLIGHT_BIN" ] && echo 1 || echo 0)" "Spotlight importer executable present"
+check "$([ -f "$SPOTLIGHT/Contents/Resources/schema.xml" ] && echo 1 || echo 0)" "Spotlight importer schema present"
+check "$([ "$(/usr/libexec/PlistBuddy -c 'Print :CFBundlePackageType' "$SPOTLIGHT_PLIST" 2>/dev/null || echo '')" = "BNDL" ] && echo 1 || echo 0)" \
+      "Spotlight importer is a CFPlugIn bundle"
+check "$([ "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleExecutable' "$SPOTLIGHT_PLIST" 2>/dev/null || echo '')" = "DownrightSpotlight" ] && echo 1 || echo 0)" \
+      "Spotlight importer executable name"
+check "$(grep -q '8B08C4BF-415B-11D8-B3F9-0003936726FC' "$SPOTLIGHT_PLIST" 2>/dev/null && echo 1 || echo 0)" \
+      "Spotlight importer declares the MDImporter plug-in type"
+check "$(grep -q 'net.daringfireball.markdown' "$SPOTLIGHT_PLIST" 2>/dev/null && echo 1 || echo 0)" \
+      "Spotlight importer claims Markdown UTI"
+if [ -x "$SPOTLIGHT_BIN" ]; then
+    SPOTLIGHT_BAD_DYLIBS="$(otool -L "$SPOTLIGHT_BIN" | tail -n +2 | grep -vE '\(architecture [^)]*\):$|@rpath|@executable_path|@loader_path|/usr/lib/|/System/|/Library/Frameworks/' || true)"
+    check "$([ -z "$SPOTLIGHT_BAD_DYLIBS" ] && echo 1 || echo 0)" \
+          "Spotlight importer has no absolute build-machine dylib paths"
+fi
+
 # --- Quick Look extensions ---------------------------------------------------
 # Two .appex layouts reach this script: flat, as Scripts/bundle-quicklook.sh
 # assembles them, and deep (Contents/MacOS, Contents/Resources) from Xcode.
@@ -157,6 +181,11 @@ host_build() { /usr/libexec/PlistBuddy -c "Print :CFBundleVersion" "$1/Contents/
 HOST_SHORT="$(host_short "$APP")"
 HOST_BUILD="$(host_build "$APP")"
 [ -n "$HOST_SHORT" ] || { check 0 "host CFBundleShortVersionString readable"; exit 1; }
+
+SPOTLIGHT_SHORT="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$SPOTLIGHT_PLIST" 2>/dev/null || echo '')"
+SPOTLIGHT_BUILD="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$SPOTLIGHT_PLIST" 2>/dev/null || echo '')"
+check "$([ "$SPOTLIGHT_SHORT" = "$HOST_SHORT" ] && echo 1 || echo 0)" "Spotlight importer marketing version matches host"
+check "$([ "$SPOTLIGHT_BUILD" = "$HOST_BUILD" ] && echo 1 || echo 0)" "Spotlight importer build version matches host"
 
 for appex in "$CONTENTS"/PlugIns/*.appex; do
     [ -e "$appex" ] || continue

--- a/Sources/DownrightApp/Integrations/SpotlightMetadata.swift
+++ b/Sources/DownrightApp/Integrations/SpotlightMetadata.swift
@@ -1,92 +1,18 @@
-import Foundation
-import MarkdownCore
-
-#if canImport(CoreSpotlight)
 import CoreSpotlight
+import DownrightSpotlightMetadata
+import Foundation
 import UniformTypeIdentifiers
-#endif
 
-/// Stable keys used by the Spotlight importer and by metadata tests.  The
-/// importer emits only local facts derived from the file; it never evaluates
-/// code fences or follows links.
-@available(macOS 14.0, *)
-public enum SpotlightMetadataKey {
-    public static let title = "kMDItemTitle"
-    public static let textContent = "kMDItemTextContent"
-    public static let keywords = "kMDItemKeywords"
-    public static let kind = "kMDItemKind"
-    public static let contentType = "kMDItemContentType"
-}
+// Keep the app-facing names stable for integrations and tests while the
+// parser-backed implementation lives in the platform-neutral target shared
+// with the mdimporter bundle.
+public typealias SpotlightMetadataKey = DownrightSpotlightMetadata.SpotlightMetadataKey
+public typealias SpotlightMetadata = DownrightSpotlightMetadata.SpotlightMetadata
+public typealias SpotlightMetadataImporter = DownrightSpotlightMetadata.SpotlightMetadataImporter
 
-@available(macOS 14.0, *)
-public struct SpotlightMetadata: Equatable, Sendable {
-    public var title: String
-    public var textContent: String
-    public var keywords: [String]
-    public var contentType: String
-
-    public init(title: String, textContent: String, keywords: [String], contentType: String) {
-        self.title = title
-        self.textContent = textContent
-        self.keywords = keywords
-        self.contentType = contentType
-    }
-
-    public var attributes: [String: Any] {
-        [
-            SpotlightMetadataKey.title: title,
-            SpotlightMetadataKey.textContent: textContent,
-            SpotlightMetadataKey.keywords: keywords,
-            SpotlightMetadataKey.kind: "Markdown document",
-            SpotlightMetadataKey.contentType: contentType,
-        ]
-    }
-}
-
-/// Shared metadata extraction logic for an MDImporter extension.  Keep file
-/// IO at this boundary so the parser remains the source of truth and tests can
-/// inject text directly.
-@available(macOS 14.0, *)
-public enum SpotlightMetadataImporter {
-    public static func metadata(forText text: String, url: URL) -> SpotlightMetadata {
-        let document = MarkdownParser.parse(text, options: .structureOnly)
-        let title = document.headings.first?.title
-            ?? document.frontMatter?.fields.first(where: { $0.key.lowercased() == "title" })?.value
-            ?? url.deletingPathExtension().lastPathComponent
-        let keywords = document.frontMatter?.fields
-            .filter { ["tag", "tags", "keyword", "keywords"].contains($0.key.lowercased()) }
-            .flatMap { $0.value.split(separator: ",").map { $0.trimmingCharacters(in: .whitespaces) } }
-            .filter { !$0.isEmpty }
-            .map { String($0) } ?? []
-        return SpotlightMetadata(
-            title: title,
-            textContent: text,
-            keywords: keywords,
-            contentType: contentType(for: url)
-        )
-    }
-
-    public static func metadata(at url: URL) throws -> SpotlightMetadata {
-        guard NativeIntegrationPolicy.accepts(url) else {
-            throw CocoaError(.fileReadUnsupportedScheme)
-        }
-        let (text, _) = try DocumentIO.read(contentsOf: url)
-        return metadata(forText: text, url: url)
-    }
-
-    public static func contentType(for url: URL) -> String {
-        switch url.pathExtension.lowercased() {
-        case "md", "markdown", "mdown", "mkd": "net.daringfireball.markdown"
-        default: "com.ezzy.downright.markdown"
-        }
-    }
-}
-
-#if canImport(CoreSpotlight)
-/// Adds documents that the user opens to the local Spotlight index. This gives
-/// the app a useful system search path without scanning folders in the
-/// background. A future MDImporter bundle can reuse the same extractor to
-/// cover files that the user has not opened in Downright.
+/// Adds documents that the user opens to the local Core Spotlight index. The
+/// filesystem importer covers unopened Markdown; this path gives an opened
+/// document immediate results before the system index catches up.
 @available(macOS 14.0, *)
 public enum SpotlightIndexer {
     public static func indexOpenedDocument(at url: URL) {
@@ -111,4 +37,3 @@ public enum SpotlightIndexer {
         }
     }
 }
-#endif

--- a/Sources/DownrightApp/Support/AppPaths.swift
+++ b/Sources/DownrightApp/Support/AppPaths.swift
@@ -6,6 +6,11 @@ enum AppPaths {
     static let bundleIdentifier = "com.ezzy.downright"
 
     static var supportDirectory: URL {
+        if let override = ProcessInfo.processInfo.environment["DOWNRIGHT_SUPPORT_DIRECTORY"],
+           !override.isEmpty
+        {
+            return URL(fileURLWithPath: override, isDirectory: true).standardizedFileURL
+        }
         let base = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
             ?? URL(fileURLWithPath: NSHomeDirectory()).appendingPathComponent("Library/Application Support")
         return base.appendingPathComponent("Downright", isDirectory: true)

--- a/Sources/DownrightSpotlightImporter/SpotlightImporter.c
+++ b/Sources/DownrightSpotlightImporter/SpotlightImporter.c
@@ -1,0 +1,118 @@
+#include <CoreFoundation/CoreFoundation.h>
+#include <CoreFoundation/CFPlugInCOM.h>
+#include <CoreServices/CoreServices.h>
+#include <stdbool.h>
+#include <stdlib.h>
+
+#define DOWNRIGHT_SPOTLIGHT_FACTORY_ID "E55A6D2B-5C76-4E83-9C13-6F4BF1D98D77"
+
+// The Markdown parser and metadata policy live in the Swift target. This C
+// layer owns only the ABI that mdworker expects from a classic MDImporter.
+extern bool DownrightSpotlightPopulateMetadata(
+    CFMutableDictionaryRef attributes,
+    CFStringRef contentTypeUTI,
+    CFStringRef pathToFile
+);
+
+static Boolean DownrightImportData(
+    void *thisInterface,
+    CFMutableDictionaryRef attributes,
+    CFStringRef contentTypeUTI,
+    CFStringRef pathToFile
+);
+
+typedef struct __DownrightMetadataImporter {
+    MDImporterInterfaceStruct *interfaceTable;
+    CFUUIDRef factoryID;
+    UInt32 refCount;
+} DownrightMetadataImporter;
+
+static HRESULT DownrightQueryInterface(void *thisInstance, REFIID iid, LPVOID *ppv);
+static ULONG DownrightAddRef(void *thisInstance);
+static ULONG DownrightRelease(void *thisInstance);
+
+static MDImporterInterfaceStruct DownrightInterfaceTable = {
+    NULL,
+    DownrightQueryInterface,
+    DownrightAddRef,
+    DownrightRelease,
+    DownrightImportData,
+};
+
+static Boolean DownrightImportData(
+    void *thisInterface,
+    CFMutableDictionaryRef attributes,
+    CFStringRef contentTypeUTI,
+    CFStringRef pathToFile
+) {
+    (void)thisInterface;
+    return DownrightSpotlightPopulateMetadata(
+        attributes, contentTypeUTI, pathToFile
+    ) ? true : false;
+}
+
+static DownrightMetadataImporter *DownrightAllocate(CFUUIDRef factoryID) {
+    DownrightMetadataImporter *instance =
+        (DownrightMetadataImporter *)calloc(1, sizeof(DownrightMetadataImporter));
+    if (instance == NULL) return NULL;
+
+    instance->interfaceTable = &DownrightInterfaceTable;
+    instance->factoryID = (CFUUIDRef)CFRetain(factoryID);
+    instance->refCount = 1;
+    CFPlugInAddInstanceForFactory(factoryID);
+    return instance;
+}
+
+static void DownrightDeallocate(DownrightMetadataImporter *instance) {
+    CFPlugInRemoveInstanceForFactory(instance->factoryID);
+    CFRelease(instance->factoryID);
+    free(instance);
+}
+
+static HRESULT DownrightQueryInterface(void *thisInstance, REFIID iid, LPVOID *ppv) {
+    if (ppv == NULL) return E_POINTER;
+    *ppv = NULL;
+
+    CFUUIDRef requested = CFUUIDCreateFromUUIDBytes(kCFAllocatorDefault, iid);
+    if (requested == NULL) return E_OUTOFMEMORY;
+
+    Boolean supported = CFEqual(requested, kMDImporterInterfaceID)
+        || CFEqual(requested, IUnknownUUID);
+    CFRelease(requested);
+    if (!supported) return E_NOINTERFACE;
+
+    DownrightAddRef(thisInstance);
+    *ppv = thisInstance;
+    return S_OK;
+}
+
+static ULONG DownrightAddRef(void *thisInstance) {
+    DownrightMetadataImporter *instance = (DownrightMetadataImporter *)thisInstance;
+    instance->refCount += 1;
+    return instance->refCount;
+}
+
+static ULONG DownrightRelease(void *thisInstance) {
+    DownrightMetadataImporter *instance = (DownrightMetadataImporter *)thisInstance;
+    if (instance->refCount > 0) instance->refCount -= 1;
+    if (instance->refCount == 0) {
+        DownrightDeallocate(instance);
+        return 0;
+    }
+    return instance->refCount;
+}
+
+__attribute__((visibility("default")))
+void *MetadataImporterPluginFactory(CFAllocatorRef allocator, CFUUIDRef typeID) {
+    (void)allocator;
+    if (!CFEqual(typeID, kMDImporterTypeID)) return NULL;
+
+    CFUUIDRef factoryID = CFUUIDCreateFromString(
+        kCFAllocatorDefault,
+        CFSTR(DOWNRIGHT_SPOTLIGHT_FACTORY_ID)
+    );
+    if (factoryID == NULL) return NULL;
+    DownrightMetadataImporter *instance = DownrightAllocate(factoryID);
+    CFRelease(factoryID);
+    return instance;
+}

--- a/Sources/DownrightSpotlightImporter/include/DownrightSpotlightImporter.h
+++ b/Sources/DownrightSpotlightImporter/include/DownrightSpotlightImporter.h
@@ -1,0 +1,7 @@
+#ifndef DOWNRIGHT_SPOTLIGHT_IMPORTER_H
+#define DOWNRIGHT_SPOTLIGHT_IMPORTER_H
+
+// The bundle is loaded through CFPlugIn. Its public ABI is discovered through
+// the factory symbol named in Info.plist rather than through this header.
+
+#endif

--- a/Sources/DownrightSpotlightMetadata/SpotlightMetadata.swift
+++ b/Sources/DownrightSpotlightMetadata/SpotlightMetadata.swift
@@ -1,0 +1,123 @@
+import CoreServices
+import Foundation
+import MarkdownCore
+
+/// Stable keys shared by Core Spotlight, the filesystem importer, and tests.
+/// The importer emits only local facts derived from the file; it never
+/// evaluates code fences or follows links.
+@available(macOS 14.0, *)
+public enum SpotlightMetadataKey {
+    public static let title = "kMDItemTitle"
+    public static let textContent = "kMDItemTextContent"
+    public static let keywords = "kMDItemKeywords"
+    public static let kind = "kMDItemKind"
+    public static let contentType = "kMDItemContentType"
+}
+
+@available(macOS 14.0, *)
+public struct SpotlightMetadata: Equatable, Sendable {
+    public var title: String
+    public var textContent: String
+    public var keywords: [String]
+    public var contentType: String
+
+    public init(title: String, textContent: String, keywords: [String], contentType: String) {
+        self.title = title
+        self.textContent = textContent
+        self.keywords = keywords
+        self.contentType = contentType
+    }
+
+    public var attributes: [String: Any] {
+        [
+            SpotlightMetadataKey.title: title,
+            SpotlightMetadataKey.textContent: textContent,
+            SpotlightMetadataKey.keywords: keywords,
+            SpotlightMetadataKey.kind: "Markdown document",
+            SpotlightMetadataKey.contentType: contentType,
+        ]
+    }
+}
+
+/// Parser-backed metadata extraction used by both the running app and the
+/// background Spotlight importer. File IO stays at this boundary so the
+/// parser remains the source of truth and tests can inject text directly.
+@available(macOS 14.0, *)
+public enum SpotlightMetadataImporter {
+    public static let markdownExtensions: Set<String> = [
+        "md", "markdown", "mdown", "mkd", "mdx", "mdc", "qmd", "rmd",
+    ]
+
+    public static func metadata(forText text: String, url: URL) -> SpotlightMetadata {
+        let document = MarkdownParser.parse(text, options: .structureOnly)
+        let title = document.headings.first?.title
+            ?? document.frontMatter?.fields.first(where: { $0.key.lowercased() == "title" })?.value
+            ?? url.deletingPathExtension().lastPathComponent
+        let keywords = document.frontMatter?.fields
+            .filter { ["tag", "tags", "keyword", "keywords"].contains($0.key.lowercased()) }
+            .flatMap { field in
+                field.value
+                    .trimmingCharacters(in: CharacterSet(charactersIn: "[]"))
+                    .split(separator: ",")
+                    .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            }
+            .filter { !$0.isEmpty }
+            .map { String($0) } ?? []
+        return SpotlightMetadata(
+            title: title,
+            textContent: text,
+            keywords: keywords,
+            contentType: contentType(for: url)
+        )
+    }
+
+    public static func metadata(at url: URL) throws -> SpotlightMetadata {
+        guard accepts(url) else {
+            throw CocoaError(.fileReadUnsupportedScheme)
+        }
+        let (text, _) = try DocumentIO.read(contentsOf: url)
+        return metadata(forText: text, url: url)
+    }
+
+    public static func accepts(_ url: URL) -> Bool {
+        url.isFileURL && markdownExtensions.contains(url.pathExtension.lowercased())
+    }
+
+    public static func contentType(for url: URL) -> String {
+        switch url.pathExtension.lowercased() {
+        case "md", "markdown", "mdown", "mkd": "net.daringfireball.markdown"
+        default: "com.ezzy.downright.markdown"
+        }
+    }
+}
+
+/// C-callable bridge used by the CFPlugIn shim. The importer process has no
+/// AppKit or window-server dependency; it fills the dictionary handed to it
+/// by Spotlight with values produced by the shared parser.
+@available(macOS 14.0, *)
+@_cdecl("DownrightSpotlightPopulateMetadata")
+public func downrightSpotlightPopulateMetadata(
+    _ attributes: CFMutableDictionary?,
+    _ contentTypeUTI: CFString?,
+    _ pathToFile: CFString?
+) -> Bool {
+    guard let attributes, let pathToFile else { return false }
+    let path = pathToFile as String
+    let url = URL(fileURLWithPath: path)
+    guard let metadata = try? SpotlightMetadataImporter.metadata(at: url) else { return false }
+
+    let values: [(CFString, CFTypeRef)] = [
+        (kMDItemTitle, metadata.title as CFString),
+        (kMDItemTextContent, metadata.textContent as CFString),
+        (kMDItemKeywords, metadata.keywords as CFArray),
+        (kMDItemKind, "Markdown document" as CFString),
+    ]
+    for (key, value) in values {
+        CFDictionarySetValue(
+            attributes,
+            Unmanaged.passUnretained(key).toOpaque(),
+            Unmanaged.passUnretained(value).toOpaque()
+        )
+    }
+    return true
+}

--- a/Tests/DownrightUITests/DownrightActivatedAppTests.swift
+++ b/Tests/DownrightUITests/DownrightActivatedAppTests.swift
@@ -1,0 +1,103 @@
+import Foundation
+import XCTest
+
+/// Acceptance coverage for the surface that SwiftPM's AppKit test runner
+/// cannot provide: an actual Downright.app with a running display cycle.
+final class DownrightActivatedAppTests: XCTestCase {
+    private var app: XCUIApplication!
+    private var root: URL!
+    private var fixture: URL!
+    private var captureDirectory: URL!
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+
+        root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("downright-activated-app-\(UUID().uuidString)", isDirectory: true)
+        captureDirectory = root.appendingPathComponent("capture", isDirectory: true)
+        try FileManager.default.createDirectory(at: captureDirectory, withIntermediateDirectories: true)
+
+        let support = root.appendingPathComponent("support", isDirectory: true)
+        try FileManager.default.createDirectory(at: support, withIntermediateDirectories: true)
+        // Keep first-run registration UI out of this acceptance case. The app
+        // still launches normally; only its state is isolated to this fixture.
+        let preferences = #"{"hasAnsweredSetup":true,"restoreSession":false,"defaultMode":"live"}"#
+        try Data(preferences.utf8).write(
+            to: support.appendingPathComponent("preferences.json"),
+            options: .atomic
+        )
+
+        fixture = root.appendingPathComponent("activated-fixture.md")
+        let body = (1...80).map { "Paragraph \($0) keeps the live viewport exercised." }.joined(separator: "\n\n")
+        try Data(("# Activated app fixture\n\n## First section\n\n" + body + "\n\n## Later section\n\nThe end.\n").utf8)
+            .write(to: fixture, options: .atomic)
+
+        // Resolve the host from the test bundle instead of Launch Services. A
+        // developer may have another Downright.app open; URL-based UI testing
+        // must still exercise this exact build product.
+        let testBundle = Bundle(for: DownrightActivatedAppTests.self).bundleURL
+        let runner = testBundle
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let productDirectory = runner.deletingLastPathComponent()
+        let siblingHost = productDirectory.appendingPathComponent("Downright.app", isDirectory: true)
+        let host = FileManager.default.fileExists(atPath: siblingHost.path)
+            ? siblingHost
+            : runner
+        XCTAssertTrue(FileManager.default.fileExists(atPath: host.path), "test host is missing: \(host.path)")
+        app = XCUIApplication(url: host)
+        app.launchArguments = [fixture.path]
+        app.launchEnvironment["DOWNRIGHT_SUPPORT_DIRECTORY"] = support.path
+        app.launchEnvironment["DOWNRIGHT_DEBUG_LAYOUT"] = "1"
+        app.launchEnvironment["DOWNRIGHT_DEBUG_CAPTURE"] = captureDirectory.path
+    }
+
+    override func tearDown() {
+        app?.terminate()
+        if let root {
+            try? FileManager.default.removeItem(at: root)
+        }
+    }
+
+    func testActivatedBundleRendersAndKeepsSourceEditingLive() throws {
+        app.launch()
+        XCTAssertTrue(app.wait(for: .runningForeground, timeout: 20))
+
+        let window = app.windows.firstMatch
+        XCTAssertTrue(window.waitForExistence(timeout: 15))
+        add(XCTAttachment(screenshot: window.screenshot()))
+
+        let rendered = app.radioButtons["Document"]
+        let source = app.radioButtons["Source"]
+        XCTAssertTrue(rendered.waitForExistence(timeout: 10), "the real toolbar never exposed Document mode")
+        XCTAssertTrue(source.waitForExistence(timeout: 10), "the real toolbar never exposed Source mode")
+
+        // This capture is produced by DocumentWindowController only after the
+        // active window has completed TextKit 2's first display cycle. It is
+        // the concrete proof missing from headless cacheDisplay tests.
+        let containerCapture = captureDirectory.appendingPathComponent("container.png")
+        XCTAssertTrue(waitForFile(containerCapture, timeout: 15))
+        XCTAssertGreaterThan((try Data(contentsOf: containerCapture)).count, 1_000)
+
+        source.click()
+        let editor = app.textViews.firstMatch
+        XCTAssertTrue(editor.waitForExistence(timeout: 10), "Source mode did not expose an editable text view")
+        editor.click()
+        editor.typeText("!")
+        editor.typeKey("z", modifierFlags: .command)
+        rendered.click()
+
+        XCTAssertTrue(rendered.isSelected || rendered.value as? String == "Selected")
+        add(XCTAttachment(screenshot: window.screenshot()))
+    }
+
+    private func waitForFile(_ url: URL, timeout: TimeInterval) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        repeat {
+            if FileManager.default.fileExists(atPath: url.path) { return true }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.25))
+        } while Date() < deadline
+        return false
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -6,6 +6,9 @@ options:
   createIntermediateGroups: true
   groupSortPosition: top
   developmentLanguage: en
+settings:
+  base:
+    DOWNRIGHT_HOST_BUNDLE_IDENTIFIER: com.ezzy.downright
 packages:
   # The root package brings its own dependencies with it, including the
   # vendored SwiftMath at Vendor/SwiftMath (a path dependency in Package.swift).
@@ -37,6 +40,8 @@ targets:
       - package: Downright
         product: MarkdownRender
       - package: Downright
+        product: DownrightSpotlightMetadata
+      - package: Downright
         product: drdownright
       - package: Sparkle
         product: Sparkle
@@ -46,7 +51,8 @@ targets:
         embed: true
     settings:
       base:
-        PRODUCT_BUNDLE_IDENTIFIER: com.ezzy.downright
+        DOWNRIGHT_HOST_BUNDLE_IDENTIFIER: com.ezzy.downright
+        PRODUCT_BUNDLE_IDENTIFIER: $(DOWNRIGHT_HOST_BUNDLE_IDENTIFIER)
         PRODUCT_NAME: Downright
         MARKETING_VERSION: 1.0.16
         CURRENT_PROJECT_VERSION: 1
@@ -73,7 +79,7 @@ targets:
         product: MarkdownRender
     settings:
       base:
-        PRODUCT_BUNDLE_IDENTIFIER: com.ezzy.downright.quicklook
+        PRODUCT_BUNDLE_IDENTIFIER: $(DOWNRIGHT_HOST_BUNDLE_IDENTIFIER).quicklook
         PRODUCT_NAME: DownrightQL
         MARKETING_VERSION: 1.0.16
         CURRENT_PROJECT_VERSION: 1
@@ -97,7 +103,7 @@ targets:
         product: MarkdownRender
     settings:
       base:
-        PRODUCT_BUNDLE_IDENTIFIER: com.ezzy.downright.thumbnail
+        PRODUCT_BUNDLE_IDENTIFIER: $(DOWNRIGHT_HOST_BUNDLE_IDENTIFIER).thumbnail
         PRODUCT_NAME: DownrightThumb
         MARKETING_VERSION: 1.0.16
         CURRENT_PROJECT_VERSION: 1
@@ -107,6 +113,22 @@ targets:
         INFOPLIST_FILE: Config/DownrightThumb-Info.plist
         SWIFT_VERSION: 5.0
         MACOSX_DEPLOYMENT_TARGET: 14.0
+  DownrightUITests:
+    type: bundle.ui-testing
+    platform: macOS
+    sources:
+      - path: Tests/DownrightUITests
+    dependencies:
+      - target: Downright
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.ezzy.downright.uitests
+        PRODUCT_NAME: DownrightUITests
+        GENERATE_INFOPLIST_FILE: YES
+        SWIFT_VERSION: 5.0
+        MACOSX_DEPLOYMENT_TARGET: 14.0
+        TEST_TARGET_NAME: Downright.app
+        UITargetAppPath: $(BUILT_PRODUCTS_DIR)/Downright.app
 schemes:
   Downright:
     build:
@@ -114,5 +136,9 @@ schemes:
         Downright: all
     run:
       config: Debug
+    test:
+      config: Debug
+      targets:
+        - DownrightUITests
     archive:
       config: Release


### PR DESCRIPTION
## What changed

- add the parser-backed Markdown Spotlight importer and bundle/sign/verify it with the app
- add the activated-app UI acceptance lane for real window, mode switching, editing, and undo
- repair the Xcode 26 UI-test manifest when it omits the exact target app path
- retain the every-main-push signed release pipeline and reconcile it with the stabilization work

## Validation

- `Scripts/check.sh`: 988 tests in 85 suites passed
- Spotlight importer build and bundle verification passed
- activated-app UI test executed against the exact built bundle: 1 test, 0 failures
- old build 176 updated through the live signed Sparkle appcast to build 177
