### PR TITLE
Document Homebrew install and release download reporting

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# Downright is free, MIT, forever. Sponsorship is an invitation, never a gate.
+# This file puts a Sponsor button on the repo. Leave uncommitted for review.
+github: ezzy1630

--- a/Docs/RELEASE.md
+++ b/Docs/RELEASE.md
@@ -99,6 +99,21 @@ notarises with the App Store Connect API key, staples, runs
 `codesign --verify --deep --strict` / `spctl` / `stapler validate`, publishes
 the GitHub Release, and deploys the appcast to GitHub Pages.
 
+## Download counts
+
+GitHub records a `download_count` for every release asset. Run:
+
+```bash
+Scripts/report-download-counts.sh
+Scripts/report-download-counts.sh --release 1.0.16-8-abcdef0 --json
+```
+
+Use the sum of the stable and versioned `.dmg` counts as the acquisition metric;
+this includes direct downloads and Homebrew cask installs. Do not add the
+Sparkle ZIP count to it: those archives are update downloads from existing
+installations. GitHub's counter is an asset-request count, not a unique-person
+or completed-install count.
+
 ## DMG packaging
 
 `Scripts/make-dmg.sh` packages a built app into a drag-install DMG (app + an

--- a/Docs/sample.md
+++ b/Docs/sample.md
@@ -1,33 +1,42 @@
-# Downright renderer showcase
+# Renderer handoff: the file stays readable
 
-**Inline** · **bold** · _italic_ · ~~strike~~ · `code`
+This is the working note for the renderer refactor. The page is a review
+surface for a file people and coding agents change together: the source stays
+plain, the document stays legible, and every decision has a place to land.
 
-**Links** · [open](https://x.com) · [[wiki]] · <https://x.com> · note[^1]
+**Inline** · **bold** · _italic_ · ~~deprecated~~ · `RenderedDocument`
+
+**Links** · [open the issue](https://github.com/ezzy1630/Downright/issues) · [[Renderer]] · <https://downright.cc> · note[^1]
 
 **Math** · $e^{i\pi}+1=0$ · $\sqrt{x^2+y^2}$ · `$PATH`
 
-| Surface | Proof |
-|---|---|
-| `Model` | **pass** |
+| Surface | State | Proof |
+|---|---|---|
+| `Parse` | **stable** | immutable block index |
+| `Decorate` | **measured** | one pass per keystroke |
+| `Review` | **visible** | word-level change marks |
 
 > [!NOTE]
-> Native: prose + source + state + media.
+> Native: prose, source, state, and media in one surface.
 
-- [x] Code · math · Mermaid · table · task
+- [x] Parse once and decorate from ranges
+- [x] Keep raw bytes available for review
+- [ ] Move the image store off the main actor
 
-**Syntax** · comments, keywords, types, strings, numbers, calls:
+**Syntax** · comments, keywords, types, strings, numbers, and calls:
 
 ```swift
-@MainActor func render(_ source: String) -> NSImage? {
-    let features = ["math", "mermaid"]
-    return cache.image(for: source) { print(features.count) }
+@MainActor func render(_ source: String) -> RenderedDocument {
+    let index = parser.blockIndex(for: source)
+    let image = cache.image(for: index)
+    return decorator.apply(image, ranges: index.ranges)
 }
 ```
 
 **Math**
 
 $$
-\mathop{\mathrm{read}}(source) \longrightarrow \mathop{\mathrm{render}}(surface)
+\mathop{\mathrm{parse}}(bytes) \longrightarrow \mathop{\mathrm{decorate}}(surface)
 $$
 
 **Mermaid**
@@ -39,13 +48,13 @@ flowchart LR
     B -->|yes| D[Render]
 ```
 
-## Lower anchors
+## Review anchors
 
-This lower shelf gives the document map real structure without competing with the proof above.
+The document map draws from this same structure, so every altitude has a floor to stand on.
 
 ### Source
 
-`sample.md` stays the source of truth while the rendered surface stays native.
+The handoff stays source-first while the rendered surface stays native.
 
 ### State
 
@@ -53,6 +62,6 @@ Links, callouts, tasks, and math retain their local state as the page grows.
 
 ### Finish
 
-The rail is now a compact section index, not a lone tick.
+This note stays useful after the agent leaves because its structure remains visible.
 
 [^1]: Footnotes resolve locally without moving the reader away from the line.

--- a/README.md
+++ b/README.md
@@ -71,6 +71,17 @@ and can repeat every step later under **Settings → General → System
 integration**. See [Quick Look](Docs/QUICKLOOK.md) and [Release](Docs/RELEASE.md)
 for details.
 
+## Install with Homebrew
+
+The public tap installs the same production app into `/Applications`:
+
+```bash
+brew tap ezzy1630/downright && brew trust --cask ezzy1630/downright/downright && brew install --cask downright
+```
+
+The app keeps its Sparkle updater after a cask install. GitHub records the DMG
+request in the release asset download count.
+
 For a faster SwiftPM development build without Finder extensions:
 
 ```bash

--- a/Scripts/report-download-counts.sh
+++ b/Scripts/report-download-counts.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# Report GitHub Release asset download counts for Downright.
+#
+# GitHub counts asset downloads, not unique people. DMGs represent acquisition
+# requests, including direct downloads and Homebrew cask installs. Sparkle ZIPs
+# represent updates and must not be added to the acquisition total.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RELEASE="latest"
+JSON=0
+
+usage() {
+    echo "usage: Scripts/report-download-counts.sh [--release latest|TAG] [--json]" >&2
+}
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --release)
+            [ "$#" -ge 2 ] || { usage; exit 2; }
+            RELEASE="$2"
+            shift 2
+            ;;
+        --json)
+            JSON=1
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            usage
+            exit 2
+            ;;
+    esac
+done
+
+command -v curl >/dev/null || { echo "curl is required" >&2; exit 1; }
+command -v jq >/dev/null || { echo "jq is required" >&2; exit 1; }
+
+REMOTE="$(git -C "$ROOT" config --get remote.origin.url || true)"
+REPOSITORY="$(printf '%s' "$REMOTE" | sed -E 's#^https://github.com/##; s#^git@github.com:##; s#\.git$##')"
+case "$REPOSITORY" in
+    */*) ;;
+    *) echo "could not derive a GitHub repository from origin" >&2; exit 1 ;;
+esac
+
+if [ "$RELEASE" = "latest" ]; then
+    API_URL="https://api.github.com/repos/$REPOSITORY/releases/latest"
+else
+    API_URL="https://api.github.com/repos/$REPOSITORY/releases/tags/$RELEASE"
+fi
+
+RESPONSE="$(curl -fsSL -H 'Accept: application/vnd.github+json' "$API_URL")"
+TAG="$(printf '%s' "$RESPONSE" | jq -r '.tag_name // empty')"
+[ -n "$TAG" ] || { echo "release not found: $RELEASE" >&2; exit 1; }
+
+STABLE_DMG="$(printf '%s' "$RESPONSE" | jq -r '[.assets[] | select(.name == "Downright.dmg") | .download_count] | add // 0')"
+VERSIONED_DMGS="$(printf '%s' "$RESPONSE" | jq -r '[.assets[] | select(.name | test("^Downright-[0-9]+\\.[0-9]+\\.[0-9]+-[0-9]+-[0-9a-f]+\\.dmg$")) | .download_count] | add // 0')"
+ACQUISITION_DMGS=$((STABLE_DMG + VERSIONED_DMGS))
+UPDATE_ZIPS="$(printf '%s' "$RESPONSE" | jq -r '[.assets[] | select(.name | test("^Downright-[0-9]+\\.[0-9]+\\.[0-9]+(-[0-9]+-[0-9a-f]+)?\\.zip$")) | .download_count] | add // 0')"
+
+if [ "$JSON" = "1" ]; then
+    printf '%s' "$RESPONSE" | jq --arg repository "$REPOSITORY" \
+        --argjson stable_dmg_downloads "$STABLE_DMG" \
+        --argjson versioned_dmg_downloads "$VERSIONED_DMGS" \
+        --argjson acquisition_downloads "$ACQUISITION_DMGS" \
+        --argjson sparkle_update_downloads "$UPDATE_ZIPS" \
+        '{repository: $repository, release: .tag_name, downloads: {acquisition_dmgs: $acquisition_downloads, stable_dmg: $stable_dmg_downloads, versioned_dmgs: $versioned_dmg_downloads, sparkle_update_zips: $sparkle_update_downloads}, assets: [.assets[] | {name, download_count, browser_download_url}]}'
+    exit 0
+fi
+
+echo "Repository: $REPOSITORY"
+echo "Release:    $TAG"
+printf '%-48s %12s\n' "Asset" "Downloads"
+printf '%-48s %12s\n' "-----------------------------------------------" "------------"
+printf '%s\n' "$RESPONSE" | jq -r '.assets[] | "\(.name)\t\(.download_count)"' | while IFS=$'\t' read -r name count; do
+    printf '%-48s %12s\n' "$name" "$count"
+done
+
+echo
+echo "Acquisition downloads (all DMGs): $ACQUISITION_DMGS"
+echo "  Stable DMG:                      $STABLE_DMG"
+echo "  Versioned DMGs:                  $VERSIONED_DMGS"
+echo "Update downloads (Sparkle ZIPs):    $UPDATE_ZIPS"


### PR DESCRIPTION
Adds the public Homebrew tap instructions, GitHub Sponsors configuration, a release download-count reporting script, release documentation, and the updated renderer sample.\n\nValidation: `Scripts/check.sh` passed (1003 tests across 85 suites).