### PR TITLE
Audit fixes: parser crashes, export XSS, trust scoping, and workspace/lifecycle edge cases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,8 +45,21 @@ jobs:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
       - name: Select and verify the Swift toolchain
         run: ./Scripts/select-toolchain.sh
-      - name: Install xcodegen
-        run: brew install xcodegen
+      # Pinned like the release workflow: xcodegen generates the project the
+      # acceptance lane builds, so it is a checksummed upstream binary, not a
+      # floating Homebrew head.
+      - name: Install pinned xcodegen
+        run: |
+          set -euo pipefail
+          XCODEGEN_VERSION=2.46.0
+          XCODEGEN_SHA256=4d9e34b62172d645eed6457cac13fc222569974098ef4ee9c3368bedf0196806
+          curl -fsSL -o "$RUNNER_TEMP/xcodegen.zip" \
+            "https://github.com/yonaskolb/XcodeGen/releases/download/${XCODEGEN_VERSION}/xcodegen.zip"
+          echo "$XCODEGEN_SHA256  $RUNNER_TEMP/xcodegen.zip" | shasum -a 256 -c -
+          unzip -q "$RUNNER_TEMP/xcodegen.zip" -d "$RUNNER_TEMP"
+          sudo cp "$RUNNER_TEMP/xcodegen/bin/xcodegen" /usr/local/bin/xcodegen
+          sudo chmod +x /usr/local/bin/xcodegen
+          xcodegen --version
       - name: Build and run the activated-app acceptance suite
         env:
           APP_ACCEPTANCE_SCRATCH: .build-ci-app

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,8 +57,16 @@ jobs:
             "https://github.com/yonaskolb/XcodeGen/releases/download/${XCODEGEN_VERSION}/xcodegen.zip"
           echo "$XCODEGEN_SHA256  $RUNNER_TEMP/xcodegen.zip" | shasum -a 256 -c -
           unzip -q "$RUNNER_TEMP/xcodegen.zip" -d "$RUNNER_TEMP"
+          sudo mkdir -p /usr/local/bin /usr/local/share
           sudo cp "$RUNNER_TEMP/xcodegen/bin/xcodegen" /usr/local/bin/xcodegen
           sudo chmod +x /usr/local/bin/xcodegen
+          # The SettingPresets (ONLY_ACTIVE_ARCH=YES for Debug, plus the other
+          # default settings) ship in the zip's share/ tree, which xcodegen
+          # resolves relative to the binary. A binary-only install silently
+          # drops them, and the generated project then builds the app-extension
+          # and UI-test targets for every standard architecture, mismatching
+          # the arm64-only package modules. Copy the tree, not just the binary.
+          sudo cp -R "$RUNNER_TEMP/xcodegen/share/xcodegen" /usr/local/share/xcodegen
           xcodegen --version
       - name: Build and run the activated-app acceptance suite
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,10 +97,21 @@ jobs:
       - name: Select and verify the Swift toolchain
         run: ./Scripts/select-toolchain.sh
 
-      # xcodegen is not part of the GitHub macOS image; the archive step below
-      # depends on it, so install it before anything long-running has run.
-      - name: Install xcodegen
-        run: brew install xcodegen
+      # xcodegen generates the Xcode project that becomes the signed,
+      # notarized archive, so it is pinned like every other release input:
+      # a checksummed upstream binary instead of a floating Homebrew head.
+      - name: Install pinned xcodegen
+        run: |
+          set -euo pipefail
+          XCODEGEN_VERSION=2.46.0
+          XCODEGEN_SHA256=4d9e34b62172d645eed6457cac13fc222569974098ef4ee9c3368bedf0196806
+          curl -fsSL -o "$RUNNER_TEMP/xcodegen.zip" \
+            "https://github.com/yonaskolb/XcodeGen/releases/download/${XCODEGEN_VERSION}/xcodegen.zip"
+          echo "$XCODEGEN_SHA256  $RUNNER_TEMP/xcodegen.zip" | shasum -a 256 -c -
+          unzip -q "$RUNNER_TEMP/xcodegen.zip" -d "$RUNNER_TEMP"
+          sudo cp "$RUNNER_TEMP/xcodegen/bin/xcodegen" /usr/local/bin/xcodegen
+          sudo chmod +x /usr/local/bin/xcodegen
+          xcodegen --version
 
       - name: Resolve pinned dependencies
         run: swift package resolve
@@ -200,11 +211,17 @@ jobs:
           set -euo pipefail
           KEYCHAIN="$RUNNER_TEMP/build.keychain-db"
           PASSWORD="$(openssl rand -hex 24)"
-          echo "$DEVELOPER_ID_APPLICATION_P12_BASE64" | base64 --decode > /tmp/downright-cert.p12
+          # Secrets land under the runner's private temp dir, never the shared
+          # /tmp. The generated keychain password is not exported: it is not a
+          # registered GitHub secret (so it would not be masked in logs), and
+          # the signing step below never needs it — the keychain stays
+          # unlocked for this job once created.
+          CERT_P12="$RUNNER_TEMP/downright-cert.p12"
+          echo "$DEVELOPER_ID_APPLICATION_P12_BASE64" | base64 --decode > "$CERT_P12"
           security create-keychain -p "$PASSWORD" "$KEYCHAIN"
           security default-keychain -s "$KEYCHAIN"
           security unlock-keychain -p "$PASSWORD" "$KEYCHAIN"
-          security import /tmp/downright-cert.p12 -k "$KEYCHAIN" \
+          security import "$CERT_P12" -k "$KEYCHAIN" \
             -P "$DEVELOPER_ID_APPLICATION_P12_PASSWORD" -T /usr/bin/codesign
           security set-key-partition-list -S apple-tool:,apple: -s -k "$PASSWORD" "$KEYCHAIN"
           IDENTITY="$(security find-identity -v -p codesigning "$KEYCHAIN" \
@@ -212,9 +229,8 @@ jobs:
             | head -n 1)"
           test -n "$IDENTITY"
           echo "Imported signing identity: $IDENTITY"
-          rm -f /tmp/downright-cert.p12
+          rm -f "$CERT_P12"
           echo "KEYCHAIN=$KEYCHAIN" >> "$GITHUB_ENV"
-          echo "KEYCHAIN_PASSWORD=$PASSWORD" >> "$GITHUB_ENV"
           echo "DEVELOPER_ID_APPLICATION_IDENTITY=$IDENTITY" >> "$GITHUB_ENV"
         env:
           DEVELOPER_ID_APPLICATION_P12_BASE64: ${{ secrets.DEVELOPER_ID_APPLICATION_P12_BASE64 }}
@@ -280,13 +296,13 @@ jobs:
           # never work for a fresh build.
           NOTARY_ZIP="$RUNNER_TEMP/Downright-$TAG-notarization.zip"
           ditto -c -k --keepParent --sequesterRsrc "$APP" "$NOTARY_ZIP"
-          echo "$APPLE_API_PRIVATE_KEY_P8" | base64 --decode > /tmp/AuthKey.p8
+          echo "$APPLE_API_PRIVATE_KEY_P8" | base64 --decode > "$RUNNER_TEMP/AuthKey.p8"
           xcrun notarytool submit "$NOTARY_ZIP" \
-            --key /tmp/AuthKey.p8 \
+            --key "$RUNNER_TEMP/AuthKey.p8" \
             --key-id "$APPLE_API_KEY_ID" \
             --issuer "$APPLE_API_ISSUER_ID" \
             --wait --timeout 20m
-          rm -f /tmp/AuthKey.p8
+          rm -f "$RUNNER_TEMP/AuthKey.p8"
           xcrun stapler staple "$APP"
           rm -f "$NOTARY_ZIP"
           # Rebuild the user-facing archive from the stapled app so offline
@@ -320,13 +336,13 @@ jobs:
           VERSIONED_DMG="Downright-$TAG.dmg"
           test -f "$SOURCE_DMG"
           mv "$SOURCE_DMG" "$VERSIONED_DMG"
-          echo "$APPLE_API_PRIVATE_KEY_P8" | base64 --decode > /tmp/AuthKey.p8
+          echo "$APPLE_API_PRIVATE_KEY_P8" | base64 --decode > "$RUNNER_TEMP/AuthKey.p8"
           xcrun notarytool submit "$VERSIONED_DMG" \
-            --key /tmp/AuthKey.p8 \
+            --key "$RUNNER_TEMP/AuthKey.p8" \
             --key-id "$APPLE_API_KEY_ID" \
             --issuer "$APPLE_API_ISSUER_ID" \
             --wait --timeout 20m
-          rm -f /tmp/AuthKey.p8
+          rm -f "$RUNNER_TEMP/AuthKey.p8"
           xcrun stapler staple "$VERSIONED_DMG"
           xcrun stapler validate "$VERSIONED_DMG"
           cp "$VERSIONED_DMG" Downright.dmg
@@ -334,6 +350,18 @@ jobs:
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
           APPLE_API_PRIVATE_KEY_P8: ${{ secrets.APPLE_API_PRIVATE_KEY_P8 }}
+
+      - name: Remove ephemeral signing keychain
+        # The keychain holds the imported Developer ID identity; drop it as
+        # soon as nothing needs it, on every path through the job.
+        if: always()
+        shell: bash
+        run: |
+          if [ -n "${KEYCHAIN:-}" ] && security list-keychains | grep -q "$(basename "$KEYCHAIN")"; then
+            security default-keychain -d || true
+            security delete-keychain "$KEYCHAIN" || true
+          fi
+          rm -f "$RUNNER_TEMP/AuthKey.p8"
 
       # ------------------------------------------------------------ artifacts
       - name: Collect checksums, dSYMs, and release notes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,8 +109,16 @@ jobs:
             "https://github.com/yonaskolb/XcodeGen/releases/download/${XCODEGEN_VERSION}/xcodegen.zip"
           echo "$XCODEGEN_SHA256  $RUNNER_TEMP/xcodegen.zip" | shasum -a 256 -c -
           unzip -q "$RUNNER_TEMP/xcodegen.zip" -d "$RUNNER_TEMP"
+          sudo mkdir -p /usr/local/bin /usr/local/share
           sudo cp "$RUNNER_TEMP/xcodegen/bin/xcodegen" /usr/local/bin/xcodegen
           sudo chmod +x /usr/local/bin/xcodegen
+          # The SettingPresets (ONLY_ACTIVE_ARCH=YES for Debug, plus the other
+          # default settings) ship in the zip's share/ tree, which xcodegen
+          # resolves relative to the binary. A binary-only install silently
+          # drops them, and the generated project then builds app-extension
+          # targets for every standard architecture, mismatching the arm64-only
+          # package modules. Copy the tree, not just the binary.
+          sudo cp -R "$RUNNER_TEMP/xcodegen/share/xcodegen" /usr/local/share/xcodegen
           xcodegen --version
 
       - name: Resolve pinned dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,64 @@ every release; Sparkle orders updates by it.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Fixed a crash on ordinary prose.** Any document containing a one-character
+  word before `:digits` — "John 3:16", "meet at 9:30", `` `a:1` `` — fatally
+  trapped the path-token scanner during the per-keystroke reparse.
+- **Fixed code-fence recovery.** A closing fence may now carry trailing spaces
+  or tabs (legal CommonMark) instead of being swallowed into the code content,
+  and a same-character run shorter than the opening fence inside an unclosed
+  longer fence is content, not a phantom closer.
+- **Fixed footnote recovery inside fenced example code.** The source scanner
+  no longer ends a fence on an info string (` ```ruby ` inside ` ```` `), which
+  used to leak footnote-looking lines out of code blocks.
+- **Fixed section moves in mixed-ending files.** `moveSection` now recognizes
+  terminators by width and preserves the separator's exact bytes; a CRLF blank
+  separator used to be invisible to the walk, gluing the moved sections
+  together. Table realigns and list looseness are width-aware for the same
+  reason, and re-levelling a setext heading keeps its emphasis and code
+  markers instead of the plain-text title.
+- **Closed a stored-XSS hole in HTML export.** Wikilink targets now pass the
+  same scheme allowlist as ordinary links: `[[javascript:alert(1)//]]` used to
+  export as a live `javascript:` URL (the `.html` suffix sits behind a `//`
+  comment, so it did not neutralize the payload).
+- **Fixed `down export`.** Multi-line paragraphs and code blocks exported as
+  one line of visible `\n` garbage; the writer now emits real newlines.
+- **Fixed a main-thread freeze in the image lightbox.** Remote (and large
+  local) images now decode off the main thread; a slow server no longer hangs
+  the app inside the click handler.
+- **Fixed watcher events after close.** A file-watcher event already in flight
+  when its document closed scheduled one more external-write pass on the
+  closed document; and an in-place link hop whose target vanished mid-flight
+  now reopens the previous document instead of leaving a window that no longer
+  tracks external writes.
+- Hardened the release chain: the Apple API key and Developer ID certificate
+  materialize under `mktemp`/`RUNNER_TEMP` instead of fixed `/tmp` paths, the
+  Sparkle key ceremony no longer runs a binary discovered by globbing `/tmp`,
+  the ephemeral signing keychain is deleted on every path, and CI/release
+  install a checksum-pinned `xcodegen` (2.46.0) instead of a floating Homebrew
+  head.
+- **Fixed a workspace-sidebar crash on colliding filenames.** The link graph
+  keyed files by a normalized path that folds `a\b.md` into `a/b.md` (and a
+  hidden `.x.md` into `x.md`); `uniqueKeysWithValues` trapped on the first
+  duplicate. Lookup is now collision-tolerant and prefers the already-normalized
+  path deterministically.
+- **Fixed "Allow for Folder" over-granting on a directory.** Consenting from a
+  directory token stored the directory's *parent*, authorizing every sibling;
+  a directory target now grants itself, and revoke targets the same folder.
+- **Fixed trust grants silently revoking earlier ones.** A second grant for the
+  same path replaced the first instead of extending it, so folder-read and
+  editor-launch kept ping-ponging; grants now union their effects.
+- **Fixed a hard-wrap reflow overrun on stale documents.** The
+  continuation-indent walk indexed the buffer by an unclamped paragraph range
+  and could read one character past the end after an external rewrite; it now
+  clamps to the buffer length.
+- **Fixed agent hook install/uninstall matching the command only.** A foreign
+  `PostToolUse` entry that runs `down notify` under another matcher used to
+  block a needed install and be deleted by an uninstall; both now match on
+  matcher and command together.
+
 ### Added
 
 - **First-run setup panel.** Downright now installs itself. On first launch it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,9 @@ every release; Sparkle orders updates by it.
   Sparkle key ceremony no longer runs a binary discovered by globbing `/tmp`,
   the ephemeral signing keychain is deleted on every path, and CI/release
   install a checksum-pinned `xcodegen` (2.46.0) instead of a floating Homebrew
-  head.
+  head, shipping its SettingPresets alongside the binary so the generated
+  project keeps `ONLY_ACTIVE_ARCH=YES` (a binary-only install dropped it and
+  made the acceptance build fail on universal app extensions).
 - **Fixed a workspace-sidebar crash on colliding filenames.** The link graph
   keyed files by a normalized path that folds `a\b.md` into `a/b.md` (and a
   hidden `.x.md` into `x.md`); `uniqueKeysWithValues` trapped on the first

--- a/Docs/STATUS.md
+++ b/Docs/STATUS.md
@@ -236,7 +236,7 @@ what they mean for §13's P0 kill criterion.
 
 ## Test suites
 
-The full check currently runs **716 tests in 71 suites**.
+The full check currently runs **1003 tests in 85 suites**.
 
 | Suite | Covers |
 |---|---|

--- a/Scripts/generate-sparkle-keys.sh
+++ b/Scripts/generate-sparkle-keys.sh
@@ -19,13 +19,24 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-GEN_KEYS="$(ls /tmp/sparkle*/bin/generate_keys /usr/local/bin/generate_keys 2>/dev/null | head -1 || true)"
+# The tool that mints the update-signing key pair must not be discovered by
+# globbing /tmp: anyone on a shared machine can plant a directory that sorts
+# ahead of the real one and substitute their own binary during the one
+# ceremony that establishes the whole update chain's trust.  Accept an
+# explicit path, or the root-owned Homebrew/legacy locations only.
+GEN_KEYS="${SPARKLE_KEYS_TOOL:-}"
 if [ -z "$GEN_KEYS" ]; then
-    echo "Sparkle tools not found. Fetch them first:" >&2
+    for candidate in /opt/homebrew/bin/generate_keys /usr/local/bin/generate_keys; do
+        if [ -x "$candidate" ]; then GEN_KEYS="$candidate"; break; fi
+    done
+fi
+if [ -z "$GEN_KEYS" ]; then
+    echo "Sparkle's generate_keys not found. Fetch the pinned tools and point this" >&2
+    echo "script at them explicitly:" >&2
     echo "  curl -fsSL -o /tmp/sparkle.tar.xz https://github.com/sparkle-project/Sparkle/releases/download/2.9.5/Sparkle-2.9.5.tar.xz" >&2
     echo "  echo '015336b601493e05c237964954bff6191370003d94edefe663724c88840d73cc  /tmp/sparkle.tar.xz' | shasum -a 256 -c -" >&2
-    echo "  tar xf /tmp/sparkle.tar.xz -C /tmp" >&2
-    echo "Then re-run this script." >&2
+    echo "  mkdir -p /tmp/sparkle-tools && tar xf /tmp/sparkle.tar.xz -C /tmp/sparkle-tools" >&2
+    echo "  SPARKLE_KEYS_TOOL=/tmp/sparkle-tools/bin/generate_keys Scripts/generate-sparkle-keys.sh" >&2
     exit 1
 fi
 

--- a/Scripts/sign-and-notarize.sh
+++ b/Scripts/sign-and-notarize.sh
@@ -117,9 +117,13 @@ trap 'rm -f "${CLEANUP[@]}"' EXIT
 if [ -n "${KEYCHAIN_PROFILE:-}" ]; then
     NOTARY=(--keychain-profile "$KEYCHAIN_PROFILE")
 else
-    printf '%s' "${APPLE_API_PRIVATE_KEY_P8:-}" > /tmp/downright-AuthKey.p8
-    CLEANUP+=(/tmp/downright-AuthKey.p8)
-    NOTARY=(--key /tmp/downright-AuthKey.p8 --key-id "$APPLE_API_KEY_ID" --issuer "$APPLE_API_ISSUER_ID")
+    # The API key is the release credential: never at a fixed /tmp path where
+    # another local user can pre-create or symlink it. mktemp gives a fresh
+    # 0600 file; the EXIT trap removes it after the last submit that uses it.
+    AUTH_KEY="$(mktemp "${TMPDIR:-/tmp}/downright-AuthKey.XXXXXX")"
+    printf '%s' "${APPLE_API_PRIVATE_KEY_P8:-}" > "$AUTH_KEY"
+    CLEANUP+=("$AUTH_KEY")
+    NOTARY=(--key "$AUTH_KEY" --key-id "$APPLE_API_KEY_ID" --issuer "$APPLE_API_ISSUER_ID")
 fi
 xcrun notarytool submit "$NOTARY_ZIP" "${NOTARY[@]}" --wait --timeout 20m
 

--- a/Sources/DownrightApp/AI/MarkdownDocument.swift
+++ b/Sources/DownrightApp/AI/MarkdownDocument.swift
@@ -241,6 +241,18 @@ final class MarkdownDocument: NSObject {
     // MARK: - Opening and saving
 
     func open(_ fileURL: URL) throws {
+        // Canonicalise once, up front.  A `.atomic` write renames a new file
+        // over the destination, which would *replace a symlink with a regular
+        // file* while the link's target kept its stale content.  Resolving here
+        // makes the identity, the watcher, and the write path agree, so saving
+        // a file opened through a symlink edits the target it points at rather
+        // than clobbering the link itself (§8.1).
+        let canonical = fileURL.resolvingSymlinksInPath()
+        // Read before touching any state: a file that vanishes between the
+        // link-follow and the read must leave the document exactly as the
+        // caller's `close()` left it, not half-torn-down.
+        let (text, fidelity) = try DocumentIO.read(contentsOf: canonical)
+
         isClosed = false
         enqueueParseControl { await $0.resume() }
         cancelParseWork()
@@ -249,14 +261,6 @@ final class MarkdownDocument: NSObject {
         // file must not decorate the next one.  `reset`, not `clear`: dropping
         // a document is not the user reviewing it.
         changes.reset()
-        // Canonicalise once, up front.  A `.atomic` write renames a new file
-        // over the destination, which would *replace a symlink with a regular
-        // file* while the link's target kept its stale content.  Resolving here
-        // makes the identity, the watcher, and the write path agree, so saving
-        // a file opened through a symlink edits the target it points at rather
-        // than clobbering the link itself (§8.1).
-        let canonical = fileURL.resolvingSymlinksInPath()
-        let (text, fidelity) = try DocumentIO.read(contentsOf: canonical)
         self.url = canonical
         self.fidelity = fidelity
         self.state = DocumentStateStore.shared.state(for: canonical)
@@ -755,6 +759,13 @@ final class MarkdownDocument: NSObject {
     }
 
     private func handleWatchEvent(_ event: FileWatcher.Event) {
+        // `FileWatcher` dispatches to the main queue; a block already in
+        // flight when `close()` ran cannot be retracted, and `stop()` only
+        // cancels work that has not started.  A late event on a closed
+        // document would schedule a fresh absorb and fire external-change UI
+        // on a window that is going away — the same guard `startAsyncReparse`
+        // and `preferencesDidChange` already apply.
+        guard !isClosed else { return }
         switch event {
         case .removed:
             onExternalEvent?(.fileRemoved)

--- a/Sources/DownrightApp/AI/PathResolver.swift
+++ b/Sources/DownrightApp/AI/PathResolver.swift
@@ -206,10 +206,17 @@ enum ExternalEditor: String, CaseIterable, Codable {
         let editor = ProcessInfo.processInfo.environment["EDITOR"].flatMap(sanitizedEditor) ?? "vi"
         let lineArg = line.map { "+\($0) " } ?? ""
         let command = "\(editor) \(lineArg)\(shellQuoted(file.path))"
+        // Inside the AppleScript string literal, backslash is an escape
+        // character too: a raw `\` in the path would swallow the next
+        // character (or break the literal).  Escape both, and only, of the
+        // characters AppleScript gives meaning to.
+        let appleScriptString = command
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
         let script = """
         tell application "Terminal"
             activate
-            do script "\(command.replacingOccurrences(of: "\"", with: "\\\""))"
+            do script "\(appleScriptString)"
         end tell
         """
         var error: NSDictionary?

--- a/Sources/DownrightApp/App/DocumentWindowController+Actions.swift
+++ b/Sources/DownrightApp/App/DocumentWindowController+Actions.swift
@@ -14,12 +14,26 @@ extension DocumentWindowController {
     /// state first so its reading position survives the hop.
     func openInPlace(_ url: URL) {
         guard confirmPendingChangesBeforeClose(markDiscardForWindowClose: false) else { return }
+        let previousURL = markdownDocument.url
         resetTransientChrome()
         markdownDocument.close()
         do {
             try open(url, mode: mode)
             resetWorkspaceState(for: url)
         } catch {
+            // The hop died mid-flight (the target vanished between the click
+            // and the read).  The document is closed and watcherless now; put
+            // the file the reader was actually looking at back instead of
+            // leaving a dead surface that no longer tracks external writes.
+            if let previousURL {
+                do {
+                    try open(previousURL, mode: mode)
+                    resetWorkspaceState(for: previousURL)
+                    return
+                } catch {
+                    // The previous file is gone too; fall through to the beep.
+                }
+            }
             NSSound.beep()
         }
     }
@@ -60,7 +74,7 @@ extension DocumentWindowController {
     // MARK: - Images
 
     func presentLightbox(source: String, caption: String?) {
-        guard let window else { return }
+        guard window != nil else { return }
         let localURL = LocalAssetPolicy.request(raw: source, documentURL: markdownDocument.url)?.url
         let remoteURL = URL(string: source).flatMap { url -> URL? in
             guard let scheme = url.scheme?.lowercased(),
@@ -72,15 +86,28 @@ extension DocumentWindowController {
         }
         let url = localURL ?? remoteURL
         guard let url else { return }
-        let present = {
+        let present = { [weak self] in
+            guard let self else { return }
             self.documentPanes.forEach { $0.textView.refreshLocalAssets() }
-            guard let image = NSImage(contentsOf: url) else { return }
-            LightboxWindow(
-                image: image,
-                caption: caption,
-                reduceMotion: self.activeStyleSheet.reduceMotion,
-                reduceTransparency: self.activeStyleSheet.reduceTransparency
-            ).present(over: window)
+            // Decoding — and for a remote image, downloading — must never
+            // block the main thread: a slow or hanging server would freeze
+            // the whole app inside the click handler. Read off-main, then
+            // present on the main actor against the window that is current
+            // when the image actually arrives.
+            let reduceMotion = self.activeStyleSheet.reduceMotion
+            let reduceTransparency = self.activeStyleSheet.reduceTransparency
+            Task.detached(priority: .userInitiated) {
+                let image = NSImage(contentsOf: url)
+                await MainActor.run { [weak self] in
+                    guard let self, let image, let window = self.window else { return }
+                    LightboxWindow(
+                        image: image,
+                        caption: caption,
+                        reduceMotion: reduceMotion,
+                        reduceTransparency: reduceTransparency
+                    ).present(over: window)
+                }
+            }
         }
         if url.isFileURL {
             authorizeLocalEffect(.readLocalAsset, target: url, action: present)

--- a/Sources/DownrightApp/App/DocumentWindowController+Trust.swift
+++ b/Sources/DownrightApp/App/DocumentWindowController+Trust.swift
@@ -185,9 +185,9 @@ extension DocumentWindowController: TrustPromptViewDelegate {
         let path: URL?
         if let targetPath = request.target.canonicalPath {
             let targetURL = URL(fileURLWithPath: targetPath)
-            path = scope == .folder ? targetURL.deletingLastPathComponent() : targetURL
+            path = scope == .folder ? folderScopeURL(for: targetURL) : targetURL
         } else if let documentURL = markdownDocument.url {
-            path = scope == .folder ? documentURL.deletingLastPathComponent() : documentURL
+            path = scope == .folder ? folderScopeURL(for: documentURL) : documentURL
         } else {
             path = nil
         }
@@ -203,11 +203,20 @@ extension DocumentWindowController: TrustPromptViewDelegate {
 
     private func revokeMatching(request: TrustRequest) {
         if let path = request.target.canonicalPath {
-            revokeTrust(scope: .file, path: URL(fileURLWithPath: path))
-            revokeTrust(scope: .folder, path: URL(fileURLWithPath: path).deletingLastPathComponent())
+            let targetURL = URL(fileURLWithPath: path)
+            revokeTrust(scope: .file, path: targetURL)
+            revokeTrust(scope: .folder, path: folderScopeURL(for: targetURL))
         } else if let documentURL = markdownDocument.url {
             revokeTrust(scope: .file, path: documentURL)
-            revokeTrust(scope: .folder, path: documentURL.deletingLastPathComponent())
+            revokeTrust(scope: .folder, path: folderScopeURL(for: documentURL))
         }
+    }
+
+    /// The folder a "Allow for Folder" grant covers for a target.  A file
+    /// target grants its parent directory; a directory target grants the
+    /// directory itself, so consenting on a folder never widens to its parent.
+    private func folderScopeURL(for target: URL) -> URL {
+        let isDirectory = (try? target.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory ?? false
+        return DocumentTrust.folderScope(for: target, isDirectory: isDirectory)
     }
 }

--- a/Sources/DownrightApp/Export/HTMLExporter.swift
+++ b/Sources/DownrightApp/Export/HTMLExporter.swift
@@ -244,6 +244,14 @@ struct HTMLExporter {
             guard linkIsSafe(destination) else { return escape(destination) }
             return "<a href=\"\(escape(destination))\">\(escape(destination))</a>"
         case .wikilink(let target, let label):
+            // Same rule as ordinary links above: a wikilink target with a
+            // scheme missing from the allowlist (`[[javascript:alert(1)//]]`)
+            // must not become a live `href` — the `.html` suffix does not
+            // neutralize it, because the `//` comments the suffix out of the
+            // script.  Render it inert with the destination as tooltip text.
+            guard linkIsSafe(target) else {
+                return "<span class=\"wikilink\" title=\"\(escape(target))\">\(escape(label ?? target))</span>"
+            }
             return "<a class=\"wikilink\" href=\"\(escape(target)).html\">\(escape(label ?? target))</a>"
         case .image(let source, let alt):
             return renderImage(source: source, alt: alt)

--- a/Sources/DownrightApp/Security/DocumentTrust.swift
+++ b/Sources/DownrightApp/Security/DocumentTrust.swift
@@ -117,4 +117,12 @@ struct DocumentTrust: Sendable {
         guard childParts.count >= rootParts.count else { return false }
         return Array(childParts.prefix(rootParts.count)) == rootParts
     }
+
+    /// The folder a "Allow for Folder" grant covers for a target.  A file
+    /// target grants its containing directory; a directory target grants the
+    /// directory itself — granting a directory's parent would authorize more
+    /// than the user consented to when the target is itself a folder.
+    static func folderScope(for target: URL, isDirectory: Bool) -> URL {
+        isDirectory ? target : target.deletingLastPathComponent()
+    }
 }

--- a/Sources/DownrightApp/Security/TrustStore.swift
+++ b/Sources/DownrightApp/Security/TrustStore.swift
@@ -76,13 +76,20 @@ final class TrustStore {
     @discardableResult
     func grant(scope: TrustScope, path: URL, effects: Set<TrustEffect>) -> Bool {
         guard let canonical = DocumentTrust.canonicalFilePath(path) else { return false }
-        let grant = TrustGrant(scope: scope, canonicalPath: canonical.path, effects: effects)
         lock.lock()
         defer { lock.unlock() }
         guard !loadFailed else { return false }
         let previous = values
+        let existing = values.first { $0.scope == scope && $0.canonicalPath == canonical.path }
         values.removeAll { $0.scope == scope && $0.canonicalPath == canonical.path }
-        values.append(grant)
+        // A new grant extends the effects already allowed for this path rather
+        // than replacing them: granting editor-launch after a folder-read must
+        // not silently revoke the read the user consented to earlier.
+        values.append(TrustGrant(
+            scope: scope,
+            canonicalPath: canonical.path,
+            effects: effects.union(existing?.effects ?? [])
+        ))
         // Keep mutation and persistence ordered. Unlocking before the save
         // lets concurrent callers write snapshots in reverse order, leaving
         // trust.json stale even though the in-memory grants are current.

--- a/Sources/DownrightApp/Workspace/WorkspaceLinkGraph.swift
+++ b/Sources/DownrightApp/Workspace/WorkspaceLinkGraph.swift
@@ -54,7 +54,22 @@ public struct WorkspaceLinkGraph: Sendable, Equatable {
 
 enum WorkspaceLinkGraphBuilder {
     static func build(snapshot: WorkspaceIndexSnapshot, includeUnlinkedMentions: Bool = false) -> WorkspaceLinkGraph {
-        let byPath = Dictionary(uniqueKeysWithValues: snapshot.entries.map { (normalize($0.relativePath), $0) })
+        // `normalize` folds distinct files together (`a\b.md` vs `a/b.md`, and
+        // a hidden `.x.md` vs `x.md`), so a plain uniqueKeysWithValues would
+        // trap on the first duplicate.  Prefer the entry whose relative path is
+        // already normalized (no backslash folding or `./` trimming); among
+        // ties the sorted scan order decides, so the winner is deterministic.
+        var byPath: [String: WorkspaceIndexEntry] = [:]
+        for entry in snapshot.entries {
+            let key = normalize(entry.relativePath)
+            if let existing = byPath[key] {
+                if existing.relativePath != key, entry.relativePath == key {
+                    byPath[key] = entry
+                }
+                continue
+            }
+            byPath[key] = entry
+        }
         let byStem = Dictionary(grouping: snapshot.entries) { normalize(URL(fileURLWithPath: $0.relativePath).deletingPathExtension().path) }
         var outgoing: [String: [WorkspaceLinkTarget]] = [:]
         var backlinks: [String: [WorkspaceBacklink]] = [:]

--- a/Sources/DownrightQL/PreviewViewController.swift
+++ b/Sources/DownrightQL/PreviewViewController.swift
@@ -87,6 +87,7 @@ final class PreviewViewController: NSViewController, QLPreviewingController {
             // actor), and cancellation is forwarded to it: a superseded or
             // dismissed preview stops paying for bytes nobody will present.
             let load = Task.detached(priority: .userInitiated) { () -> LoadResult in
+                if Task.isCancelled { return LoadResult.failure }
                 let byteCount =
                     (try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? 0
                 switch QuickLookPolicy.presentation(forByteCount: byteCount) {
@@ -95,11 +96,13 @@ final class PreviewViewController: NSViewController, QLPreviewingController {
                         contentsOf: url,
                         limit: QuickLookPolicy.prefixReadLimitBytes
                     ) else { return LoadResult.failure }
+                    if Task.isCancelled { return LoadResult.failure }
                     return LoadResult.prefix(head)
                 case .full:
                     guard let (text, _) = try? DocumentIO.read(contentsOf: url) else {
                         return LoadResult.failure
                     }
+                    if Task.isCancelled { return LoadResult.failure }
                     return LoadResult.full(text)
                 }
             }

--- a/Sources/DownrightQL/PreviewViewController.swift
+++ b/Sources/DownrightQL/PreviewViewController.swift
@@ -83,8 +83,10 @@ final class PreviewViewController: NSViewController, QLPreviewingController {
 
             // Finder owns the main thread that presents this controller. File
             // coordination and decoding must not occupy it, especially for the
-            // multi-megabyte prefix path.
-            let load = await Task.detached(priority: .userInitiated) {
+            // multi-megabyte prefix path. The load runs detached (off the main
+            // actor), and cancellation is forwarded to it: a superseded or
+            // dismissed preview stops paying for bytes nobody will present.
+            let load = Task.detached(priority: .userInitiated) { () -> LoadResult in
                 let byteCount =
                     (try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? 0
                 switch QuickLookPolicy.presentation(forByteCount: byteCount) {
@@ -100,7 +102,12 @@ final class PreviewViewController: NSViewController, QLPreviewingController {
                     }
                     return LoadResult.full(text)
                 }
-            }.value
+            }
+            let loadResult = await withTaskCancellationHandler {
+                await load.value
+            } onCancel: {
+                load.cancel()
+            }
 
             guard !Task.isCancelled else {
                 handler(CocoaError(.userCancelled))
@@ -119,7 +126,7 @@ final class PreviewViewController: NSViewController, QLPreviewingController {
                 // appearance from the first file shown in this process.
                 self.view.appearance = self.previewAppearance.nsAppearance
                 self.resetPreview()
-                switch load {
+                switch loadResult {
                 case .prefix(let head): self.presentTruncated(head, url: url)
                 case .full(let text): self.present(text, url: url)
                 case .failure:

--- a/Sources/MarkdownCore/Derived.swift
+++ b/Sources/MarkdownCore/Derived.swift
@@ -24,7 +24,11 @@ struct SourceScanner {
     init(map: SourceMap) {
         let text = map.text
         var line = 0
-        var fence: String?
+        /// The open fence's character and run length.  CommonMark: a closing
+        /// fence line is only fence characters and whitespace, and at least as
+        /// long as the opening run — an info string (`\`\`\`ruby`) inside a
+        /// longer fence is content, not a closer.
+        var fence: (character: unichar, length: Int)?
         while line < map.lineCount {
             defer { line += 1 }
             let lineRange = map.contentRange(ofLine: line)
@@ -51,11 +55,21 @@ struct SourceScanner {
             let trimmedLength = end - trimmedStart
 
             if let open = fence {
-                if hasPrefix(text, at: trimmedStart, length: trimmedLength, open) { fence = nil }
+                if isClosingFenceLine(text, at: trimmedStart, length: trimmedLength, fence: open) {
+                    fence = nil
+                }
                 continue
             }
-            if hasPrefix(text, at: trimmedStart, length: trimmedLength, "```") { fence = "```"; continue }
-            if hasPrefix(text, at: trimmedStart, length: trimmedLength, "~~~") { fence = "~~~"; continue }
+            if let backticks = fenceRun(text, at: trimmedStart, length: trimmedLength, character: 0x60),
+               backticks >= 3 {
+                fence = (0x60, backticks)
+                continue
+            }
+            if let tildes = fenceRun(text, at: trimmedStart, length: trimmedLength, character: 0x7E),
+               tildes >= 3 {
+                fence = (0x7E, tildes)
+                continue
+            }
             guard indentColumns < 4, trimmedLength > 0,
                   text.character(at: trimmedStart) == 0x5B
             else { continue }
@@ -105,12 +119,27 @@ struct SourceScanner {
         }
     }
 
-    /// Whether `text[trimmedStart..<trimmedStart+length]` begins with `prefix`.
-    /// All prefixes in play are ASCII, so UTF-16 units can be compared directly.
-    private func hasPrefix(_ text: NSString, at offset: Int, length: Int, _ prefix: String) -> Bool {
-        var index = 0
-        for unit in prefix.utf16 { // lazy UTF-16 view, no array allocation
-            guard index < length, text.character(at: offset + index) == unit else { return false }
+    /// The leading run of `character` on a trimmed line, or `nil` when there is
+    /// none.  ASCII units compare directly on the UTF-16 buffer.
+    private func fenceRun(_ text: NSString, at offset: Int, length: Int, character: unichar) -> Int? {
+        var run = 0
+        while run < length, text.character(at: offset + run) == character { run += 1 }
+        return run > 0 ? run : nil
+    }
+
+    /// CommonMark's closing-fence test: the same character as the opening
+    /// fence, a run at least as long as (and no shorter than three), and
+    /// nothing after it but spaces or tabs.  An info string does not close.
+    private func isClosingFenceLine(
+        _ text: NSString, at offset: Int, length: Int, fence: (character: unichar, length: Int)
+    ) -> Bool {
+        guard let run = fenceRun(text, at: offset, length: length, character: fence.character),
+              run >= 3, run >= fence.length else { return false }
+        var index = offset + run
+        let end = offset + length
+        while index < end {
+            let c = text.character(at: index)
+            if c != 0x20, c != 0x09 { return false }
             index += 1
         }
         return true

--- a/Sources/MarkdownCore/Extensions/PathTokenScanner.swift
+++ b/Sources/MarkdownCore/Extensions/PathTokenScanner.swift
@@ -201,8 +201,10 @@ enum PathTokenScanner {
     private static func isURL(_ text: NSString, range: NSRange) -> Bool {
         let start = range.location
         let end = range.upperBound
-        // `://` anywhere in the token.
-        for index in start..<(end - 2) where text.character(at: index) == 0x3A {
+        // `://` anywhere in the token.  A one-unit path (`3:16` splits to the
+        // path `3`) makes `end - 2` precede `start`; building that range
+        // traps, so clamp it — there is nothing to scan.
+        for index in start..<max(start, end - 2) where text.character(at: index) == 0x3A {
             if text.character(at: index + 1) == 0x2F, text.character(at: index + 2) == 0x2F {
                 return true
             }

--- a/Sources/MarkdownCore/Parser.swift
+++ b/Sources/MarkdownCore/Parser.swift
@@ -343,9 +343,24 @@ struct BlockBuilder {
         for index in children.indices.dropFirst() {
             let start = children[index - 1].range.location
             let span = NSRange(location: start, length: max(0, children[index].range.location - start))
-            // Only the two trailing UTF-16 units decide; avoid a substring.
-            let end = span.upperBound
-            if end >= 2, text.character(at: end - 1) == 0x0A, text.character(at: end - 2) == 0x0A { return false }
+            // A blank line means two terminators back to back; `\r\n` counts
+            // as one, so recognize terminators by width rather than assuming
+            // LF units.
+            var end = span.upperBound
+            var terminators = 0
+            while terminators < 2 {
+                if end >= 2,
+                   text.character(at: end - 2) == 0x0D, text.character(at: end - 1) == 0x0A {
+                    end -= 2
+                } else if end >= 1,
+                          text.character(at: end - 1) == 0x0A || text.character(at: end - 1) == 0x0D {
+                    end -= 1
+                } else {
+                    break
+                }
+                terminators += 1
+            }
+            if terminators >= 2 { return false }
         }
         // CommonMark: a list is loose when any item directly contains two
         // block-level elements, not only when a single item happens to.
@@ -424,12 +439,20 @@ struct BlockBuilder {
             let closeStart = endLine > startLine ? map.lineStarts[endLine] : range.upperBound
             // A closing fence must match the opening fence's character, not a
             // mixture of both, or a `~~~` code block could be terminated by a
-            // backtick fence and vice versa.
+            // backtick fence and vice versa.  CommonMark also requires it to be
+            // at least as long as the opening fence and to be followed only by
+            // spaces or tabs — an info string (`\`\`\`ruby`) does not close,
+            // and a shorter same-character run inside an unclosed longer
+            // fence is content, not chrome.
             let fenceChar: Character = fenceCharacters.hasPrefix("~~~") ? "~" : "`"
+            let openLength = fenceCharacters.prefix { $0 == fenceChar }.count
             let closeLine = Self.fencePrefix(of: map.string(ofLine: endLine))
+            let closeRun = closeLine.prefix { $0 == fenceChar }
+            let closeTail = closeLine.dropFirst(closeRun.count)
+                .trimmingCharacters(in: .whitespaces)
             let hasClosingFence = endLine > startLine
-                && !closeLine.isEmpty
-                && closeLine.allSatisfy { $0 == fenceChar }
+                && closeRun.count >= max(3, openLength)
+                && closeTail.isEmpty
             let contentEnd = hasClosingFence ? closeStart : range.upperBound
             content = NSRange(location: openEnd, length: max(0, contentEnd - openEnd))
             if hasClosingFence {
@@ -602,12 +625,13 @@ struct BlockBuilder {
                 existing.inlines = InlineSpan.clipLeading(existing.inlines, to: definition.markerRange.upperBound)
                 continue
             }
+            let synthesized = clampedSynthesisRange(definition.range, in: children)
             let block = MDBlock(
                 content: .footnoteDefinition(identifier: definition.identifier),
-                range: definition.range,
+                range: synthesized,
                 contentRange: NSRange(
                     location: definition.markerRange.upperBound,
-                    length: max(0, definition.range.upperBound - definition.markerRange.upperBound)
+                    length: max(0, synthesized.upperBound - definition.markerRange.upperBound)
                 ),
                 markerRange: definition.markerRange,
                 depth: 1
@@ -615,6 +639,20 @@ struct BlockBuilder {
             let insertion = children.firstIndex { $0.range.location > definition.range.location }
             children.insert(block, at: insertion ?? children.count)
         }
+    }
+
+    /// The scanner folds indented continuation lines into a footnote
+    /// definition's range, but cmark can claim those same lines for a sibling
+    /// (an indented code block, when the definition's body parses as a bare
+    /// URL).  Top-level children never overlap — a synthesized block must not
+    /// either, so it ends where the next child begins.
+    private func clampedSynthesisRange(_ range: NSRange, in children: [MDBlock]) -> NSRange {
+        var clamped = range
+        if let next = children.first(where: { $0.range.location > range.location }),
+           next.range.location < clamped.upperBound {
+            clamped.length = max(0, next.range.location - clamped.location)
+        }
+        return clamped
     }
 }
 

--- a/Sources/MarkdownCore/Restructure.swift
+++ b/Sources/MarkdownCore/Restructure.swift
@@ -124,7 +124,10 @@ public enum Restructure {
         if hashes.count != heading.level {
             // Setext can express only H1/H2. The direct picker still promises
             // H1...H6, so normalize this heading to ATX while preserving the
-            // parsed title, indentation, and original line ending.
+            // title's exact source bytes, indentation, and original line
+            // ending.  The *source* span, not `heading.title`: the parsed
+            // title is plain text, and rebuilding from it would strip the
+            // emphasis and code markers the line carries.
             let titleLineNumber = doc.line(at: line.location)
             guard titleLineNumber < doc.lineStarts.count else { return nil }
             let underlineStart = doc.lineStarts[titleLineNumber]
@@ -137,9 +140,10 @@ public enum Restructure {
                     length: underlineStart - line.upperBound
                 ))
                 : ""
+            let rawTitle = doc.substring(heading.contentRange)
             return TextEdit(
                 range: NSRange(location: line.location, length: removalEnd - line.location),
-                replacement: "\(indent)\(String(repeating: "#", count: level)) \(heading.title)\(separator)",
+                replacement: "\(indent)\(String(repeating: "#", count: level)) \(rawTitle)\(separator)",
                 summary: "H\(heading.level) → H\(level): \(heading.title)"
             )
         }
@@ -175,20 +179,23 @@ public enum Restructure {
         let text = doc.text as NSString
         let ending = DocumentIO.dominantLineEnding(doc.text).rawValue
         let title = doc.headings[headingIndex].title
-        let split = SectionSplit(section, in: text, ending: ending)
-        let leadingBlanks = blankRun(before: section.location, in: text, ending: ending)
+        let split = SectionSplit(section, in: text)
+        let leadingSeparator = Self.blankSeparator(before: section.location, in: text)
 
         // Cut.  A section that owns a trailing blank run takes it along and the
         // separator before it survives to join its neighbours.  The last
         // section owns nothing, so the run before it — and the final newline,
-        // if the file has none of its own — go too.  `leadingBlanks` counts
-        // *lines*, so the extension must scale by the terminator's width or a
-        // CRLF separator is only half-swallowed and its stray `\r` survives.
+        // if the file has none of its own — go too.  The separator is measured
+        // in its own bytes: a mixed-ending file keeps whatever terminators it
+        // actually had instead of being rebuilt as LF.
         var cut = section
         if split.trailingBlanks > 0 || section.upperBound < doc.length {
             cut = section
         } else {
-            let extra = (leadingBlanks + (split.isTerminated ? 0 : 1)) * ending.utf16.count
+            let unterminatedWidth = split.isTerminated
+                ? 0
+                : (Self.terminator(endingAt: section.location, in: text)?.utf16.count ?? ending.utf16.count)
+            let extra = leadingSeparator.utf16.count + unterminatedWidth
             cut = NSRange(
                 location: max(0, section.location - extra),
                 length: section.length + min(extra, section.location)
@@ -201,13 +208,13 @@ public enum Restructure {
             // Appending: the separator has to go in front, since there is no
             // following section to carry one.
             let separator = split.trailingBlanks > 0
-                ? String(repeating: ending, count: split.trailingBlanks)
-                : String(repeating: ending, count: max(1, leadingBlanks))
+                ? split.trailingSeparator
+                : (leadingSeparator.isEmpty ? ending : leadingSeparator)
             insertion = separator + split.core
         } else {
-            var separator = blankRun(before: destination, in: text, ending: ending)
-            if separator == 0 { separator = leadingBlanks }
-            insertion = split.terminatedCore + String(repeating: ending, count: separator)
+            var separator = Self.blankSeparator(before: destination, in: text)
+            if separator.isEmpty { separator = leadingSeparator }
+            insertion = split.terminatedCore(ending) + separator
         }
 
         return [
@@ -220,51 +227,73 @@ public enum Restructure {
         ]
     }
 
+    /// The line terminator that ends exactly at `offset` (`\r\n`, `\n`, or a
+    /// lone `\r`), or `nil` when no terminator ends there.
+    private static func terminator(endingAt offset: Int, in text: NSString) -> String? {
+        guard offset > 0 else { return nil }
+        if offset >= 2,
+           text.character(at: offset - 2) == 0x0D, text.character(at: offset - 1) == 0x0A {
+            return "\r\n"
+        }
+        if text.character(at: offset - 1) == 0x0A { return "\n" }
+        if text.character(at: offset - 1) == 0x0D { return "\r" }
+        return nil
+    }
+
     /// A section's content, its terminator and the blank run that trails it.
-    /// `ending` is the document's dominant line terminator (`\n`, `\r\n` or a
-    /// lone `\r`), so a move through a classic-Mac or CRLF file never mixes
-    /// endings.
+    /// Terminators are recognised by width (`\r\n`, `\n`, `\r`), so a move
+    /// through a CRLF, classic-Mac, or mixed file keeps the bytes it found.
     private struct SectionSplit {
         var core: String
         var isTerminated: Bool
         var trailingBlanks: Int
-        private let ending: String
+        /// The exact terminator bytes of the trailing blank run, in document
+        /// order — what a move must hand back when it re-establishes the gap.
+        var trailingSeparator: String
 
-        init(_ section: NSRange, in text: NSString, ending: String) {
-            self.ending = ending
-            let length = ending.utf16.count
+        init(_ section: NSRange, in text: NSString) {
             var end = section.upperBound
-            var terminators = 0
-            while end - length >= section.location,
-                  text.substring(with: NSRange(location: end - length, length: length)) == ending {
-                end -= length
-                terminators += 1
+            var stripped: [String] = []
+            while let terminator = Restructure.terminator(endingAt: end, in: text),
+                  end - terminator.utf16.count >= section.location {
+                end -= terminator.utf16.count
+                stripped.append(terminator)
             }
-            isTerminated = terminators > 0
-            let coreEnd = isTerminated ? end + length : end
-            core = text.substring(with: NSRange(
-                location: section.location, length: coreEnd - section.location
-            ))
-            trailingBlanks = max(0, terminators - (isTerminated ? 1 : 0))
+            isTerminated = !stripped.isEmpty
+            // `stripped` is in reverse document order; the first element is
+            // the terminator that directly follows the content.
+            if let own = stripped.last {
+                core = text.substring(with: NSRange(
+                    location: section.location, length: end + own.utf16.count - section.location
+                ))
+            } else {
+                core = text.substring(with: NSRange(location: section.location, length: end - section.location))
+            }
+            trailingBlanks = max(0, stripped.count - (isTerminated ? 1 : 0))
+            trailingSeparator = stripped.dropLast(isTerminated ? 1 : 0).reversed().joined()
         }
 
         /// The content with a line terminator, for pasting somewhere that is
         /// not the end of the document.
-        var terminatedCore: String { isTerminated ? core : core + ending }
+        func terminatedCore(_ ending: String) -> String {
+            if isTerminated { return core }
+            return core.hasSuffix("\n") || core.hasSuffix("\r") ? core : core + ending
+        }
     }
 
-    /// Blank lines immediately before `offset`, which is a line start: the run
-    /// of `ending` terminators there, less the previous line's own terminator.
-    private static func blankRun(before offset: Int, in text: NSString, ending: String) -> Int {
-        let length = (ending as NSString).length
-        var count = 0
+    /// The blank-line separator immediately before `offset`, which is a line
+    /// start: the run of terminators there, less the previous line's own
+    /// terminator, as the exact bytes found in the document.
+    private static func blankSeparator(before offset: Int, in text: NSString) -> String {
+        var terminators: [String] = []
         var index = offset
-        while index - length >= 0,
-              text.substring(with: NSRange(location: index - length, length: length)) == ending {
-            count += 1
-            index -= length
+        while let terminator = Self.terminator(endingAt: index, in: text) {
+            terminators.append(terminator)
+            index -= terminator.utf16.count
         }
-        return max(0, count - 1)
+        // `terminators[0]` is the previous line's own terminator; the rest are
+        // the blank lines that make up the separator.
+        return terminators.dropFirst().reversed().joined()
     }
 
     /// Moves the block containing `offset` past its neighbouring sibling.  The

--- a/Sources/MarkdownCore/SmartPaste.swift
+++ b/Sources/MarkdownCore/SmartPaste.swift
@@ -271,7 +271,14 @@ private struct HTMLToMarkdown {
     }
 
     private func attribute(_ name: String, in tag: String) -> String? {
-        guard let start = tag.range(of: "\(name)=", options: .caseInsensitive) else { return nil }
+        // `href=` must start at an attribute boundary: matching it as a bare
+        // substring would also hit `data-href=` or `xlink-href=` and pull the
+        // wrong value out of the tag.
+        guard let start = tag.range(of: "\(name)=", options: .caseInsensitive),
+              start.lowerBound == tag.startIndex
+                  || tag[tag.index(before: start.lowerBound)].isWhitespace
+                  || tag[tag.index(before: start.lowerBound)] == "/"
+        else { return nil }
         var rest = tag[start.upperBound...]
         guard let quote = rest.first else { return nil }
         if quote == "\"" || quote == "'" {

--- a/Sources/MarkdownCore/TableFormatter.swift
+++ b/Sources/MarkdownCore/TableFormatter.swift
@@ -15,6 +15,10 @@ enum TableFormatter {
         var rows: [[String]]
         var alignments: [TableAlignment]
         var indent: String
+        /// The line terminator that followed each source line, in render order
+        /// (header, delimiter, body…).  A mixed-ending file keeps the bytes it
+        /// had instead of being rebuilt as LF; empty where unknown.
+        var lineTerminators: [String] = []
         var columnCount: Int { Swift.max(alignments.count, rows.map(\.count).max() ?? 0) }
     }
 
@@ -31,7 +35,29 @@ enum TableFormatter {
         let rows = table.rows.map { row in
             row.cells.map { text.substring(with: $0.range).trimmingCharacters(in: .whitespaces) }
         }
-        return Model(rows: rows, alignments: table.alignments, indent: indent)
+        return Model(
+            rows: rows, alignments: table.alignments, indent: indent,
+            lineTerminators: lineTerminators(of: table, in: text)
+        )
+    }
+
+    /// One terminator per source line of the table, in order.  A line without
+    /// a terminator (the last one, in a file with no final newline) yields "".
+    private static func lineTerminators(of table: TableData, in text: NSString) -> [String] {
+        let range = sourceRange(of: table, fallback: NSRange(location: 0, length: 0))
+        var terminators: [String] = []
+        var offset = range.location
+        while offset < range.upperBound {
+            let lineEnd = min(text.length, text.lineEnd(after: offset))
+            var contentEnd = lineEnd
+            if contentEnd > offset, text.character(at: contentEnd - 1) == 0x0A { contentEnd -= 1 }
+            if contentEnd > offset, text.character(at: contentEnd - 1) == 0x0D { contentEnd -= 1 }
+            terminators.append(text.substring(with: NSRange(
+                location: contentEnd, length: max(0, lineEnd - contentEnd)
+            )))
+            offset = lineEnd
+        }
+        return terminators
     }
 
     /// Renders a table back to aligned pipe syntax.
@@ -52,7 +78,17 @@ enum TableFormatter {
         for row in model.rows.dropFirst() {
             lines.append(renderRow(row, widths: widths, alignments: model.alignments, indent: model.indent))
         }
-        return lines.joined(separator: "\n")
+        var out = ""
+        for (index, line) in lines.enumerated() {
+            out += line
+            if index < lines.count - 1 {
+                let captured = model.lineTerminators.indices.contains(index)
+                    ? model.lineTerminators[index]
+                    : ""
+                out += captured.isEmpty ? "\n" : captured
+            }
+        }
+        return out
     }
 
     private static func renderRow(

--- a/Sources/MarkdownRender/Engine/HardWrapReflow.swift
+++ b/Sources/MarkdownRender/Engine/HardWrapReflow.swift
@@ -133,6 +133,9 @@ enum HardWrapReflow {
         hiddenRanges: [NSRange]
     ) -> [NSRange] {
         var runs: [NSRange] = []
+        // A stale parsed document can outlive the buffer it was parsed from, so
+        // the caller's limit may run past `text.length`; clamp before indexing.
+        let limit = Swift.min(limit, text.length)
         var cursor = terminator.upperBound
         while cursor < limit {
             if let hidden = hiddenRanges.first(where: { $0.location == cursor }), hidden.length > 0 {

--- a/Sources/drdownright/AgentBridge.swift
+++ b/Sources/drdownright/AgentBridge.swift
@@ -115,9 +115,14 @@ public enum AgentBridge {
         let command = hookCommand(executable: executable)
         let entries = (settings["hooks"] as? [String: Any])?["PostToolUse"] as? [[String: Any]] ?? []
         return entries.contains { entry in
-            (entry["hooks"] as? [[String: Any]] ?? [])
-                .compactMap { $0["command"] as? String }
-                .contains(command)
+            // Our hook is identified by its matcher *and* its command.  A
+            // foreign entry that happens to run `down notify` under another
+            // matcher must not count as installed — matching on the command
+            // alone would block a needed install and let uninstall delete it.
+            entry["matcher"] as? String == toolMatcher
+                && (entry["hooks"] as? [[String: Any]] ?? [])
+                    .compactMap { $0["command"] as? String }
+                    .contains(command)
         }
     }
 
@@ -157,6 +162,13 @@ public enum AgentBridge {
         var changed = false
         var remaining: [[String: Any]] = []
         for var entry in postToolUse {
+            // Only entries under our matcher are ours to edit.  A foreign entry
+            // with the same command string is the user's own hook and must
+            // survive an uninstall untouched.
+            guard entry["matcher"] as? String == toolMatcher else {
+                remaining.append(entry)
+                continue
+            }
             let commands = entry["hooks"] as? [[String: Any]] ?? []
             let kept = commands.filter { ($0["command"] as? String) != command }
             if kept.count != commands.count { changed = true }

--- a/Sources/drdownright/MarkdownCLI.swift
+++ b/Sources/drdownright/MarkdownCLI.swift
@@ -385,7 +385,7 @@ public enum MarkdownCLI {
 
         func flushParagraph() {
             guard !paragraph.isEmpty else { return }
-            body.append("<p>\(inline(paragraph.joined(separator: "\\n")))</p>")
+            body.append("<p>\(inline(paragraph.joined(separator: "\n")))</p>")
             paragraph.removeAll(keepingCapacity: true)
         }
         var selfListKind: Character?
@@ -397,7 +397,7 @@ public enum MarkdownCLI {
         for line in lines {
             if inCode {
                 if line.hasPrefix("```") {
-                    body.append("<pre><code class=\"language-\(escape(codeLanguage))\">\(escape(codeLines.joined(separator: "\\n")))</code></pre>")
+                    body.append("<pre><code class=\"language-\(escape(codeLanguage))\">\(escape(codeLines.joined(separator: "\n")))</code></pre>")
                     codeLines.removeAll(keepingCapacity: true)
                     inCode = false
                 } else { codeLines.append(line) }
@@ -419,9 +419,9 @@ public enum MarkdownCLI {
             }
             paragraph.append(line)
         }
-        if inCode { body.append("<pre><code>\(escape(codeLines.joined(separator: "\\n")))</code></pre>") }
+        if inCode { body.append("<pre><code>\(escape(codeLines.joined(separator: "\n")))</code></pre>") }
         flushParagraph(); closeList()
-        return "<!doctype html><html><head><meta charset=\"utf-8\"><meta name=\"viewport\" content=\"width=device-width,initial-scale=1\"><title>\(escape(title))</title><style>body{font:16px/1.55 -apple-system,BlinkMacSystemFont,sans-serif;max-width:70ch;margin:3rem auto;padding:0 1rem;color:#222}pre{padding:1rem;background:#f3f3f3;overflow:auto}code{font-family:ui-monospace,monospace}blockquote{border-left:3px solid #aaa;padding-left:1rem;color:#555}img{max-width:100%}</style></head><body>\(body.joined(separator: "\\n"))</body></html>"
+        return "<!doctype html><html><head><meta charset=\"utf-8\"><meta name=\"viewport\" content=\"width=device-width,initial-scale=1\"><title>\(escape(title))</title><style>body{font:16px/1.55 -apple-system,BlinkMacSystemFont,sans-serif;max-width:70ch;margin:3rem auto;padding:0 1rem;color:#222}pre{padding:1rem;background:#f3f3f3;overflow:auto}code{font-family:ui-monospace,monospace}blockquote{border-left:3px solid #aaa;padding-left:1rem;color:#555}img{max-width:100%}</style></head><body>\(body.joined(separator: "\n"))</body></html>"
     }
 
     public static func diagnostics(for markdown: String, baseURL: URL? = nil) -> [DocumentHealthDiagnostic] {
@@ -562,7 +562,7 @@ public enum MarkdownCLI {
             }
             return "<a href=\"\(destination)\">\(label)</a>"
         }
-        return result.replacingOccurrences(of: "\\n", with: "<br>\\n")
+        return result.replacingOccurrences(of: "\n", with: "<br>\n")
     }
 
     private static let linkSchemeAllowlist: Set<String> = ["http", "https", "mailto"]

--- a/Tests/DownrightAppTests/AppLayerTests.swift
+++ b/Tests/DownrightAppTests/AppLayerTests.swift
@@ -549,6 +549,29 @@ struct AppLayerTests {
         #expect(html.contains("href=\"https://example.com\""), "absolute links are untouched")
     }
 
+    /// Regression: wikilink targets used to ship as live `href`s with no
+    /// scheme check.  `[[javascript:alert(1)//]]` exported as
+    /// `href="javascript:alert(1)//.html"` — the `//` comments the suffix out
+    /// of the script, so opening the export and clicking ran the payload.
+    @Test @MainActor func htmlExportMakesUnsafeWikilinkTargetsInert() {
+        let document = MarkdownParser.parse(
+            """
+            [[javascript:alert(document.domain)//]] [[data:text/html;base64,x]]
+            [[Notes]] [[deep/note|with a label]]
+            """
+        )
+        let html = HTMLExporter(
+            document: document, theme: ThemeStore.shared.current,
+            title: "T", baseDirectory: nil, imageProvider: nil
+        ).html()
+        #expect(!html.lowercased().contains("href=\"javascript:"), "script wikilinks must not be live")
+        #expect(!html.lowercased().contains("href=\"data:"), "data wikilinks must not be live")
+        #expect(!html.contains("href=\"javascript:alert(document.domain)//.html\""))
+        #expect(html.contains("href=\"Notes.html\""), "plain wikilinks still export")
+        #expect(html.contains("href=\"deep/note.html\""), "labelled wikilinks still export")
+        #expect(html.contains(">with a label<"))
+    }
+
     @Test @MainActor func htmlExportKeepsDeepHeadingHierarchy() {
         let markdown = "# H1\n\n## H2\n\n### H3\n\n#### H4\n\n##### H5\n\n###### H6\n"
         let html = HTMLExporter(

--- a/Tests/DownrightAppTests/TrustTests.swift
+++ b/Tests/DownrightAppTests/TrustTests.swift
@@ -142,6 +142,33 @@ struct DocumentTrustTests {
         ))
         #expect(store.grants().isEmpty)
     }
+
+    /// "Allow for Folder" on a directory must grant that directory, not its
+    /// parent — granting the parent authorizes every sibling the user never
+    /// consented to.
+    @Test
+    func folderScopeGrantsADirectoryItselfButAParentForAFile() {
+        let directory = URL(fileURLWithPath: "/workspace/assets")
+        let file = directory.appendingPathComponent("logo.png")
+        // `deletingLastPathComponent` keeps a trailing slash, so compare the
+        // path — both spellings name the same directory.
+        #expect(DocumentTrust.folderScope(for: file, isDirectory: false).path == directory.path)
+        #expect(DocumentTrust.folderScope(for: directory, isDirectory: true).path == directory.path)
+    }
+
+    /// A second grant for the same path extends the earlier one; it must not
+    /// wipe the first effect, which is how folder-read and editor-launch kept
+    /// ping-ponging (granting one silently blocked the other).
+    @Test
+    func grantingASecondEffectExtendsTheExistingGrant() {
+        let store = TrustStore(persistence: InMemoryTrustStorePersistence())
+        let path = URL(fileURLWithPath: "/tmp/downright-trust-effects")
+        #expect(store.grant(scope: .file, path: path, effects: [.readLocalAsset]))
+        #expect(store.grant(scope: .file, path: path, effects: [.launchPathOrEditor]))
+        let grants = store.grants()
+        #expect(grants.count == 1)
+        #expect(grants.first?.effects == Set([.readLocalAsset, .launchPathOrEditor]))
+    }
 }
 
 private enum TrustPersistenceFailure: Error { case unavailable }

--- a/Tests/DownrightAppTests/WorkspaceTests.swift
+++ b/Tests/DownrightAppTests/WorkspaceTests.swift
@@ -147,6 +147,50 @@ struct WorkspaceTests {
     }
 
     @Test
+    func graphToleratesNormalizedPathCollisions() {
+        // `normalize` folds backslashes to slashes and trims a leading `./`, so
+        // `a\b.md` collides with `a/b.md` and `.x.md` with `x.md`.  The builder
+        // used to trap on the first duplicate; it must instead prefer the
+        // already-normalized path deterministically.
+        let root = URL(fileURLWithPath: "/workspace")
+        let slash = WorkspaceIndexEntry(
+            url: URL(fileURLWithPath: "/workspace/a/b.md"), relativePath: "a/b.md",
+            text: "", headings: [], frontMatter: [], links: [], byteCount: 0
+        )
+        let backslash = WorkspaceIndexEntry(
+            url: URL(fileURLWithPath: "/workspace/a\\b.md"), relativePath: "a\\b.md",
+            text: "", headings: [], frontMatter: [], links: [], byteCount: 0
+        )
+        let visible = WorkspaceIndexEntry(
+            url: URL(fileURLWithPath: "/workspace/x.md"), relativePath: "x.md",
+            text: "", headings: [], frontMatter: [], links: [], byteCount: 0
+        )
+        let hidden = WorkspaceIndexEntry(
+            url: URL(fileURLWithPath: "/workspace/.x.md"), relativePath: ".x.md",
+            text: "", headings: [], frontMatter: [], links: [], byteCount: 0
+        )
+        let source = WorkspaceIndexEntry(
+            url: URL(fileURLWithPath: "/workspace/notes.md"), relativePath: "notes.md",
+            text: "", headings: [], frontMatter: [],
+            links: [
+                WorkspaceLink(destination: "a/b.md", range: NSRange(location: 0, length: 6), kind: .markdown),
+                WorkspaceLink(destination: "x.md", range: NSRange(location: 7, length: 4), kind: .markdown),
+            ],
+            byteCount: 0
+        )
+        let snapshot = WorkspaceIndexSnapshot(
+            rootURL: root, revision: 1, entries: [slash, backslash, visible, hidden, source]
+        )
+        let graph = WorkspaceLinkGraphBuilder.build(snapshot: snapshot)
+        let resolved = Set(graph.outgoing[source.id]?.compactMap(\.targetFile) ?? [])
+        #expect(resolved.contains(slash.id))
+        #expect(resolved.contains(visible.id))
+        #expect(!resolved.contains(backslash.id))
+        #expect(!resolved.contains(hidden.id))
+        #expect(graph.unresolved.isEmpty)
+    }
+
+    @Test
     func sidebarShowsTreeSearchAndAccessibleRows() throws {
         let entry = WorkspaceIndexEntry(
             url: URL(fileURLWithPath: "/workspace/readme.md"), relativePath: "readme.md", text: "# Readme", headings: [], frontMatter: [], links: [], byteCount: 8

--- a/Tests/MarkdownCLITests/AgentBridgeTests.swift
+++ b/Tests/MarkdownCLITests/AgentBridgeTests.swift
@@ -142,6 +142,36 @@ struct AgentBridgeTests {
         #expect((hooks?["PostToolUse"] as? [[String: Any]])?.count == 2)
     }
 
+    /// Our hook is identified by its matcher *and* its command.  A foreign
+    /// entry that runs `down notify` under another matcher is the user's own
+    /// hook, so it must not count as installed and must not block our install.
+    @Test("A foreign entry with our command under another matcher is not ours")
+    func foreignMatcherWithSameCommandDoesNotBlockInstall() {
+        let foreign: [String: Any] = [
+            "hooks": ["PostToolUse": [["matcher": "Bash", "hooks": [["type": "command", "command": "down notify"]]]]],
+        ]
+        #expect(!AgentBridge.isHookInstalled(in: foreign, executable: "down"))
+        let (settings, changed) = AgentBridge.installingHook(into: foreign, executable: "down")
+        #expect(changed)
+        let postToolUse = (settings["hooks"] as? [String: Any])?["PostToolUse"] as? [[String: Any]]
+        #expect(postToolUse?.count == 2)
+        #expect(AgentBridge.isHookInstalled(in: settings, executable: "down"))
+    }
+
+    @Test("Uninstalling leaves a foreign entry with the same command untouched")
+    func uninstallPreservesForeignMatcherWithSameCommand() {
+        let foreign: [String: Any] = [
+            "hooks": ["PostToolUse": [["matcher": "Bash", "hooks": [["type": "command", "command": "down notify"]]]]],
+        ]
+        let installed = AgentBridge.installingHook(into: foreign, executable: "down").settings
+        let (settings, changed) = AgentBridge.removingHook(from: installed, executable: "down")
+        #expect(changed)
+        let postToolUse = (settings["hooks"] as? [String: Any])?["PostToolUse"] as? [[String: Any]]
+        #expect(postToolUse?.count == 1)
+        #expect(postToolUse?.first?["matcher"] as? String == "Bash")
+        #expect((postToolUse?.first?["hooks"] as? [[String: Any]])?.first?["command"] as? String == "down notify")
+    }
+
     @Test("Uninstalling removes only our hook")
     func uninstallRemovesOnlyOurs() {
         let seeded: [String: Any] = [

--- a/Tests/MarkdownCLITests/MarkdownCLITests.swift
+++ b/Tests/MarkdownCLITests/MarkdownCLITests.swift
@@ -34,6 +34,17 @@ struct MarkdownCLITests {
         #expect(!html.contains("http://") && !html.contains("https://"))
     }
 
+    /// Regression: the writer joined paragraphs, code lines, and body blocks
+    /// with the two characters `\` + `n` instead of a newline, so every
+    /// multi-line paragraph and every code block exported as one line of text
+    /// with visible `\n` garbage in it.
+    @Test func htmlExportUsesRealNewlines() {
+        let html = MarkdownCLI.html(for: "line one\nline two\n\n```swift\nlet a = 1\nlet b = 2\n```\n")
+        #expect(html.contains("<p>line one<br>\nline two</p>"))
+        #expect(html.contains(">let a = 1\nlet b = 2</code>"))
+        #expect(!html.contains("\\n"), "no literal backslash-n may appear in the output")
+    }
+
     @Test func htmlExportMakesUnsafeLinksInert() {
         let html = MarkdownCLI.html(for: """
         [relative](guide.md) [anchor](#part) [web](https://example.com) [mail](mailto:a@example.com)

--- a/Tests/MarkdownCoreTests/ExtensionTests.swift
+++ b/Tests/MarkdownCoreTests/ExtensionTests.swift
@@ -318,6 +318,21 @@ import Testing
         // A real extension after the emoji still resolves.
         #expect(paths("Edit `src/cache.🚀.ts`.\n") == ["src/cache.🚀.ts"])
     }
+
+    /// Regression: a one-character path before a `:digits` suffix (`3:16`,
+    /// `9:30`) used to reach `isURL` with a one-unit range, whose `://` scan
+    /// built `start..<(start - 1)` and fatally trapped the per-keystroke
+    /// parse.  Ordinary prose times and ratios must simply not be tokens.
+    @Test func singleCharacterClockAndRatioTokensDoNotCrash() {
+        #expect(paths("John 3:16 says so.\n").isEmpty)
+        #expect(paths("Meet at 9:30 sharp.\n").isEmpty)
+        #expect(paths("A ratio of 1:2 here.\n").isEmpty)
+        #expect(paths("Run `a:1` for it.\n").isEmpty)
+        #expect(paths("Verse 2:5 and chapter 3:16 agree.\n").isEmpty)
+        // A real path keeps its suffix behaviour after the fix.
+        let doc = MarkdownParser.parse("Edit src/auth/session.ts:42 next.\n")
+        #expect(doc.pathTokens.first?.token.line == 42)
+    }
 }
 
 @Suite struct FenceLanguageTests {

--- a/Tests/MarkdownCoreTests/ParserTests.swift
+++ b/Tests/MarkdownCoreTests/ParserTests.swift
@@ -138,6 +138,38 @@ import Testing
         #expect(doc.substring(block.trailingMarkerRange!) == "```")
     }
 
+    /// CommonMark: a closing fence "may be followed only by spaces or tabs,
+    /// which are ignored".  The recovery used to reject a closer carrying
+    /// trailing whitespace, swallow it into the content, and render it inside
+    /// the block (and copy it, and feed it to math/Mermaid sources).
+    @Test func closingFenceMayCarryTrailingWhitespace() {
+        let doc = MarkdownParser.parse("```swift\nlet x = 1\n``` \n")
+        let block = doc.root.children.first!
+        guard case .codeBlock(_, let isFenced, let content) = block.content else {
+            Issue.record("expected a code block, got \(block.content)")
+            return
+        }
+        #expect(isFenced)
+        #expect(doc.substring(content) == "let x = 1\n")
+        #expect(doc.substring(block.trailingMarkerRange!) == "``` ")
+    }
+
+    /// CommonMark: "The closing code fence must be at least as long as the
+    /// opening fence."  Inside an unclosed four-backtick block a three-backtick
+    /// line is *content*; the recovery used to treat it as the closer and hide
+    /// it as chrome.
+    @Test func shortFenceLineInsideLongerUnclosedFenceIsContent() {
+        let doc = MarkdownParser.parse("````\ncode\n```\nmore\n")
+        let block = doc.root.children.first!
+        guard case .codeBlock(_, let isFenced, let content) = block.content else {
+            Issue.record("expected a code block, got \(block.content)")
+            return
+        }
+        #expect(isFenced)
+        #expect(doc.substring(content) == "code\n```\nmore")
+        #expect(block.trailingMarkerRange == nil)
+    }
+
     @Test func indentedCodeIsNotFenced() {
         let doc = MarkdownParser.parse("    indented\n    more\n")
         guard case .codeBlock(_, let isFenced, _) = doc.root.children.first!.content else {
@@ -231,6 +263,35 @@ import Testing
             }
         }
         #expect(referenced)
+    }
+
+    /// Regression: a line inside an outer fence that starts with a shorter
+    /// fence run plus an info string (`\`\`\`ruby` inside `\`\`\`\`) is content,
+    /// not a closer.  The source scanner used to close on it and then read a
+    /// footnote-looking line *inside* the fence as a real definition.
+    @Test func fencedExampleCodeWithInfoStringsHidesFootnoteLookingLines() {
+        let doc = MarkdownParser.parse(
+            "````markdown\n```ruby\n[^inner]: not a definition\n```\n````\n"
+        )
+        #expect(doc.footnotes["inner"] == nil)
+        #expect(doc.root.children.count == 1, "the whole construct is one code block")
+    }
+
+    /// Regression: when a footnote definition's body parses as a bare URL,
+    /// cmark consumes the definition line and gives the indented continuation
+    /// to a code block.  The synthesized footnote block used to cover both
+    /// lines and overlap that sibling — top-level children never overlap.
+    @Test func synthesizedFootnoteBlockDoesNotOverlapItsSibling() {
+        let doc = MarkdownParser.parse("[^a]: first\n    continued\n")
+        // The definition itself is still recognized…
+        #expect(doc.footnotes["a"] != nil)
+        // …and no two top-level blocks claim the same bytes.
+        let children = doc.root.children
+        for (index, block) in children.enumerated() {
+            if index + 1 < children.count {
+                #expect(block.range.upperBound <= children[index + 1].range.location)
+            }
+        }
     }
 
     @Test func tablesCarryRowsCellsAndAlignments() {

--- a/Tests/MarkdownCoreTests/RestructureTests.swift
+++ b/Tests/MarkdownCoreTests/RestructureTests.swift
@@ -131,6 +131,31 @@ import Testing
         #expect(Restructure.moveSection(doc, headingIndex: 0, before: 0).isEmpty)
     }
 
+    /// A consistently CRLF document keeps CRLF through a move — the classic-Mac
+    /// and Windows round trips must not silently become LF.
+    @Test func moveSectionKeepsConsistentCRLFEndings() {
+        let text = "## A\r\n\r\nbody a\r\n\r\n## B\r\n\r\nbody b\r\n"
+        let doc = MarkdownParser.parse(text)
+        let out = apply(text, Restructure.moveSection(doc, headingIndex: 1, before: 0))
+        #expect(out == "## B\r\n\r\nbody b\r\n\r\n## A\r\n\r\nbody a\r\n")
+        #expect(!out.contains("\r\r"), "no stray carriage returns")
+    }
+
+    /// Regression: in a mixed-ending file the old width-blind walk could not
+    /// see the `\r\n` blank line before the last section, so a move glued the
+    /// two sections together with no separator at all.  The separator's own
+    /// bytes must survive the move.
+    @Test func moveSectionPreservesMixedEndingSeparators() {
+        let text = "## A\n\nbody a\r\n\r\n## B\n\nbody b\n"
+        let doc = MarkdownParser.parse(text)
+        let out = apply(text, Restructure.moveSection(doc, headingIndex: 1, before: 0))
+        let escaped = out.replacingOccurrences(of: "\r", with: "\\r")
+            .replacingOccurrences(of: "\n", with: "\\n")
+        // B keeps its own terminator, the `\r\n` blank separator it had in
+        // life lands between it and A, and A keeps its own CRLF terminator.
+        #expect(escaped == "## B\\n\\nbody b\\n\\r\\n## A\\n\\nbody a\\r\\n")
+    }
+
     @Test func moveSectionSurvivesAnArbitraryPermutation() {
         var text = "# Doc\n\n## A\n\na\n\n## B\n\nb\n\n## C\n\nc\n\n## D\n\nd\n"
         for (from, to) in [(4, 1), (1, 4), (2, 1), (3, 2)] {

--- a/Tests/MarkdownRenderTests/ReflowAndRhythmTests.swift
+++ b/Tests/MarkdownRenderTests/ReflowAndRhythmTests.swift
@@ -137,6 +137,23 @@ private let wrappedListItem = """
     #expect(made.ranges.isEmpty)
 }
 
+@Test func aStaleDocumentLongerThanTheBufferDoesNotOverrunIndents() {
+    // The planner is defensive by contract: a parsed document can outlive the
+    // buffer it was parsed from (an external rewrite racing the last parse), so
+    // a paragraph range can run past `text.length`.  The continuation-indent
+    // walk indexed the text by that unclamped range and read one past the end.
+    //
+    // Three leading spaces keep this a soft break (four would make a code
+    // block), and the truncated buffer ends mid-indent so the walk reaches the
+    // very end of the text and used to read one character past it.
+    let source = "line one\n   line two\n"
+    let document = MarkdownParser.parse(source)
+    let truncated = String(source.prefix(12)) as NSString  // "line one\n   "
+    let made = HardWrapReflow.plan(document: document, text: truncated, hiddenRanges: [], enabled: true)
+    #expect(made.substitutions.allSatisfy { $0.sourceRange.upperBound <= truncated.length })
+    #expect(made.substitutions.contains { $0.sourceRange == NSRange(location: 9, length: 3) })
+}
+
 @Test func aCalloutBodyDoesNotOpenWithASpace() {
     // A quoted paragraph's range begins on the newline that ends the line above
     // it, so the terminator that opens the element joins nothing.  Rendered as a


### PR DESCRIPTION
## Summary

An exhaustive reliability/security audit of Downright, fixed as four commits.
Each fix carries a regression test; the full gate and the release performance
budgets are green at the end.

## Validated issues fixed

### P0 — crashes

- **Crash on ordinary prose.** Any document containing a one-character word
  before `:digits` — `John 3:16`, `meet at 9:30`, `` `a:1` `` — fatally trapped
  the path-token scanner during the per-keystroke reparse. The `://` scan now
  clamps its end.
- **Workspace-sidebar crash on colliding filenames.** The link graph keyed
  files by a normalized path that folds `a\b.md` into `a/b.md` (and `.x.md`
  into `x.md`); `uniqueKeysWithValues` trapped on the first duplicate. Lookup
  is now collision-tolerant and prefers the already-normalized path.
- **Hard-wrap reflow overrun on stale documents.** The continuation-indent
  walk indexed the buffer by an unclamped paragraph range and could read one
  character past the end when a parsed document outlives its buffer.

### Security

- **Stored XSS in HTML export.** Wikilink targets now pass the same scheme
  allowlist as ordinary links; `[[javascript:alert(1)//]]` used to export as a
  live `javascript:` href (the appended `.html` sits behind a `//` comment, so
  it did not neutralize the payload).
- **Trust over-scope.** "Allow for Folder" on a directory target stored the
  directory's *parent*, authorizing every sibling; a directory now grants
  itself, and revoke matches the same folder.
- **Trust grant ping-pong.** A second grant for a path replaced the first,
  silently revoking the earlier effect (folder-read then editor-launch);
  grants now union their effects.

### Correctness

- **Code-fence recovery.** A closing fence may carry trailing spaces/tabs
  (legal CommonMark), and a same-character run shorter than the opening fence
  inside an unclosed longer fence is content, not a phantom closer.
- **Footnote recovery inside fenced code.** The source scanner no longer ends
  a fence on an info string, which used to leak footnote-looking lines out of
  code blocks.
- **Section moves in mixed-ending files.** `moveSection` recognizes
  terminators by width and preserves the separator's exact bytes; table
  realigns and list looseness are width-aware, and re-levelling a setext
  heading keeps its emphasis/code markers.
- **`down export`.** Multi-line paragraphs and code blocks exported as one
  line of literal `\n`; the writer now emits real newlines.
- **Main-thread lightbox freeze.** Remote (and large local) images decode off
  the main thread; cancellation is now honored inside the Quick Look load
  task too.
- **Watcher events after close.** An in-flight event no longer schedules work
  on a closed document, and a failed in-place hop reopens the previous
  document instead of leaving a window that no longer tracks writes.
- **Agent hook install/uninstall.** Matching now keys on matcher *and*
  command, so a foreign `PostToolUse` entry running `down notify` under
  another matcher neither blocks a needed install nor is deleted by an
  uninstall.

### Release chain

Apple API key and Developer ID certificate materialize under
`mktemp`/`RUNNER_TEMP` (not fixed `/tmp` paths), the Sparkle key ceremony no
longer globs `/tmp`, the ephemeral keychain is deleted on every path, and CI/
release install a checksum-pinned `xcodegen` (2.46.0).

## Validation

```text
RUN_DRBENCH=1 Scripts/check.sh
```

- **1003 tests in 85 suites**, all green (baseline before the audit: 988).
- Release bench under budget: typing response p95 **0.15 ms** (8 ms budget),
  end-to-end semantic convergence p95 **~31 ms** (100 ms budget).

## Architecture-behavior notes

- All parser/render fixes preserve the core invariant: raw file text is the
  only source of truth. Reflow stays a display-only substitution, and
  mixed-ending edits are width-aware rather than normalized.
- Trust grants remain canonical-path keyed; the changes only correct *which*
  path a folder grant covers and keep effects additive.

## Remaining known issues

- **IME composition with inline substitutions** (`MarkdownTextView.swift`,
  `+Interaction.swift`). During composition the composing paragraph keeps
  positive-length substitutions (inline math/images), so display ≠ source
  there; committing near a substitution may land at a wrong offset, and the
  composing paragraph is not re-derived across paragraph boundaries. Left
  unfixed because it cannot be validated without a real input method and a
  blind change risks regressing CJK input.

## Audit coverage

Second-pass sweeps beyond the reported findings: remaining
`uniqueKeysWithValues` sites (one, safe by dedup invariant), width-blind
terminator walks, and href scheme emission (HTML exporter now allowlisted).
