### PR TITLE
Keep every install path on the rolling update channel

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: true
+blank_issues_enabled: false
 contact_links:
   - name: Security vulnerability
     url: https://github.com/ezzy1630/Downright/security/advisories/new

--- a/.github/ISSUE_TEMPLATE/rendering_bug.yml
+++ b/.github/ISSUE_TEMPLATE/rendering_bug.yml
@@ -1,0 +1,63 @@
+name: Rendering or external-change bug
+description: A Markdown document renders incorrectly or an external rewrite is handled incorrectly.
+labels: [bug, rendering]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please remove private content. A minimal five-line document is more
+        useful than a full confidential README. For file corruption or a
+        non-byte-identical round trip, say so first.
+
+  - type: textarea
+    id: document
+    attributes:
+      label: Minimal Markdown
+      description: The smallest document that reproduces the problem.
+      render: markdown
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected and actual result
+      description: What should render or happen, and what happened instead.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Surface
+      options:
+        - Document view
+        - Split view
+        - Source Focus
+        - Quick Look
+        - Finder thumbnail
+        - External-write review
+        - down CLI
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Downright version or commit
+    validations:
+      required: true
+
+  - type: input
+    id: system
+    attributes:
+      label: macOS version and chip
+      placeholder: "macOS 15.3, M2"
+    validations:
+      required: true
+
+  - type: textarea
+    id: external_process
+    attributes:
+      label: External process, if relevant
+      description: What changed the file, and whether local edits were dirty.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,11 @@
 name: Release
 
-# Every push to `main` triggers the full production pipeline: gates → tests →
+# Every push to `main` triggers the rolling production pipeline: gates → tests →
 # signed, notarized, stapled universal build → Sparkle-signed appcast → GitHub
-# Release → GitHub Pages deployment. All secrets live in the `release`
-# environment. The workflow gives each commit a unique build identity so
-# Sparkle can order updates without requiring a manual version-tag push.
+# Release → GitHub Pages deployment. Feature-branch pushes are covered by CI;
+# a merge or push to `main` is the release event. All secrets live in the
+# `release` environment, and the newest verified build becomes the download
+# and updater channel.
 
 on:
   push:
@@ -65,9 +66,8 @@ jobs:
             exit 1
           fi
           SHORT_SHA="${GITHUB_SHA:0:12}"
-          # TAG is used in human-facing asset filenames. RELEASE_TAG is the
-          # unique GitHub release tag; it is intentionally not a source version
-          # tag, because every main commit is a release.
+          # TAG is used in immutable asset filenames. RELEASE_TAG identifies
+          # this rolling main-channel build without moving an existing tag.
           TAG="${MARKETING_VERSION}-${BUILD}-${SHORT_SHA}"
           RELEASE_TAG="auto-${GITHUB_SHA}"
           echo "MARKETING_VERSION=$MARKETING_VERSION" >> "$GITHUB_ENV"
@@ -395,7 +395,7 @@ jobs:
             > "artifacts/Downright-$TAG-dSYMs.zip.sha256"
           # Auto-assemble release notes from the commits since the previous
           # generated or manually tagged release.
-          PREV_TAG="$(git tag --sort=-creatordate | grep -E '^(auto-[0-9a-f]{40}|v[0-9]+\.[0-9]+\.[0-9]+)$' | head -1 || true)"
+          PREV_TAG="$(git tag --sort=-creatordate | grep -E '^(auto-[0-9a-f]{40}|v[0-9]+\.[0-9]+\.[0-9]+)$' | grep -v "^${RELEASE_TAG}$" | head -1 || true)"
           if [ -n "$PREV_TAG" ]; then
             COMMITS="$(git log --oneline --no-merges "${PREV_TAG}..HEAD")"
           else
@@ -506,6 +506,7 @@ jobs:
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           tag_name: ${{ steps.release_identity.outputs.release_tag }}
+          name: Downright ${{ env.MARKETING_VERSION }} (build ${{ env.BUILD }})
           target_commitish: ${{ github.sha }}
           make_latest: true
           files: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,61 @@
+# Contributing to Downright
+
+Downright is a native macOS Markdown reader and editor. Contributions should
+keep the product file-first, source-preserving, offline by default, and useful
+for ordinary Markdown files that people and coding agents change together.
+
+## Before opening an issue
+
+- Search existing issues and read [Docs/STATUS.md](Docs/STATUS.md).
+- For rendering problems, reduce the document to the smallest Markdown that
+  still fails.
+- For external-write problems, describe the original file, the process that
+  changed it, and whether there were dirty local edits.
+- Never attach private documents, credentials, or unredacted crash logs.
+
+Security vulnerabilities belong in [SECURITY.md](SECURITY.md), not a public
+issue.
+
+## Build and test
+
+Requirements: macOS 14 or newer, Xcode or the Command Line Tools, Swift 6
+toolchain, and `xcodegen` for the complete app bundle.
+
+Use the repository gate rather than bare `swift test`:
+
+```bash
+Scripts/check.sh
+```
+
+For the complete installed app and Quick Look extensions:
+
+```bash
+Scripts/bundle-xcode-app.sh
+APP_SOURCE=.build-xcode/Build/Products/Release/Downright.app Scripts/install.sh
+Scripts/check-app.sh
+```
+
+Changes to rendering or storage should include a focused regression test and
+must preserve the source file's exact bytes. Changes to external-write review
+should cover clean and dirty local-edit states.
+
+## Pull requests
+
+Describe the user-visible problem, the invariant the change preserves, and the
+checks you ran. Keep commits focused. Update `CHANGELOG.md` under
+`[Unreleased]` for user-visible behavior, and include screenshots or a short
+recording only when the change is visual and the document itself cannot prove
+it.
+
+Do not add a sync service, vault database, plugin runtime, remote model
+dependency, or chat panel without first changing the product contract and
+architecture documentation.
+
+## Releases
+
+The production channel is rolling and main-driven. Update
+`Config/version.env` only when the marketing version changes, run the full
+check, and merge or push the reviewed commit to `main`. Every push to `main`
+gets a monotonically increasing build number, a signed/notarized/stapled
+artifact, a GitHub Release, and a signed Sparkle appcast. Feature branches run
+CI but do not publish customer-facing builds. See [Docs/RELEASE.md](Docs/RELEASE.md).

--- a/Docs/RELEASE.md
+++ b/Docs/RELEASE.md
@@ -94,8 +94,10 @@ notarise and staple the DMG. Credentials come from either a stored
 `notarytool` keychain profile or the App Store Connect API key variables.
 
 The GitHub Actions pipeline (`.github/workflows/release.yml`) is the supported
-path: it signs every nested executable individually (no `codesign --deep`),
-notarises with the App Store Connect API key, staples, runs
+path for the rolling production channel: every push to `main` publishes the
+reviewed commit as the newest customer-facing build. Feature-branch pushes run
+CI but do not publish. The pipeline signs every nested executable
+individually (no `codesign --deep`), notarises with the App Store Connect API key, staples, runs
 `codesign --verify --deep --strict` / `spctl` / `stapler validate`, publishes
 the GitHub Release, and deploys the appcast to GitHub Pages.
 
@@ -109,13 +111,13 @@ curl -fsSL https://downright.cc/install | bash
 npx --yes downright-installer
 ```
 
-Both commands install the latest signed DMG into `/Applications`, verify the
+Both commands install the latest signed main-channel DMG into `/Applications`, verify the
 published DMG checksum and mounted app signature, register the Finder
 integrations, and leave Sparkle updates enabled. The npm launcher requires
 Node.js 18 or newer; the curl installer has no Node.js dependency.
 
 Each successful invocation downloads `Downright.dmg`, so GitHub records it in
-the stable DMG asset count. The installer itself is not a separate unique-user
+the rolling DMG asset count. The installer itself is not a separate unique-user
 metric; GitHub counts asset requests, not completed installs or people.
 
 ## Download counts
@@ -127,7 +129,7 @@ Scripts/report-download-counts.sh
 Scripts/report-download-counts.sh --release 1.0.16-8-abcdef0 --json
 ```
 
-Use the sum of the stable and versioned `.dmg` counts as the acquisition metric;
+Use the sum of the rolling and versioned `.dmg` counts as the acquisition metric;
 this includes direct downloads and Homebrew cask installs. Do not add the
 Sparkle ZIP count to it: those archives are update downloads from existing
 installations. GitHub's counter is an asset-request count, not a unique-person
@@ -191,12 +193,18 @@ non-placeholder public key.
 1. Bump `Config/version.env`; run `Scripts/sync-versions.sh fix`.
 2. `Scripts/check.sh` — all suites, version gates, and the Sparkle link-scope
    check pass.
-3. Push a `vX.Y.Z` SemVer tag pointing into `main`. `release.yml` takes over:
+3. Merge or push the reviewed commit to `main`. `release.yml` takes over:
    gates → tests → universal signed/notarized build → zip + DMG → appcast →
    GitHub Release → GitHub Pages. If Pages deployment fails after the Release
    is public, the previous appcast stays active and re-running the deployment
    is safe.
 4. Set Pages → Source: **GitHub Actions** in the repository settings (one-time).
+
+Each main-channel build receives an immutable `auto-<full-commit-sha>` release
+tag and unique versioned asset names. The `latest` GitHub Release alias and
+`Downright.dmg` asset move to the newest verified main build; named `vX.Y.Z`
+tags remain available for milestone references but are not required for routine
+publishing.
 
 For a release that must not go through CI, the manual path is
 `bundle-xcode-app.sh` → `sign-and-notarize.sh` → `make-dmg.sh` above; run

--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@
 
 <p align="center"><strong>macOS 14+ · Swift 6 · Native AppKit · MIT</strong></p>
 
+<p align="center">
+  <a href="https://github.com/ezzy1630/Downright/actions/workflows/ci.yml"><img src="https://github.com/ezzy1630/Downright/actions/workflows/ci.yml/badge.svg" alt="CI status"></a>
+  <a href="https://github.com/ezzy1630/Downright/releases"><img src="https://img.shields.io/github/v/release/ezzy1630/Downright?display_name=tag&sort=semver" alt="Latest release"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-307afe" alt="MIT license"></a>
+</p>
+
+<p align="center"><a href="https://downright.cc/download/">Download the signed macOS release</a> · <a href="https://downright.cc/">downright.cc</a> · <a href="https://github.com/ezzy1630/homebrew-downright">Public Homebrew tap</a></p>
+
 ---
 
 <p align="center">
@@ -82,9 +90,12 @@ brew tap ezzy1630/downright && brew trust --cask ezzy1630/downright/downright &&
 The app keeps its Sparkle updater after a cask install. GitHub records the DMG
 request in the release asset download count.
 
+This is the developer tap. The tap-free `brew install --cask downright`
+command is not advertised until an official Homebrew Cask is accepted.
+
 ## Install with curl or npm
 
-The simplest install command downloads the latest signed release, verifies its
+The simplest install command downloads the latest signed main-channel build, verifies its
 published checksum and app signature, installs it into `/Applications`,
 registers the Finder integrations, and links `down` and `md` when possible:
 
@@ -99,7 +110,9 @@ first-party installer:
 npx --yes downright-installer
 ```
 
-Both paths leave Sparkle updates enabled in the installed app. The curl path
+Both paths leave Sparkle updates enabled in the installed app. Every subsequent
+verified push to `main` becomes the next Sparkle update; feature-branch pushes
+never reach users. The curl path
 needs no Node.js; the npm path is macOS-only and requires Node.js 18+.
 
 For a faster SwiftPM development build without Finder extensions:
@@ -204,7 +217,7 @@ See [Privacy](Docs/PRIVACY.md).
 
 ## Project status
 
-The canonical source version is **1.0.0**; current polish is tracked under
+The current rolling release is tracked in [GitHub Releases](https://github.com/ezzy1630/Downright/releases); current polish is tracked under
 [Unreleased](CHANGELOG.md). The repository contains the app, CLI, Quick Look,
 updater, signing, notarization, DMG, and release automation. See [Status](Docs/STATUS.md)
 for known gaps and implementation notes.


### PR DESCRIPTION
Align the public contract with the rolling main-channel release pipeline.

- document that every reviewed push to main publishes the signed/notarized/stapled Sparkle build
- keep the latest DMG alias and immutable auto-SHA releases explicit
- add rendering issue intake and remove blank issue drift
- give the release action a readable release name

Validation: Scripts/check.sh (1003 tests / 85 suites), git diff --check, Ruby cask syntax.