### PR TITLE
Codex/release installers

### DIFF
--- a/Docs/RELEASE.md
+++ b/Docs/RELEASE.md
@@ -106,7 +106,7 @@ launcher:
 
 ```bash
 curl -fsSL https://downright.cc/install | bash
-npx --yes @ezzy/downright-installer
+npx --yes downright-installer
 ```
 
 Both commands install the latest signed DMG into `/Applications`, verify the

--- a/Docs/RELEASE.md
+++ b/Docs/RELEASE.md
@@ -99,6 +99,25 @@ notarises with the App Store Connect API key, staples, runs
 `codesign --verify --deep --strict` / `spctl` / `stapler validate`, publishes
 the GitHub Release, and deploys the appcast to GitHub Pages.
 
+## One-line release installers
+
+The production website serves the same release installer used by the npm
+launcher:
+
+```bash
+curl -fsSL https://downright.cc/install | bash
+npx --yes @ezzy/downright-installer
+```
+
+Both commands install the latest signed DMG into `/Applications`, verify the
+published DMG checksum and mounted app signature, register the Finder
+integrations, and leave Sparkle updates enabled. The npm launcher requires
+Node.js 18 or newer; the curl installer has no Node.js dependency.
+
+Each successful invocation downloads `Downright.dmg`, so GitHub records it in
+the stable DMG asset count. The installer itself is not a separate unique-user
+metric; GitHub counts asset requests, not completed installs or people.
+
 ## Download counts
 
 GitHub records a `download_count` for every release asset. Run:

--- a/README.md
+++ b/README.md
@@ -82,6 +82,26 @@ brew tap ezzy1630/downright && brew trust --cask ezzy1630/downright/downright &&
 The app keeps its Sparkle updater after a cask install. GitHub records the DMG
 request in the release asset download count.
 
+## Install with curl or npm
+
+The simplest install command downloads the latest signed release, verifies its
+published checksum and app signature, installs it into `/Applications`,
+registers the Finder integrations, and links `down` and `md` when possible:
+
+```bash
+curl -fsSL https://downright.cc/install | bash
+```
+
+If Node.js 18 or newer is already installed, the npm launcher runs that same
+first-party installer:
+
+```bash
+npx --yes @ezzy/downright-installer
+```
+
+Both paths leave Sparkle updates enabled in the installed app. The curl path
+needs no Node.js; the npm path is macOS-only and requires Node.js 18+.
+
 For a faster SwiftPM development build without Finder extensions:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ If Node.js 18 or newer is already installed, the npm launcher runs that same
 first-party installer:
 
 ```bash
-npx --yes @ezzy/downright-installer
+npx --yes downright-installer
 ```
 
 Both paths leave Sparkle updates enabled in the installed app. The curl path

--- a/Scripts/install-release.sh
+++ b/Scripts/install-release.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# Install the latest signed Downright release from GitHub.
+#
+# This is the remote installer used by https://downright.cc/install and by the
+# npm launcher. It deliberately downloads the stable DMG and its published
+# checksum, then verifies the mounted app before replacing an existing copy.
+set -euo pipefail
+
+RELEASE_BASE_URL="${DOWNRIGHT_RELEASE_BASE_URL:-https://github.com/ezzy1630/Downright/releases/latest/download}"
+APP_DEST="${DOWNRIGHT_APP_DEST:-/Applications/Downright.app}"
+BIN_DEST="${DOWNRIGHT_BIN_DIR:-$HOME/.local/bin}"
+TEMP_ROOT="${TMPDIR:-/tmp}"
+WORK_DIR="$(mktemp -d "$TEMP_ROOT/downright-release-install.XXXXXX")"
+MOUNT_DIR="$WORK_DIR/mount"
+DMG_PATH="$WORK_DIR/Downright.dmg"
+CHECKSUM_PATH="$WORK_DIR/Downright.dmg.sha256"
+STAGED_APP="$WORK_DIR/Downright.app"
+BACKUP_APP="$WORK_DIR/previous.app"
+DEVICE=""
+
+log() {
+    printf '==> %s\n' "$*"
+}
+
+fail() {
+    printf 'error: %s\n' "$*" >&2
+    exit 1
+}
+
+cleanup() {
+    local status=$?
+
+    trap - EXIT INT TERM
+    if [ -n "$DEVICE" ]; then
+        hdiutil detach "$DEVICE" -force >/dev/null 2>&1 || true
+    fi
+    rm -rf "$WORK_DIR"
+    exit "$status"
+}
+
+trap cleanup EXIT
+trap 'exit 130' INT TERM
+
+[ "$(uname -s)" = "Darwin" ] || fail "this installer only supports macOS"
+
+for command_name in curl shasum hdiutil diskutil ditto codesign awk; do
+    command -v "$command_name" >/dev/null 2>&1 || fail "required command not found: $command_name"
+done
+
+DEST_PARENT="$(dirname "$APP_DEST")"
+[ -d "$DEST_PARENT" ] || fail "application directory does not exist: $DEST_PARENT"
+
+if pgrep -f "^${APP_DEST}/Contents/MacOS/Downright$" >/dev/null 2>&1; then
+    fail "Downright is running; close it and run the installer again"
+fi
+
+mkdir -p "$MOUNT_DIR"
+log "Downloading the latest Downright release"
+curl -fsSL --retry 3 --retry-delay 1 "$RELEASE_BASE_URL/Downright.dmg" -o "$DMG_PATH"
+curl -fsSL --retry 3 --retry-delay 1 "$RELEASE_BASE_URL/Downright.dmg.sha256" -o "$CHECKSUM_PATH"
+
+EXPECTED_SHA="$(awk 'NF { print tolower($1); exit }' "$CHECKSUM_PATH")"
+ACTUAL_SHA="$(shasum -a 256 "$DMG_PATH" | awk '{ print tolower($1) }')"
+[ "${#EXPECTED_SHA}" -eq 64 ] || fail "release checksum file is malformed"
+[ "$ACTUAL_SHA" = "$EXPECTED_SHA" ] || fail "DMG checksum mismatch"
+log "DMG checksum verified"
+
+ATTACH_OUTPUT="$(diskutil image attach --mountOptions nobrowse --readOnly --mountPoint "$MOUNT_DIR" "$DMG_PATH")"
+DEVICE="$(printf '%s\n' "$ATTACH_OUTPUT" | awk '$1 ~ /^\/dev\/disk/ { print $1; exit }')"
+[ -n "$DEVICE" ] || fail "could not determine mounted disk"
+
+SOURCE_APP="$MOUNT_DIR/Downright.app"
+[ -d "$SOURCE_APP" ] || fail "release DMG does not contain Downright.app"
+codesign --verify --deep --strict "$SOURCE_APP" >/dev/null
+log "Application signature verified"
+
+ditto "$SOURCE_APP" "$STAGED_APP"
+codesign --verify --deep --strict "$STAGED_APP" >/dev/null
+
+move_into_app_parent() {
+    if [ -w "$DEST_PARENT" ]; then
+        mv "$@"
+    else
+        sudo mv "$@"
+    fi
+}
+
+if [ -e "$APP_DEST" ]; then
+    log "Replacing $APP_DEST"
+    move_into_app_parent "$APP_DEST" "$BACKUP_APP"
+fi
+
+if ! move_into_app_parent "$STAGED_APP" "$APP_DEST"; then
+    if [ -e "$BACKUP_APP" ]; then
+        move_into_app_parent "$BACKUP_APP" "$APP_DEST" || true
+    fi
+    fail "could not install the application in $APP_DEST"
+fi
+
+if [ -e "$BACKUP_APP" ]; then
+    if [ -w "$WORK_DIR" ]; then
+        rm -rf "$BACKUP_APP"
+    else
+        sudo rm -rf "$BACKUP_APP"
+    fi
+fi
+
+codesign --verify --deep --strict "$APP_DEST" >/dev/null
+
+if [ "${DOWNRIGHT_SKIP_SYSTEM_INTEGRATION:-0}" != "1" ]; then
+    LSREGISTER="/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister"
+    [ -x "$LSREGISTER" ] && "$LSREGISTER" -f "$APP_DEST" >/dev/null 2>&1 || true
+
+    if command -v pluginkit >/dev/null 2>&1; then
+        for extension in DownrightQL.appex DownrightThumb.appex; do
+            if [ -d "$APP_DEST/Contents/PlugIns/$extension" ]; then
+                pluginkit -a "$APP_DEST/Contents/PlugIns/$extension" >/dev/null 2>&1 || true
+            fi
+        done
+        pluginkit -e use -i com.ezzy.downright.quicklook >/dev/null 2>&1 || true
+        pluginkit -e use -i com.ezzy.downright.thumbnail >/dev/null 2>&1 || true
+    fi
+
+    if command -v qlmanage >/dev/null 2>&1; then
+        qlmanage -r >/dev/null 2>&1 || true
+        qlmanage -r cache >/dev/null 2>&1 || true
+    fi
+fi
+
+if [ -x "$APP_DEST/Contents/MacOS/down" ]; then
+    link_cli() {
+        local name="$1"
+        local destination="$BIN_DEST/$name"
+        if [ -e "$destination" ] && [ ! -L "$destination" ]; then
+            printf 'warning: leaving existing non-symlink CLI at %s\n' "$destination" >&2
+            return 0
+        fi
+        ln -sfn "$APP_DEST/Contents/MacOS/down" "$destination"
+    }
+
+    if mkdir -p "$BIN_DEST" && link_cli down && link_cli md; then
+        log "CLI linked in $BIN_DEST"
+    else
+        printf 'warning: could not link the CLI in %s\n' "$BIN_DEST" >&2
+    fi
+fi
+
+VERSION="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$APP_DEST/Contents/Info.plist" 2>/dev/null || printf 'latest')"
+log "Installed Downright $VERSION in $APP_DEST"
+printf 'Sparkle updates remain enabled in the installed app.\n'

--- a/npm/downright-installer/README.md
+++ b/npm/downright-installer/README.md
@@ -1,0 +1,15 @@
+# @ezzy/downright-installer
+
+Install the signed Downright macOS app into `/Applications`:
+
+```bash
+npx --yes @ezzy/downright-installer
+```
+
+The launcher fetches the first-party installer at `https://downright.cc/install`.
+That installer downloads the latest GitHub release DMG, verifies its published
+SHA-256 checksum and code signature, installs the app, registers Quick Look,
+and links the `down` and `md` CLI commands in `~/.local/bin` when possible.
+
+Downright keeps its built-in Sparkle updater after installation. The installer
+is macOS-only and requires Node.js 18 or newer.

--- a/npm/downright-installer/README.md
+++ b/npm/downright-installer/README.md
@@ -1,9 +1,9 @@
-# @ezzy/downright-installer
+# downright-installer
 
 Install the signed Downright macOS app into `/Applications`:
 
 ```bash
-npx --yes @ezzy/downright-installer
+npx --yes downright-installer
 ```
 
 The launcher fetches the first-party installer at `https://downright.cc/install`.

--- a/npm/downright-installer/bin/downright-install.mjs
+++ b/npm/downright-installer/bin/downright-install.mjs
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+
+const installerURL = process.env.DOWNRIGHT_INSTALLER_URL ?? "https://downright.cc/install";
+
+if (process.platform !== "darwin") {
+  console.error("Downright is currently available through this installer on macOS only.");
+  process.exit(1);
+}
+
+try {
+  const response = await fetch(installerURL, {
+    headers: { Accept: "text/plain" },
+    redirect: "follow",
+  });
+
+  if (!response.ok) {
+    throw new Error(`installer endpoint returned HTTP ${response.status}`);
+  }
+
+  const script = await response.text();
+  if (!script.startsWith("#!/usr/bin/env bash") || !script.includes("DMG checksum verified")) {
+    throw new Error("installer endpoint did not return the expected Downright installer");
+  }
+
+  const result = spawnSync("/bin/bash", ["-s", "downright-release-installer"], {
+    env: process.env,
+    input: script,
+    stdio: ["pipe", "inherit", "inherit"],
+  });
+
+  if (result.error) throw result.error;
+  process.exit(result.status ?? 1);
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`Downright installer failed: ${message}`);
+  process.exit(1);
+}

--- a/npm/downright-installer/package.json
+++ b/npm/downright-installer/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@ezzy/downright-installer",
+  "version": "0.1.0",
+  "description": "Install the signed Downright macOS app from its latest release",
+  "type": "module",
+  "bin": {
+    "downright-install": "bin/downright-install.mjs"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "files": [
+    "bin",
+    "README.md"
+  ],
+  "license": "MIT",
+  "homepage": "https://downright.cc/",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ezzy1630/Downright.git",
+    "directory": "npm/downright-installer"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/npm/downright-installer/package.json
+++ b/npm/downright-installer/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "@ezzy/downright-installer",
-  "version": "0.1.0",
+  "name": "downright-installer",
+  "version": "0.1.1",
   "description": "Install the signed Downright macOS app from its latest release",
   "type": "module",
   "bin": {
-    "downright-install": "bin/downright-install.mjs"
+    "downright-installer": "bin/downright-install.mjs"
   },
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
## What this changes

<!-- One paragraph. What was wrong or missing, and what you did about it. -->

## Why this way

<!-- Only if the approach is not obvious. Alternatives you rejected and why. -->

## Checks

- [ ] `Scripts/check.sh` passes. Bare `swift test` runs zero tests here and
      exits 0 — never trust it (`Docs/STATUS.md`).
- [ ] New behaviour has a test, or the reason it cannot have one is in the
      description.
- [ ] No new compiler warnings.
- [ ] `CHANGELOG.md` updated under `## [Unreleased]` if this is user-visible.

## If it touches the render or storage path

- [ ] Round trips stay byte-identical — the text storage still holds the file's
      exact bytes and decoration mutates no characters.
- [ ] `swift run -c release drbench` is still inside the budgets in
      `Docs/PERFORMANCE.md`. Typing p95 under 8 ms is the P0 gate.
