### PR TITLE
Refine app surfaces and rolling DMG release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,16 @@ every release; Sparkle orders updates by it.
 - The start window is 600pt tall rather than 576 to fit the two-line rows, and
   the no-recents placeholder is now derived from the height a full list
   occupies instead of a fixed 150pt that was already 100pt short of it.
+- The welcome window's two entry actions now share one readable control well;
+  drag-and-drop feedback appears only while a supported file is over the
+  window, and an update failure collapses to a quiet, discoverable warning
+  instead of competing with the primary actions.
+- Update failures now lead with a clear "your files are safe" message, fit the
+  panel to the shorter failure state, and keep technical details behind an
+  explicit disclosure.
+- The rolling DMG now carries a Finder-aligned install window with a hand-drawn
+  background and drag-to-Applications arrangement, while retaining a valid
+  headless packaging path for CI.
 
 - The start window's **Take the Tour** button now retires: immediately once the
   tour has been opened, and after three launches regardless. It was permanent,

--- a/Docs/RELEASE.md
+++ b/Docs/RELEASE.md
@@ -145,7 +145,12 @@ Scripts/make-dmg.sh                       # finds the latest built app
 OUT_DIR=~/Desktop Scripts/make-dmg.sh /path/to/Downright.app
 ```
 
-It writes `dist/Downright-<MARKETING_VERSION>.dmg` and verifies the image.
+It writes `dist/Downright-<MARKETING_VERSION>.dmg` and verifies the image. The
+Finder window uses the hand-drawn `Scripts/dmg-background.svg`, rasterised at
+the exact 720×450 Finder canvas so the cute lettering and drag gesture stay
+aligned with the icons, and persists the icon positions plus `/Applications`
+alias when Finder is available. Set `DMG_LAYOUT=0` for a headless/default-window
+package; the image remains a valid drag installer either way.
 Run it on the *signed and notarised* app. Gatekeeper trusts the ticket stapled
 inside the app, and the release workflow additionally notarises and staples the
 DMG itself so users can run straight from the image. The DMG is a convenience

--- a/Scripts/dmg-background.svg
+++ b/Scripts/dmg-background.svg
@@ -1,0 +1,50 @@
+<!--
+  This is the artwork for the Finder canvas, not a marketing banner. Finder
+  renders the DMG background at its logical window size, so keep the source at
+  the same 720x450 size as the window configured by make-dmg.sh.
+-->
+<svg xmlns="http://www.w3.org/2000/svg" width="720" height="450" viewBox="0 0 720 450">
+  <defs>
+    <radialGradient id="paper-wash" cx="84%" cy="10%" r="82%">
+      <stop offset="0" stop-color="#dceaff" stop-opacity="0.72"/>
+      <stop offset="0.52" stop-color="#f8f5ef" stop-opacity="0.18"/>
+      <stop offset="1" stop-color="#f8f5ef" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="underline" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#307afe" stop-opacity="0.34"/>
+      <stop offset="0.52" stop-color="#307afe" stop-opacity="0.92"/>
+      <stop offset="1" stop-color="#307afe" stop-opacity="0.34"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="720" height="450" fill="#f8f5ef"/>
+  <rect width="720" height="450" fill="url(#paper-wash)"/>
+
+  <g
+    fill="#292522"
+    font-family="Noteworthy, 'Chalkboard SE', 'Marker Felt', 'Bradley Hand', 'Comic Sans MS', sans-serif"
+    text-anchor="middle">
+    <text x="360" y="76" font-size="30" font-weight="600" transform="rotate(-2 360 76)">one tiny move</text>
+    <text x="360" y="184" font-size="35" font-weight="600" transform="rotate(-4 360 184)">drag Downright to</text>
+    <text x="360" y="211" fill="#766e66" font-size="14" font-weight="500" transform="rotate(-2 360 211)">Applications</text>
+  </g>
+
+  <!-- Hand-drawn underline and double arrow echo the original gesture. -->
+  <path d="M236 96C300 107 420 107 484 95" fill="none" stroke="url(#underline)" stroke-linecap="round" stroke-width="3"/>
+  <path d="M240 102C304 111 416 111 480 100" fill="none" stroke="#307afe" stroke-linecap="round" stroke-width="1.2" opacity="0.27"/>
+
+  <g fill="none" stroke="#307afe" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M244 276C293 212 402 198 520 257" stroke-width="3.8" opacity="0.92"/>
+    <path d="M246 287C302 224 407 211 515 265" stroke-width="1.6" opacity="0.32"/>
+    <path d="M498 245l25 13-23 8" stroke-width="3.8"/>
+    <circle cx="244" cy="274" r="4" fill="#307afe" stroke="none" opacity="0.76"/>
+  </g>
+
+  <g
+    fill="#766e66"
+    font-family="Noteworthy, 'Chalkboard SE', 'Marker Felt', 'Bradley Hand', 'Comic Sans MS', sans-serif"
+    text-anchor="middle">
+    <text x="360" y="373" font-size="13" font-weight="500" letter-spacing="0.8">then open Downright once</text>
+    <text x="360" y="395" fill="#9b9288" font-size="11" letter-spacing="0.55">updates happen automatically</text>
+  </g>
+</svg>

--- a/Scripts/make-dmg.sh
+++ b/Scripts/make-dmg.sh
@@ -12,7 +12,8 @@
 #
 # Env:
 #   OUT_DIR   where the DMG lands (default: $ROOT/dist)
-#   VOLNAME   volume name override (default: "Downright $MARKETING_VERSION")
+#   VOLNAME   volume name override (default: "Install Downright")
+#   DMG_LAYOUT set to 0 to skip the optional Finder window arrangement
 #
 # Produces OUT_DIR/Downright-<MARKETING_VERSION>.dmg containing the app and an
 # /Applications symlink, so double-click → drag to Applications.  Run this on
@@ -41,28 +42,111 @@ APP="$(cd "$(dirname "$APP")" && pwd)/$(basename "$APP")"
 [ -d "$APP" ] || { echo "not an app bundle: $APP" >&2; exit 1; }
 
 OUT_DIR="${OUT_DIR:-$ROOT/dist}"
-VOLNAME="${VOLNAME:-Downright $MARKETING_VERSION}"
+VOLNAME="${VOLNAME:-Install Downright}"
 DMG="$OUT_DIR/Downright-$MARKETING_VERSION.dmg"
+RW_DMG="$OUT_DIR/.Downright-$MARKETING_VERSION-rw.dmg"
+DMG_LAYOUT="${DMG_LAYOUT:-1}"
+DMG_BACKGROUND="${DMG_BACKGROUND:-$ROOT/Scripts/dmg-background.svg}"
 
 echo "==> Packaging $APP"
 echo "    -> $DMG"
 
 STAGING="$(mktemp -d)"
-trap 'rm -rf "$STAGING"' EXIT
+trap 'rm -rf "$STAGING"; rm -f "$RW_DMG"' EXIT
 
 cp -R "$APP" "$STAGING/"
 ln -s /Applications "$STAGING/Applications"
 
+# Finder uses this hidden folder for the install note. Keep the source as SVG
+# so the hand-drawn artwork stays reviewable, then rasterise it at the exact
+# logical Finder window size. Finder maps a larger bitmap to the wrong canvas
+# instead of treating it as a Retina asset, which crops the instructions.
+if [ -n "$DMG_BACKGROUND" ]; then
+    command -v sips >/dev/null 2>&1 || {
+        echo "sips is required to rasterise the DMG background" >&2
+        exit 1
+    }
+    [ -f "$DMG_BACKGROUND" ] || {
+        echo "DMG background not found: $DMG_BACKGROUND" >&2
+        exit 1
+    }
+    mkdir -p "$STAGING/.background"
+    SOURCE_PNG="$STAGING/.background/dmg-background-source.png"
+    sips -s format png "$DMG_BACKGROUND" --out "$SOURCE_PNG" >/dev/null
+    sips -z 450 720 "$SOURCE_PNG" --out "$STAGING/.background/dmg-background.png" >/dev/null
+    rm -f "$SOURCE_PNG"
+    WIDTH="$(sips -g pixelWidth "$STAGING/.background/dmg-background.png" | awk '/pixelWidth/ { print $2 }')"
+    HEIGHT="$(sips -g pixelHeight "$STAGING/.background/dmg-background.png" | awk '/pixelHeight/ { print $2 }')"
+    [ "$WIDTH" = "720" ] && [ "$HEIGHT" = "450" ] || {
+        echo "DMG background must be 720x450, got ${WIDTH:-unknown}x${HEIGHT:-unknown}" >&2
+        exit 1
+    }
+    # Finder can be configured to show dotfiles. The artwork is implementation
+    # detail, not a third item in the install window, so keep the folder hidden
+    # even for those users.
+    chflags hidden "$STAGING/.background" 2>/dev/null || true
+fi
+
 mkdir -p "$OUT_DIR"
-# UDZO (zlib) is the safe default: readable by every macOS since 10.6.
-# --volname must match the final volume name; macOS renames the image to the
-# volname on attach, so a mismatch looks like a bug.
+# Build a writable image first so Finder can persist its icon-view metadata.
+# Compress only after the layout has been written; applying AppleScript to a
+# final UDZO image can appear to succeed while silently losing the .DS_Store.
 hdiutil create \
     -volname "$VOLNAME" \
     -srcfolder "$STAGING" \
     -ov \
+    -format UDRW \
+    "$RW_DMG" >/dev/null
+
+# Best-effort Finder polish. The image remains valid when Finder is not
+# available (for example on a headless CI runner), but local release builds
+# get a predictable window, icon scale, and drag-to-Applications layout.
+if [ "$DMG_LAYOUT" = "1" ] && [ -f "$STAGING/.background/dmg-background.png" ] && command -v osascript >/dev/null 2>&1; then
+    MOUNT_OUTPUT="$(hdiutil attach -nobrowse -noautoopen "$RW_DMG" 2>/dev/null || true)"
+    MOUNT_POINT="$(printf '%s\n' "$MOUNT_OUTPUT" | sed -n 's#.*\(/Volumes/.*\)$#\1#p' | head -n 1)"
+    if [ -n "$MOUNT_POINT" ]; then
+        # hdiutil's source-folder copy does not reliably carry UF_HIDDEN into
+        # the mounted filesystem. Apply it here, where Finder reads it.
+        chflags hidden "$MOUNT_POINT/.background" 2>/dev/null || true
+        if ! osascript - "$MOUNT_POINT" <<'APPLESCRIPT'
+on run argv
+    set volumeRoot to POSIX file (item 1 of argv) as alias
+    tell application "Finder"
+        tell disk (name of volumeRoot)
+            open
+            set theWindow to container window
+            set current view of theWindow to icon view
+            set toolbar visible of theWindow to false
+            set statusbar visible of theWindow to false
+            set bounds of theWindow to {120, 100, 840, 550}
+            set viewOptions to icon view options of theWindow
+            set arrangement of viewOptions to not arranged
+            set icon size of viewOptions to 112
+            set text size of viewOptions to 13
+            set background picture of viewOptions to file ".background:dmg-background.png"
+            set position of item "Downright.app" of theWindow to {190, 240}
+            set position of item "Applications" of theWindow to {530, 240}
+            delay 0.5
+            close
+            open
+        end tell
+    end tell
+end run
+APPLESCRIPT
+        then
+            echo "warning: Finder layout could not be applied; using the default DMG window" >&2
+        fi
+        hdiutil detach "$MOUNT_POINT" -quiet >/dev/null 2>&1 || hdiutil detach "$MOUNT_POINT" -force -quiet >/dev/null 2>&1 || true
+    else
+        echo "warning: DMG mounted without a discoverable volume path; using the default window" >&2
+    fi
+fi
+
+# UDZO (zlib) is the safe default: readable by every macOS since 10.6.
+hdiutil convert "$RW_DMG" \
     -format UDZO \
-    "$DMG" >/dev/null
+    -ov \
+    -o "$DMG" >/dev/null
 
 echo "==> Verifying image"
 hdiutil verify "$DMG" >/dev/null

--- a/Sources/DownrightApp/App/DocumentWindowController.swift
+++ b/Sources/DownrightApp/App/DocumentWindowController.swift
@@ -534,6 +534,9 @@ final class DocumentWindowController: NSWindowController {
         // the leading lane where the outline it expands into belongs.
         primaryContainer.leadingAccessory = densityGutterView
         breadcrumbView.delegate = self
+        breadcrumbView.onZoomChange = { [weak self] level in
+            self?.setSharedZoom(level)
+        }
         breadcrumbView.styleSheet = activeStyleSheet
         densityGutterView.delegate = self
         densityGutterView.styleSheet = activeStyleSheet

--- a/Sources/DownrightApp/App/StartWindowController.swift
+++ b/Sources/DownrightApp/App/StartWindowController.swift
@@ -21,7 +21,12 @@ enum StartLayout {
     static let bottomInset: CGFloat = 36
     static let sectionSpacing: CGFloat = 20
     static let contentWidth: CGFloat = 592
-    static let buttonHeight: CGFloat = 38
+    static let buttonHeight: CGFloat = 40
+    // Both peer actions share a generous well: 196pt fits the longest title,
+    // icon, and keycap without truncation while keeping the action group
+    // visually compact inside the 592pt welcome column.
+    static let actionButtonWidth: CGFloat = 196
+    static let actionSpacing: CGFloat = 10
     static let rowHeight: CGFloat = 46
     static let rowSpacing: CGFloat = 2
     static let cornerRadius: CGFloat = 7
@@ -175,7 +180,10 @@ private final class StartView: NSView {
     private let hero: StartHeroView
     private let dropOverlay = StartDropOverlay()
     private let contentStack = NSStackView()
-    private let updatePill = UpdateStatusPill()
+    // The start surface has enough context to make an icon-only warning
+    // discoverable through its tooltip and accessibility label. Keep the
+    // titlebar warning from becoming a second hero CTA.
+    private let updatePill = UpdateStatusPill(presentation: .compactWarning)
     private var sheet: StyleSheet
     private var didPlayEntrance = false
     private var keyObserver: NSObjectProtocol?
@@ -261,7 +269,9 @@ private final class StartView: NSView {
         ])
 
         // The drop affordance is a non-interactive accent frame that appears
-        // while a file is dragged anywhere over the window.
+        // while a file is dragged anywhere over the window. There is no idle
+        // helper copy: the window only spends visual attention on dropping
+        // when a drop is actually possible.
         dropOverlay.translatesAutoresizingMaskIntoConstraints = false
         dropOverlay.isHidden = true
         addSubview(dropOverlay)
@@ -278,8 +288,11 @@ private final class StartView: NSView {
         updatePill.translatesAutoresizingMaskIntoConstraints = false
         addSubview(updatePill)
         NSLayoutConstraint.activate([
-            updatePill.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -14),
-            updatePill.topAnchor.constraint(equalTo: topAnchor, constant: 7),
+            // Give the warning its own titlebar lane: the extra inset keeps
+            // the pill off the window edge and visually separates it from the
+            // traffic-light/titlebar chrome at small capture sizes.
+            updatePill.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -18),
+            updatePill.topAnchor.constraint(equalTo: topAnchor, constant: 10),
         ])
     }
 
@@ -421,7 +434,6 @@ private final class StartView: NSView {
     override func draggingEntered(_ sender: NSDraggingInfo) -> NSDragOperation {
         let urls = droppedURLs(from: sender.draggingPasteboard)
         let ok = !urls.isEmpty
-        hero.setDropActive(ok)
         dropOverlay.setActive(ok)
         return ok ? .copy : []
     }
@@ -431,18 +443,15 @@ private final class StartView: NSView {
     }
 
     override func draggingExited(_ sender: NSDraggingInfo?) {
-        hero.setDropActive(false)
         dropOverlay.setActive(false)
     }
 
     override func draggingEnded(_ sender: NSDraggingInfo) {
-        hero.setDropActive(false)
         dropOverlay.setActive(false)
     }
 
     override func performDragOperation(_ sender: NSDraggingInfo) -> Bool {
         let urls = droppedURLs(from: sender.draggingPasteboard)
-        hero.setDropActive(false)
         dropOverlay.setActive(false)
         guard !urls.isEmpty else { return false }
         guard owner?.beginHandoff() == true else { return false }
@@ -465,9 +474,9 @@ private final class StartView: NSView {
     }
 }
 
-/// A quiet accent frame that acknowledges a drag before the drop.  It draws
-/// nothing on its own state — just a filled border that appears and fades,
-/// and it never takes a hit so the content underneath stays interactive.
+/// A quiet accent frame that acknowledges a drag before the drop. It is hidden
+/// at rest and becomes a dashed border only while a supported file is over the
+/// window, so the welcome surface never carries a permanent instruction line.
 private final class StartDropOverlay: NSView {
     private var isActive = false
     private var sheet = StartTheme.makeSheet()
@@ -476,7 +485,6 @@ private final class StartDropOverlay: NSView {
         super.init(frame: frameRect)
         wantsLayer = true
         layer?.cornerRadius = 14
-        layer?.borderWidth = 1.5
         layer?.opacity = 0
         apply(sheet: sheet)
     }
@@ -488,17 +496,21 @@ private final class StartDropOverlay: NSView {
     func apply(sheet: StyleSheet) {
         self.sheet = sheet
         let contrast = sheet.increaseContrast
-        layer?.borderColor = sheet.accent.cgColor
         layer?.backgroundColor = sheet.accent
-            .withAlphaComponent(contrast ? 0.12 : 0.07).cgColor
+            .withAlphaComponent(contrast ? 0.055 : 0.025).cgColor
+        needsDisplay = true
     }
 
     func setActive(_ active: Bool) {
         guard active != isActive else { return }
         isActive = active
         isHidden = false
+        needsDisplay = true
         let reduce = sheet.reduceMotion
-        let apply = { self.layer?.opacity = active ? 1 : 0 }
+        let apply = {
+            self.layer?.opacity = active ? 1 : 0
+            self.needsDisplay = true
+        }
         if reduce {
             apply()
             if !active { isHidden = true }
@@ -511,6 +523,21 @@ private final class StartDropOverlay: NSView {
                 }
             }
         }
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        guard isActive, let context = NSGraphicsContext.current?.cgContext else { return }
+        let rect = bounds.insetBy(dx: 1.5, dy: 1.5)
+        let path = CGPath(roundedRect: rect, cornerWidth: 13, cornerHeight: 13, transform: nil)
+        context.saveGState()
+        context.addPath(path)
+        context.setLineWidth(1.5)
+        context.setLineDash(phase: 0, lengths: [7, 5])
+        context.setStrokeColor(sheet.accent.withAlphaComponent(
+            sheet.increaseContrast ? 0.8 : 0.52
+        ).cgColor)
+        context.strokePath()
+        context.restoreGState()
     }
 }
 
@@ -528,10 +555,9 @@ private final class StartCanvasView: NSView {
 
 // MARK: - Hero
 
-/// The welcome column: brand, one clear sentence, two entry paths, and a quiet
-/// drop hint.  The primary action is the only filled accent shape in the hero
-/// (Von Restorff: one strong cue per screen), and the hint under it is passive
-/// copy, not a third button (Hick: two choices at the decision point).
+/// The welcome column: brand, one clear sentence, and two equally weighted
+/// entry paths. Dragging is communicated by the window-level overlay, not by a
+/// permanent instruction that competes with the actual actions.
 private final class StartHeroView: NSView {
     let openButton: StartActionButton
     private let newButton: StartActionButton
@@ -541,16 +567,11 @@ private final class StartHeroView: NSView {
     private let brandLabel = NSTextField(labelWithString: "")
     private let titleLabel = NSTextField(labelWithString: "")
     private let subtitleLabel = NSTextField(wrappingLabelWithString: "")
-    private let dropHint = NSTextField(labelWithString: "")
-    private let dropIcon = NSImageView()
     private let brand: BrandMarkView
     private let guide: StartGuideOffer
     /// Whether this window has anything of the user's own to show.
     private let isReturning: Bool
     private var sheet: StyleSheet
-    private var isDropActive = false
-    private static let idleDropHint = "You can also drop a file anywhere"
-
     init(
         owner: StartWindowController, guide: StartGuideOffer,
         isReturning: Bool, sheet: StyleSheet
@@ -560,12 +581,12 @@ private final class StartHeroView: NSView {
         let guideLeads = guide == .primary
         openButton = StartActionButton(
             title: "Open File", icon: "folder", command: .open,
-            kind: guideLeads ? .secondary : .primary, sheet: sheet, target: owner,
+            kind: .secondary, sheet: sheet, target: owner,
             action: #selector(StartWindowController.openPanel(_:))
         )
         newButton = StartActionButton(
             title: "New Document", icon: "doc", command: .newDocument,
-            kind: .secondary, sheet: sheet, target: owner,
+            kind: guideLeads ? .secondary : .primary, sheet: sheet, target: owner,
             action: #selector(StartWindowController.newDocument(_:))
         )
         guideButton = guide == .unavailable ? nil : StartActionButton(
@@ -573,7 +594,7 @@ private final class StartHeroView: NSView {
             kind: guideLeads ? .primary : .secondary, sheet: sheet, target: owner,
             action: #selector(StartWindowController.openGuide(_:))
         )
-        leadButton = (guideLeads ? guideButton : nil) ?? openButton
+        leadButton = (guideLeads ? guideButton : nil) ?? newButton
         brand = BrandMarkView()
         self.sheet = sheet
         super.init(frame: .zero)
@@ -598,50 +619,35 @@ private final class StartHeroView: NSView {
         subtitleLabel.preferredMaxLayoutWidth = StartLayout.contentWidth
         configurePassiveLabel(subtitleLabel)
 
-        // Peer entry paths, with exactly one carrying primary emphasis.
+        // Peer entry paths, with exactly one carrying primary emphasis. On a
+        // normal launch creation is the strongest next step; a first-launch
+        // tour temporarily takes that role because it is the onboarding path.
         let actions = NSStackView(views: [openButton, newButton] + (guideButton.map { [$0] } ?? []))
         actions.orientation = .horizontal
         actions.alignment = .centerY
-        actions.spacing = 8
+        actions.spacing = StartLayout.actionSpacing
         actions.distribution = .fill
 
-        dropIcon.translatesAutoresizingMaskIntoConstraints = false
-        dropIcon.image = NSImage(systemSymbolName: "arrow.down.doc", accessibilityDescription: nil)
-        dropIcon.symbolConfiguration = NSImage.SymbolConfiguration(pointSize: 11, weight: .medium)
-        dropIcon.setContentHuggingPriority(.required, for: .horizontal)
-
-        dropHint.translatesAutoresizingMaskIntoConstraints = false
-        dropHint.font = .systemFont(ofSize: 12, weight: .regular)
-        dropHint.alignment = .left
-        configurePassiveLabel(dropHint)
-
-        let dropSlot = NSStackView(views: [dropIcon, dropHint])
-        dropSlot.orientation = .horizontal
-        dropSlot.alignment = .centerY
-        dropSlot.spacing = 6
-        dropSlot.translatesAutoresizingMaskIntoConstraints = false
-
-        let stack = NSStackView(views: [brandRow, titleLabel, subtitleLabel, actions, dropSlot])
+        let stack = NSStackView(views: [brandRow, titleLabel, subtitleLabel, actions])
         stack.translatesAutoresizingMaskIntoConstraints = false
         stack.orientation = .vertical
         stack.alignment = .leading
         stack.spacing = 0
         addSubview(stack)
 
-        // Each action sizes to its own content.  Matching the two widths was
-        // worse than ragged: the shorter "Open File" absorbed the difference as
-        // a wide label-to-shortcut gap, and the longer "New Document" fit with
-        // zero headroom, so any measurement drift clipped it mid-word — the
-        // same failure the old fixed width had.
+        // The two file actions are peer entry points, so they share a control
+        // well. The shortcut keycap remains right-aligned inside each well,
+        // which keeps the labels readable without turning one action into the
+        // visually dominant choice just because its title is longer.
         var constraints: [NSLayoutConstraint] = [
             brand.widthAnchor.constraint(equalToConstant: 38),
             brand.heightAnchor.constraint(equalToConstant: 38),
             openButton.heightAnchor.constraint(equalToConstant: StartLayout.buttonHeight),
             newButton.heightAnchor.constraint(equalToConstant: StartLayout.buttonHeight),
+            openButton.widthAnchor.constraint(equalToConstant: StartLayout.actionButtonWidth),
+            newButton.widthAnchor.constraint(equalToConstant: StartLayout.actionButtonWidth),
             titleLabel.widthAnchor.constraint(lessThanOrEqualToConstant: StartLayout.contentWidth),
             subtitleLabel.widthAnchor.constraint(lessThanOrEqualToConstant: StartLayout.contentWidth),
-            dropSlot.widthAnchor.constraint(equalTo: stack.widthAnchor),
-
             stack.leadingAnchor.constraint(equalTo: leadingAnchor),
             stack.trailingAnchor.constraint(equalTo: trailingAnchor),
             stack.topAnchor.constraint(equalTo: topAnchor),
@@ -654,10 +660,9 @@ private final class StartHeroView: NSView {
         }
         NSLayoutConstraint.activate(constraints)
 
-        stack.setCustomSpacing(16, after: brandRow)
+        stack.setCustomSpacing(12, after: brandRow)
         stack.setCustomSpacing(4, after: titleLabel)
-        stack.setCustomSpacing(20, after: subtitleLabel)
-        stack.setCustomSpacing(9, after: actions)
+        stack.setCustomSpacing(18, after: subtitleLabel)
 
         apply(sheet: sheet)
         setAccessibilityRole(.group)
@@ -712,26 +717,7 @@ private final class StartHeroView: NSView {
         )
         subtitleLabel.stringValue = subheadline
         subtitleLabel.textColor = sheet.textSecondary
-        dropHint.textColor = isDropActive ? sheet.accent : sheet.textSecondary
-        dropIcon.contentTintColor = isDropActive ? sheet.accent : sheet.textFaint
-        if !isDropActive { dropHint.stringValue = Self.idleDropHint }
         needsDisplay = true
-    }
-
-    func setDropActive(_ active: Bool) {
-        guard active != isDropActive else { return }
-        isDropActive = active
-        let reduceMotion = sheet.reduceMotion
-        let changes = {
-            self.dropHint.textColor = active ? self.sheet.accent : self.sheet.textSecondary
-            self.dropIcon.contentTintColor = active ? self.sheet.accent : self.sheet.textFaint
-            self.dropHint.stringValue = active ? "Release to open" : Self.idleDropHint
-        }
-        if reduceMotion {
-            changes()
-        } else {
-            Motion.run(reduceMotion: false, duration: Motion.quick, curve: .easeOut) { _ in changes() }
-        }
     }
 }
 
@@ -745,35 +731,26 @@ private func configurePassiveLabel(_ field: NSTextField) {
 
 // MARK: - Recents
 
-/// The recents list: a quiet header (label, count, clear) over equal-height
-/// rows.  Uniform row height and tight spacing make the list read as one
-/// gestalt group; the title carries the weight and the trailing detail stays
-/// faint so names are found pre-attentively.
+/// The recents list: a quiet header (label, shortcut hint) over equal-height
+/// rows. Uniform row height and tight spacing make the list read as one gestalt
+/// group; the title carries the weight, the timestamp owns a fixed trailing
+/// column, and the ordinal keycap appears only for the row under attention.
 private final class RecentDocumentsPanel: NSView {
     private weak var owner: StartWindowController?
     private let headerLabel = NSTextField(labelWithString: "Recent files")
     private let countLabel = NSTextField(labelWithString: "")
-    private let clearButton: StartTextButton
     private let divider = NSView()
     private let list = NSStackView()
     private var rowViews: [RecentDocumentButton] = []
     private var displayedRecents: [RecentDocument] = []
     private var sheet: StyleSheet
-    private var clearAction: ButtonAction?
 
     init(recents: [RecentDocument], owner: StartWindowController, sheet: StyleSheet) {
         self.owner = owner
         self.sheet = sheet
-        let clear = StartTextButton(title: "Clear")
-        self.clearButton = clear
         super.init(frame: .zero)
 
-        let action = ButtonAction { [weak owner] in owner?.onClearRecents?() }
-        clearAction = action
-        clear.target = action
-        clear.action = #selector(ButtonAction.fire(_:))
-        clear.setAccessibilityLabel("Clear recent files")
-        clear.toolTip = "Clear the recent files list"
+        menu = Self.makeContextMenu(owner: owner)
 
         // A hairline rule separates the decide phase (hero) from the continue
         // phase (recents); two kinds of work should not share one silent gap.
@@ -796,9 +773,6 @@ private final class RecentDocumentsPanel: NSView {
         header.translatesAutoresizingMaskIntoConstraints = false
         addSubview(header)
 
-        clearButton.translatesAutoresizingMaskIntoConstraints = false
-        addSubview(clearButton)
-
         list.translatesAutoresizingMaskIntoConstraints = false
         list.orientation = .vertical
         list.alignment = .width
@@ -811,12 +785,10 @@ private final class RecentDocumentsPanel: NSView {
             divider.topAnchor.constraint(equalTo: topAnchor),
             divider.heightAnchor.constraint(equalToConstant: 1),
 
-            header.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 12),
+            // Keep the section label on the same vertical grid as each file
+            // title; the document glyph lives in the small leading gutter.
+            header.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 36),
             header.topAnchor.constraint(equalTo: divider.bottomAnchor, constant: 12),
-
-            clearButton.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -4),
-            clearButton.centerYAnchor.constraint(equalTo: header.centerYAnchor),
-            clearButton.leadingAnchor.constraint(greaterThanOrEqualTo: header.trailingAnchor, constant: 12),
 
             list.leadingAnchor.constraint(equalTo: leadingAnchor),
             list.trailingAnchor.constraint(equalTo: trailingAnchor),
@@ -846,7 +818,6 @@ private final class RecentDocumentsPanel: NSView {
             .withAlphaComponent(sheet.increaseContrast ? 0.6 : 0.4).cgColor
         headerLabel.textColor = sheet.textSecondary
         countLabel.textColor = sheet.textFaint
-        clearButton.apply(sheet: sheet)
         for row in rowViews {
             row.apply(sheet: sheet)
         }
@@ -887,8 +858,6 @@ private final class RecentDocumentsPanel: NSView {
         let shown = min(recents.count, StartWindowController.recentDisplayLimit)
         countLabel.stringValue = shown > 1 ? "⌘1–\(shown)" : ""
         countLabel.isHidden = countLabel.stringValue.isEmpty
-        clearButton.isHidden = recents.isEmpty
-
         if recents.isEmpty {
             let empty = RecentEmptyState(sheet: sheet)
             empty.translatesAutoresizingMaskIntoConstraints = false
@@ -920,68 +889,18 @@ private final class RecentDocumentsPanel: NSView {
             }
         }
     }
-}
 
-/// A quiet text button (header-level Clear) with its own hover: faint at rest,
-/// a step brighter under the pointer, always a plain label — never a bezel.
-private final class StartTextButton: NSButton {
-    private var isHovered = false
-    private var sheet: StyleSheet = StartTheme.makeSheet()
-
-    init(title: String) {
-        super.init(frame: .zero)
-        self.title = title
-        isBordered = false
-        setButtonType(.momentaryChange)
-        focusRingType = .none
-        font = .systemFont(ofSize: 11.5, weight: .regular)
-        setAccessibilityRole(.button)
-        wantsLayer = true
-        addTrackingArea(NSTrackingArea(
-            rect: .zero,
-            options: [.activeInKeyWindow, .mouseEnteredAndExited, .inVisibleRect],
-            owner: self,
-            userInfo: nil
-        ))
-        apply(sheet: sheet)
-    }
-
-    required init?(coder: NSCoder) { nil }
-
-    override var intrinsicContentSize: NSSize {
-        NSSize(width: ceil(title.size(withAttributes: [.font: font ?? .systemFont(ofSize: 11.5)]).width), height: 20)
-    }
-
-    override var acceptsFirstResponder: Bool { true }
-
-    override func drawFocusRingMask() {
-        NSBezierPath(roundedRect: bounds.insetBy(dx: -3, dy: -2), xRadius: 5, yRadius: 5).fill()
-    }
-
-    override var focusRingMaskBounds: NSRect { bounds.insetBy(dx: -3, dy: -2) }
-
-    func apply(sheet: StyleSheet) {
-        self.sheet = sheet
-        attributedTitle = NSAttributedString(
-            string: title,
-            attributes: [
-                .font: NSFont.systemFont(ofSize: 11.5, weight: .regular),
-                .foregroundColor: isHovered ? sheet.textSecondary : sheet.textFaint,
-            ]
+    fileprivate static func makeContextMenu(owner: StartWindowController) -> NSMenu {
+        let menu = NSMenu()
+        let clear = NSMenuItem(
+            title: "Clear Recent Files…",
+            action: #selector(StartWindowController.clearRecents(_:)),
+            keyEquivalent: ""
         )
+        clear.target = owner
+        menu.addItem(clear)
+        return menu
     }
-
-    override func mouseEntered(with event: NSEvent) {
-        isHovered = true
-        apply(sheet: sheet)
-    }
-
-    override func mouseExited(with event: NSEvent) {
-        isHovered = false
-        apply(sheet: sheet)
-    }
-
-    override func highlight(_ flag: Bool) {}
 }
 
 private final class RecentEmptyState: NSView {
@@ -1044,7 +963,8 @@ private final class StartActionButton: NSButton {
     private let iconView = NSImageView()
     private let titleLabel: NSTextField
     private let shortcutLabel = NSTextField(labelWithString: "")
-    private var shortcutGap: NSLayoutConstraint!
+    private let contentGroup = NSStackView()
+    private var shortcutWidth: NSLayoutConstraint!
     private var isHovered = false
     private var isPressed = false
     private var sheet: StyleSheet
@@ -1083,45 +1003,55 @@ private final class StartActionButton: NSButton {
         iconView.translatesAutoresizingMaskIntoConstraints = false
         iconView.symbolConfiguration = NSImage.SymbolConfiguration(pointSize: 13, weight: .medium)
         iconView.image = NSImage(systemSymbolName: icon, accessibilityDescription: title)
-        shell.addSubview(iconView)
-
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
         titleLabel.font = .systemFont(ofSize: 13, weight: .semibold)
-        titleLabel.lineBreakMode = .byClipping
+        titleLabel.usesSingleLineMode = true
+        titleLabel.lineBreakMode = .byTruncatingTail
         configurePassiveLabel(titleLabel)
-        shell.addSubview(titleLabel)
-
         shortcutLabel.translatesAutoresizingMaskIntoConstraints = false
-        shortcutLabel.font = .monospacedDigitSystemFont(ofSize: 11, weight: .semibold)
-        shortcutLabel.lineBreakMode = .byClipping
+        shortcutLabel.font = .systemFont(ofSize: 11, weight: .semibold)
+        shortcutLabel.alignment = .center
+        shortcutLabel.usesSingleLineMode = true
+        shortcutLabel.lineBreakMode = .byTruncatingTail
+        shortcutLabel.wantsLayer = true
+        shortcutLabel.layer?.cornerRadius = 5
+        shortcutLabel.layer?.masksToBounds = true
         configurePassiveLabel(shortcutLabel)
-        shell.addSubview(shortcutLabel)
+        contentGroup.orientation = .horizontal
+        contentGroup.alignment = .centerY
+        contentGroup.spacing = 10
+        contentGroup.detachesHiddenViews = true
+        contentGroup.translatesAutoresizingMaskIntoConstraints = false
+        contentGroup.addArrangedSubview(iconView)
+        contentGroup.addArrangedSubview(titleLabel)
+        contentGroup.addArrangedSubview(shortcutLabel)
+        contentGroup.setCustomSpacing(12, after: titleLabel)
+        shell.addSubview(contentGroup)
 
-        shortcutGap = shortcutLabel.leadingAnchor.constraint(
-            greaterThanOrEqualTo: titleLabel.trailingAnchor, constant: Self.shortcutGapWidth
-        )
+        shortcutWidth = shortcutLabel.widthAnchor.constraint(greaterThanOrEqualToConstant: 30)
         NSLayoutConstraint.activate([
             shell.leadingAnchor.constraint(equalTo: leadingAnchor),
             shell.trailingAnchor.constraint(equalTo: trailingAnchor),
             shell.topAnchor.constraint(equalTo: topAnchor),
             shell.bottomAnchor.constraint(equalTo: bottomAnchor),
 
-            iconView.leadingAnchor.constraint(equalTo: shell.leadingAnchor, constant: 14),
-            iconView.centerYAnchor.constraint(equalTo: shell.centerYAnchor),
-            iconView.widthAnchor.constraint(equalToConstant: 14),
-            iconView.heightAnchor.constraint(equalToConstant: 14),
+            contentGroup.leadingAnchor.constraint(greaterThanOrEqualTo: shell.leadingAnchor, constant: 12),
+            contentGroup.trailingAnchor.constraint(lessThanOrEqualTo: shell.trailingAnchor, constant: -12),
+            contentGroup.centerXAnchor.constraint(equalTo: shell.centerXAnchor),
+            contentGroup.centerYAnchor.constraint(equalTo: shell.centerYAnchor),
 
-            titleLabel.leadingAnchor.constraint(equalTo: iconView.trailingAnchor, constant: 7),
-            titleLabel.centerYAnchor.constraint(equalTo: shell.centerYAnchor),
-
-            shortcutGap,
-            shortcutLabel.trailingAnchor.constraint(equalTo: shell.trailingAnchor, constant: -14),
-            shortcutLabel.centerYAnchor.constraint(equalTo: shell.centerYAnchor),
+            iconView.widthAnchor.constraint(equalToConstant: 16),
+            iconView.heightAnchor.constraint(equalToConstant: 16),
+            shortcutWidth,
+            // A low keycap is enough to signal the binding without becoming a
+            // second control inside the control.
+            shortcutLabel.heightAnchor.constraint(equalToConstant: 20),
         ])
 
         // The label must never be the thing that gives: a clipped "New Documen"
         // is worse than a wider button.
         titleLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
+        shortcutLabel.setContentHuggingPriority(.required, for: .horizontal)
         shortcutLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
 
         isEnabled = true
@@ -1145,9 +1075,6 @@ private final class StartActionButton: NSButton {
         updateSurface(animated: false)
     }
 
-    /// Space between the label and the shortcut when there is a shortcut.
-    private static let shortcutGapWidth: CGFloat = 12
-
     /// Re-reads the binding.  A command with no binding shows no hint and the
     /// button closes up around its label.
     func refreshShortcut() {
@@ -1156,7 +1083,7 @@ private final class StartActionButton: NSButton {
             .map(\.displayString) ?? ""
         shortcutLabel.stringValue = hint
         shortcutLabel.isHidden = hint.isEmpty
-        shortcutGap.constant = hint.isEmpty ? 0 : Self.shortcutGapWidth
+        shortcutWidth.isActive = !hint.isEmpty
         setAccessibilityHelp(hint.isEmpty ? nil : hint)
         invalidateIntrinsicContentSize()
         needsLayout = true
@@ -1171,10 +1098,10 @@ private final class StartActionButton: NSButton {
         // the under-reported intrinsic made the shell ~4pt too narrow — the
         // label-to-shortcut gap collapsed below its constant and the longer
         // label clipped.  fittingSize is what the label actually renders at.
-        let titleW = titleLabel.fittingSize.width
-        let shortW = shortcutLabel.isHidden ? 0 : shortcutLabel.fittingSize.width
-        // Trailing shortcut sits at the far edge; leave room so labels never clip.
-        return NSSize(width: ceil(14 + 14 + 7 + titleW + shortcutGap.constant + shortW + 14), height: 34)
+        // The content group is centered in the well, so intrinsic sizing is
+        // only used by the optional tour button; Open/New receive equal wells
+        // from StartHeroView.
+        return NSSize(width: ceil(contentGroup.fittingSize.width + 24), height: 34)
     }
 
     override func hitTest(_ point: NSPoint) -> NSView? {
@@ -1269,6 +1196,7 @@ private final class StartActionButton: NSButton {
         let contrast = sheet.increaseContrast
         let isFocused = window?.firstResponder === self && window?.isKeyWindow == true
         let changes = {
+            let engaged = self.isPressed || self.isHovered || isFocused
             if self.kind == .primary {
                 let accent = sheet.startWindowPrimaryAction
                 let fill: NSColor
@@ -1285,6 +1213,11 @@ private final class StartActionButton: NSButton {
                 self.titleLabel.textColor = .white
                 self.shortcutLabel.textColor = .white
                 self.iconView.contentTintColor = .white
+                self.shortcutLabel.layer?.backgroundColor = NSColor.white.withAlphaComponent(
+                    self.isPressed ? 0.18 : (engaged ? 0.12 : 0.08)
+                ).cgColor
+                self.shortcutLabel.layer?.borderWidth = engaged ? 1 : 0
+                self.shortcutLabel.layer?.borderColor = NSColor.white.withAlphaComponent(0.20).cgColor
             } else {
                 let fillAlpha: CGFloat = self.isPressed ? 0.11 : (self.isHovered ? 0.075 : 0.045)
                 self.shell.layer?.backgroundColor = sheet.text
@@ -1293,21 +1226,30 @@ private final class StartActionButton: NSButton {
                 self.shell.layer?.borderColor = (isFocused ? sheet.accent : sheet.rule)
                     .withAlphaComponent(isFocused ? 0.9 : (contrast ? 0.55 : 0.35)).cgColor
                 self.titleLabel.textColor = sheet.text
-                self.shortcutLabel.textColor = sheet.textSecondary
-                self.iconView.contentTintColor = self.isHovered ? sheet.text : sheet.textSecondary
+                self.shortcutLabel.textColor = engaged ? sheet.text : sheet.textSecondary
+                self.iconView.contentTintColor = engaged ? sheet.text : sheet.textSecondary
+                self.shortcutLabel.layer?.backgroundColor = sheet.text.withAlphaComponent(
+                    contrast
+                        ? (engaged ? 0.12 : 0.07)
+                        : (engaged ? 0.10 : 0.055)
+                ).cgColor
+                self.shortcutLabel.layer?.borderWidth = engaged ? 1 : 0
+                self.shortcutLabel.layer?.borderColor = sheet.text.withAlphaComponent(
+                    engaged ? 0.18 : 0.10
+                ).cgColor
             }
             self.shell.layer?.setAffineTransform(
                 self.isPressed
-                    ? CGAffineTransform(scaleX: 0.98, y: 0.98)
+                    ? CGAffineTransform(scaleX: 0.985, y: 0.985)
                     : self.isHovered
-                        ? CGAffineTransform(scaleX: 1.01, y: 1.01)
+                        ? CGAffineTransform(scaleX: 1.004, y: 1.004)
                         : .identity
             )
         }
         if animated {
             Motion.run(
                 reduceMotion: sheet.reduceMotion,
-                duration: Motion.quick,
+                duration: Motion.hover,
                 curve: .easeOut
             ) { _ in changes() }
         } else {
@@ -1319,9 +1261,16 @@ private final class StartActionButton: NSButton {
 // MARK: - Recent row
 
 enum RecentRowCopy {
-    private static let relativeFormatter: RelativeDateTimeFormatter = {
-        let formatter = RelativeDateTimeFormatter()
-        formatter.unitsStyle = .abbreviated
+    private static let monthDayFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = .current
+        formatter.setLocalizedDateFormatFromTemplate("MMM d")
+        return formatter
+    }()
+    private static let monthDayYearFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = .current
+        formatter.setLocalizedDateFormatFromTemplate("MMM d yyyy")
         return formatter
     }()
 
@@ -1367,7 +1316,15 @@ enum RecentRowCopy {
     }
 
     static func timestamp(for recent: RecentDocument) -> String {
-        relativeFormatter.localizedString(for: recent.lastOpened, relativeTo: Date())
+        let calendar = Calendar.current
+        if calendar.isDateInToday(recent.lastOpened) { return "Today" }
+        if calendar.isDateInYesterday(recent.lastOpened) { return "Yesterday" }
+        let now = Date()
+        let year = calendar.component(.year, from: recent.lastOpened)
+        let currentYear = calendar.component(.year, from: now)
+        return year == currentYear
+            ? monthDayFormatter.string(from: recent.lastOpened)
+            : monthDayYearFormatter.string(from: recent.lastOpened)
     }
 
     static func folder(for recent: RecentDocument) -> String {
@@ -1384,7 +1341,7 @@ enum RecentRowCopy {
     /// exists to solve.  It is skipped only when it would repeat the title
     /// back, in which case the folder is the more informative thing to say.
     static func subtitle(for recent: RecentDocument, title: String) -> String {
-        let heading = recent.firstHeading.trimmingCharacters(in: .whitespacesAndNewlines)
+        let heading = cleanedHeading(recent.firstHeading)
         let place = folder(for: recent)
         guard !heading.isEmpty, !echoes(heading, of: title) else { return place }
         // `README` in `Downright/` under the heading "Downright" would otherwise
@@ -1393,6 +1350,18 @@ enum RecentRowCopy {
         // Both, when the folder is what disambiguates two same-named documents
         // and the heading is what explains them.
         return "\(heading)  ·  \(place)"
+    }
+
+    /// A malformed editor write once persisted a partial prose prefix directly
+    /// against a capitalized heading (`ThiDownright …`). Keep that stale
+    /// metadata from leaking into the welcome surface while leaving ordinary
+    /// headings, including `This …`, untouched.
+    private static func cleanedHeading(_ rawHeading: String) -> String {
+        let heading = rawHeading.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard heading.hasPrefix("Thi"),
+              heading.dropFirst(3).first?.isUppercase == true
+        else { return heading }
+        return String(heading.dropFirst(3))
     }
 
     /// Whether the heading would just restate the title.  Compared without case
@@ -1442,11 +1411,12 @@ enum RecentRowCopy {
 private final class RecentDocumentButton: NSButton {
     let documentPath: String
     private let shell = NSView()
-    private let ordinalLabel = NSTextField(labelWithString: "")
+    private let documentIcon = NSImageView()
     private let titleLabel: NSTextField
+    private let titleRow = NSStackView()
     private let subtitleLabel: NSTextField
     private let detailLabel: NSTextField
-    private let chevron = NSImageView()
+    private let shortcutLabel = NSTextField(labelWithString: "")
     private var isHovered = false
     private var isPressed = false
     private var sheet: StyleSheet
@@ -1472,6 +1442,7 @@ private final class RecentDocumentButton: NSButton {
         setAccessibilityRole(.button)
         setAccessibilityLabel("Open \(title)")
         setAccessibilityValue("\(subtitleLabel.stringValue), \(detailLabel.stringValue)")
+        setAccessibilityHelp(ordinal <= 9 ? "Press ⌘\(ordinal) to open" : nil)
         wantsLayer = true
         toolTip = recent.path
 
@@ -1481,19 +1452,16 @@ private final class RecentDocumentButton: NSButton {
         shell.layer?.masksToBounds = true
         addSubview(shell)
 
-        // The ordinal, not a document glyph.  Six identical `doc` icons carried
-        // no information — they only said "these are files", which the names
-        // already said — and this slot instead teaches ⌘1…⌘6, which is the
-        // fastest way out of this window and the one thing about it worth
-        // learning.  The header spells the shortcut out once so the bare digit
-        // is never a riddle.
-        ordinalLabel.translatesAutoresizingMaskIntoConstraints = false
-        ordinalLabel.stringValue = ordinal <= 9 ? "\(ordinal)" : ""
-        ordinalLabel.font = .monospacedDigitSystemFont(ofSize: 11, weight: .medium)
-        ordinalLabel.alignment = .center
-        configurePassiveLabel(ordinalLabel)
-        ordinalLabel.setAccessibilityHidden(true)
-        shell.addSubview(ordinalLabel)
+        documentIcon.translatesAutoresizingMaskIntoConstraints = false
+        documentIcon.image = NSImage(
+            systemSymbolName: "doc.text",
+            accessibilityDescription: "Markdown document"
+        )
+        documentIcon.symbolConfiguration = NSImage.SymbolConfiguration(
+            pointSize: 14, weight: .regular
+        )
+        documentIcon.setAccessibilityLabel("Markdown document")
+        shell.addSubview(documentIcon)
 
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
         titleLabel.font = .systemFont(ofSize: 13, weight: .medium)
@@ -1515,19 +1483,37 @@ private final class RecentDocumentButton: NSButton {
 
         detailLabel.translatesAutoresizingMaskIntoConstraints = false
         detailLabel.font = .systemFont(ofSize: 11.5, weight: .regular)
-        detailLabel.lineBreakMode = .byClipping
+        detailLabel.alignment = .right
+        detailLabel.usesSingleLineMode = true
+        detailLabel.lineBreakMode = .byTruncatingTail
         detailLabel.maximumNumberOfLines = 1
         configurePassiveLabel(detailLabel)
         shell.addSubview(detailLabel)
 
-        chevron.translatesAutoresizingMaskIntoConstraints = false
-        chevron.image = NSImage(systemSymbolName: "chevron.right", accessibilityDescription: "Open")
-        chevron.symbolConfiguration = NSImage.SymbolConfiguration(pointSize: 10, weight: .semibold)
-        chevron.wantsLayer = true
-        chevron.layer?.opacity = 0
-        shell.addSubview(chevron)
+        shortcutLabel.translatesAutoresizingMaskIntoConstraints = false
+        shortcutLabel.stringValue = ordinal <= 9 ? "⌘\(ordinal)" : ""
+        shortcutLabel.font = .systemFont(ofSize: 11, weight: .semibold)
+        shortcutLabel.alignment = .center
+        shortcutLabel.usesSingleLineMode = true
+        shortcutLabel.lineBreakMode = .byTruncatingTail
+        shortcutLabel.wantsLayer = true
+        shortcutLabel.layer?.cornerRadius = 4
+        shortcutLabel.layer?.masksToBounds = true
+        shortcutLabel.isHidden = true
+        configurePassiveLabel(shortcutLabel)
+        shortcutLabel.setAccessibilityLabel("Keyboard shortcut \(shortcutLabel.stringValue)")
 
-        let text = NSStackView(views: [titleLabel, subtitleLabel])
+        titleRow.orientation = .horizontal
+        titleRow.alignment = .centerY
+        titleRow.spacing = 7
+        titleRow.detachesHiddenViews = true
+        titleRow.translatesAutoresizingMaskIntoConstraints = false
+        titleRow.addArrangedSubview(titleLabel)
+        titleRow.addArrangedSubview(shortcutLabel)
+
+        menu = RecentDocumentsPanel.makeContextMenu(owner: target)
+
+        let text = NSStackView(views: [titleRow, subtitleLabel])
         text.orientation = .vertical
         text.alignment = .leading
         text.spacing = 1
@@ -1540,26 +1526,28 @@ private final class RecentDocumentButton: NSButton {
             shell.topAnchor.constraint(equalTo: topAnchor),
             shell.bottomAnchor.constraint(equalTo: bottomAnchor),
 
-            ordinalLabel.leadingAnchor.constraint(equalTo: shell.leadingAnchor, constant: 10),
-            ordinalLabel.centerYAnchor.constraint(equalTo: shell.centerYAnchor),
-            ordinalLabel.widthAnchor.constraint(equalToConstant: 14),
+            documentIcon.leadingAnchor.constraint(equalTo: shell.leadingAnchor, constant: 11),
+            documentIcon.centerYAnchor.constraint(equalTo: shell.centerYAnchor),
+            documentIcon.widthAnchor.constraint(equalToConstant: 18),
+            documentIcon.heightAnchor.constraint(equalToConstant: 18),
 
-            text.leadingAnchor.constraint(equalTo: ordinalLabel.trailingAnchor, constant: 9),
+            text.leadingAnchor.constraint(equalTo: documentIcon.trailingAnchor, constant: 7),
+            text.trailingAnchor.constraint(lessThanOrEqualTo: detailLabel.leadingAnchor, constant: -16),
             text.centerYAnchor.constraint(equalTo: shell.centerYAnchor),
 
-            detailLabel.leadingAnchor.constraint(greaterThanOrEqualTo: text.trailingAnchor, constant: 16),
-            detailLabel.trailingAnchor.constraint(equalTo: chevron.leadingAnchor, constant: -8),
+            shortcutLabel.widthAnchor.constraint(greaterThanOrEqualToConstant: 30),
+            shortcutLabel.heightAnchor.constraint(equalToConstant: 22),
+            detailLabel.widthAnchor.constraint(equalToConstant: 74),
+            detailLabel.trailingAnchor.constraint(equalTo: shell.trailingAnchor, constant: -12),
             detailLabel.centerYAnchor.constraint(equalTo: shell.centerYAnchor),
-
-            chevron.trailingAnchor.constraint(equalTo: shell.trailingAnchor, constant: -12),
-            chevron.centerYAnchor.constraint(equalTo: shell.centerYAnchor),
-            chevron.widthAnchor.constraint(equalToConstant: 10),
-            chevron.heightAnchor.constraint(equalToConstant: 10),
         ])
 
         titleLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         subtitleLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        text.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         detailLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
+        shortcutLabel.setContentHuggingPriority(.required, for: .horizontal)
+        shortcutLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
 
         addTrackingArea(NSTrackingArea(
             rect: .zero,
@@ -1665,17 +1653,22 @@ private final class RecentDocumentButton: NSButton {
             self.shell.layer?.backgroundColor = fill.cgColor
             self.shell.layer?.borderWidth = isFocused ? 1.5 : 0
             self.shell.layer?.borderColor = sheet.accent.cgColor
-            // The ordinal lifts to the accent on engagement, which is what
-            // makes the shortcut register as a shortcut rather than a bullet.
-            self.ordinalLabel.textColor = engaged ? sheet.accent : sheet.textFaint
+            // The header teaches the ordinal shortcuts once. The row only
+            // reveals its own keycap when it is the target of attention, so
+            // the timestamp column remains clean at rest.
+            self.shortcutLabel.isHidden = !engaged
+            self.documentIcon.contentTintColor = engaged ? sheet.text : sheet.textSecondary
             self.titleLabel.textColor = sheet.text
-            self.subtitleLabel.textColor = engaged ? sheet.textSecondary : sheet.textFaint
+            self.subtitleLabel.textColor = engaged ? sheet.text : sheet.textSecondary
             self.detailLabel.textColor = engaged ? sheet.textSecondary : sheet.textFaint
-            self.chevron.contentTintColor = sheet.accent
-            self.chevron.layer?.opacity = engaged ? 1 : 0
-            self.chevron.layer?.setAffineTransform(
-                engaged ? .identity : CGAffineTransform(translationX: 4, y: 0)
-            )
+            self.shortcutLabel.textColor = engaged ? sheet.accent : sheet.textFaint
+            self.shortcutLabel.layer?.backgroundColor = sheet.text.withAlphaComponent(
+                engaged ? (contrast ? 0.14 : 0.12) : (contrast ? 0.10 : 0.08)
+            ).cgColor
+            self.shortcutLabel.layer?.borderWidth = 1
+            self.shortcutLabel.layer?.borderColor = sheet.text.withAlphaComponent(
+                engaged ? 0.24 : 0.16
+            ).cgColor
             self.shell.layer?.setAffineTransform(
                 self.isPressed
                     ? CGAffineTransform(scaleX: 0.992, y: 0.992)

--- a/Sources/DownrightApp/Panels/BreadcrumbView.swift
+++ b/Sources/DownrightApp/Panels/BreadcrumbView.swift
@@ -35,7 +35,15 @@ final class BreadcrumbView: NSView {
         }
     }
 
-    var zoomLevel: ZoomLevel = .everything
+    var zoomLevel: ZoomLevel = .everything {
+        didSet {
+            guard zoomLevel != oldValue else { return }
+            updateZoomButton()
+            needsLayout = true
+        }
+    }
+
+    var onZoomChange: ((ZoomLevel) -> Void)?
 
     /// Ancestor chain, root first.  Indices are into the document's headings.
     var trail: [(index: Int, title: String, level: Int)] = [] {
@@ -49,7 +57,9 @@ final class BreadcrumbView: NSView {
     }
 
     private let sectionButton = ToolbarInteractiveButton(frame: .zero)
+    private let zoomButton = ToolbarInteractiveButton(frame: .zero)
     private var sectionAction: ButtonAction?
+    private var zoomAction: ButtonAction?
     private var isCuePresented = false
 
     var isPresentedForTesting: Bool { !isHidden && isCuePresented }
@@ -100,6 +110,22 @@ final class BreadcrumbView: NSView {
         (sectionButton.cell as? NSButtonCell)?.lineBreakMode = .byTruncatingTail
         addSubview(sectionButton)
 
+        let zAction = ButtonAction { [weak self] in self?.showZoomMenu() }
+        zoomAction = zAction
+        zoomButton.feedbackInsetX = 2
+        zoomButton.feedbackInsetY = 1
+        zoomButton.feedbackCornerRadius = 4
+        zoomButton.isBordered = false
+        zoomButton.bezelStyle = .accessoryBarAction
+        zoomButton.focusRingType = .default
+        zoomButton.imagePosition = .imageLeading
+        zoomButton.imageScaling = .scaleProportionallyDown
+        zoomButton.target = zAction
+        zoomButton.action = #selector(ButtonAction.fire(_:))
+        (zoomButton.cell as? NSButtonCell)?.lineBreakMode = .byTruncatingTail
+        zoomButton.isHidden = true
+        addSubview(zoomButton)
+
         setAccessibilityRole(.group)
         setAccessibilityLabel("Current section")
         // Keep the lane in layout even when the cue itself is absent. Toggling
@@ -107,6 +133,7 @@ final class BreadcrumbView: NSView {
         isHidden = false
         alphaValue = 1
         sectionButton.alphaValue = 0
+        updateZoomButton()
         rebuild(animated: false)
     }
 
@@ -225,27 +252,104 @@ final class BreadcrumbView: NSView {
         layer.add(transition, forKey: "section-change")
     }
 
+    private func updateZoomButton() {
+        guard zoomLevel != .everything else {
+            zoomButton.isHidden = true
+            return
+        }
+        zoomButton.isHidden = false
+        let label = switch zoomLevel {
+        case .h1: "Top level"
+        case .h2: "Two levels"
+        case .headings: "Headings"
+        case .skeleton: "Skeleton"
+        case .everything: "Everything"
+        }
+        zoomButton.attributedTitle = NSAttributedString(string: "\(label)", attributes: [
+            .font: PanelFont.system(11.5, weight: .medium),
+            .foregroundColor: styleSheet.accent,
+        ])
+        zoomButton.image = NSImage(
+            systemSymbolName: "line.3.horizontal.decrease.circle.fill",
+            accessibilityDescription: "Structural Zoom"
+        )?.withSymbolConfiguration(.init(pointSize: 10, weight: .semibold))
+        zoomButton.contentTintColor = styleSheet.accent
+        zoomButton.toolTip = "Structural Zoom active (\(label)). Click to switch or restore all content."
+        zoomButton.setAccessibilityLabel("Structural zoom: \(label)")
+    }
+
     // MARK: - Layout
 
     override func layout() {
         super.layout()
-        guard let current = trail.last else { return }
-        let titleWidth = styledTitle(current.title).size().width
-        let availableWidth = min(max(44, bounds.width), Metrics.maximumButtonWidth)
-        let width = min(availableWidth, titleWidth + Metrics.horizontalContentAllowance)
-        sectionButton.frame = NSRect(
-            x: 0,
-            y: (bounds.height - Metrics.buttonHeight) / 2,
-            width: max(44, width),
-            height: Metrics.buttonHeight
-        )
+        if let current = trail.last {
+            let titleWidth = styledTitle(current.title).size().width
+            let availableWidth = min(max(44, bounds.width), Metrics.maximumButtonWidth)
+            let width = min(availableWidth, titleWidth + Metrics.horizontalContentAllowance)
+            sectionButton.frame = NSRect(
+                x: 0,
+                y: (bounds.height - Metrics.buttonHeight) / 2,
+                width: max(44, width),
+                height: Metrics.buttonHeight
+            )
+        }
+        if !zoomButton.isHidden {
+            let zoomTextWidth = (zoomButton.attributedTitle.string as NSString).size(withAttributes: [
+                .font: PanelFont.system(11.5, weight: .medium)
+            ]).width + 26
+            let zoomX = isCuePresented && !sectionButton.isHidden
+                ? sectionButton.frame.maxX + 8
+                : 0
+            zoomButton.frame = NSRect(
+                x: zoomX,
+                y: (bounds.height - Metrics.buttonHeight) / 2,
+                width: max(40, zoomTextWidth),
+                height: Metrics.buttonHeight
+            )
+        }
         discardCursorRects()
         window?.invalidateCursorRects(for: self)
     }
 
     override func resetCursorRects() {
-        guard isCuePresented, !sectionButton.isHidden else { return }
-        addCursorRect(sectionButton.frame, cursor: .pointingHand)
+        if isCuePresented, !sectionButton.isHidden {
+            addCursorRect(sectionButton.frame, cursor: .pointingHand)
+        }
+        if !zoomButton.isHidden {
+            addCursorRect(zoomButton.frame, cursor: .pointingHand)
+        }
+    }
+
+    private func showZoomMenu() {
+        let menu = NSMenu()
+        for level in ZoomLevel.allCases {
+            let name: String = switch level {
+            case .h1: "Top Level (H1)"
+            case .h2: "Two Levels (H1–H2)"
+            case .headings: "All Headings"
+            case .skeleton: "Skeleton (Headings, First Sentences, Artifacts)"
+            case .everything: "Everything (Full Document)"
+            }
+            let item = NSMenuItem(
+                title: "Level \(level.rawValue) — \(name)",
+                action: #selector(selectZoomItem(_:)),
+                keyEquivalent: ""
+            )
+            item.target = self
+            item.representedObject = level
+            item.state = level == zoomLevel ? .on : .off
+            menu.addItem(item)
+        }
+        menu.popUp(
+            positioning: nil,
+            at: NSPoint(x: zoomButton.frame.minX, y: zoomButton.frame.minY),
+            in: self
+        )
+    }
+
+    @objc private func selectZoomItem(_ sender: NSMenuItem) {
+        guard let level = sender.representedObject as? ZoomLevel else { return }
+        onZoomChange?(level)
     }
 
     private func showPathMenu() {

--- a/Sources/DownrightApp/Panels/CommandPaletteView.swift
+++ b/Sources/DownrightApp/Panels/CommandPaletteView.swift
@@ -36,6 +36,7 @@ final class CommandPaletteView: NSView, PanelSurface {
     private var model: CommandPaletteModel
     private let recentStore: CommandPaletteRecentStore
     private var keyMonitor: Any?
+    private var actions: [ButtonAction] = []
 
     convenience init() {
         self.init(styleSheet: .current, recentStore: UserDefaultsCommandPaletteRecentStore())
@@ -98,6 +99,48 @@ final class CommandPaletteView: NSView, PanelSurface {
         searchField.translatesAutoresizingMaskIntoConstraints = false
         addSubview(searchField)
 
+        let filterChips: [(title: String, prefix: String)] = [
+            ("All", ""),
+            ("Commands", "> "),
+            ("Headings", "# "),
+            ("Symbols", "@ "),
+            ("Tasks", "task: "),
+            ("Files", "file: ")
+        ]
+        let filterStack = NSStackView()
+        filterStack.orientation = .horizontal
+        filterStack.spacing = 6
+        filterStack.alignment = .centerY
+        filterStack.translatesAutoresizingMaskIntoConstraints = false
+
+        for chip in filterChips {
+            let action = ButtonAction { [weak self] in
+                guard let self else { return }
+                self.searchField.stringValue = chip.prefix
+                self.model.updateQuery(chip.prefix)
+                self.reloadResults()
+                self.window?.makeFirstResponder(self.searchField)
+                if let editor = self.searchField.currentEditor() {
+                    editor.selectedRange = NSRange(location: chip.prefix.count, length: 0)
+                }
+            }
+            actions.append(action)
+            let btn = ToolbarInteractiveButton(frame: .zero)
+            btn.attributedTitle = NSAttributedString(string: chip.title, attributes: [
+                .font: PanelFont.system(11, weight: .medium),
+                .foregroundColor: styleSheet.textSecondary,
+            ])
+            btn.feedbackInsetX = 4
+            btn.feedbackInsetY = 2
+            btn.feedbackCornerRadius = 4
+            btn.isBordered = false
+            btn.bezelStyle = .accessoryBarAction
+            btn.target = action
+            btn.action = #selector(ButtonAction.fire(_:))
+            filterStack.addArrangedSubview(btn)
+        }
+        addSubview(filterStack)
+
         let column = NSTableColumn(identifier: NSUserInterfaceItemIdentifier("command"))
         tableView.addTableColumn(column)
         tableView.headerView = nil
@@ -144,9 +187,13 @@ final class CommandPaletteView: NSView, PanelSurface {
             searchField.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16),
             searchField.topAnchor.constraint(equalTo: topAnchor, constant: 14),
             searchField.heightAnchor.constraint(equalToConstant: 32),
+            filterStack.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
+            filterStack.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor, constant: -16),
+            filterStack.topAnchor.constraint(equalTo: searchField.bottomAnchor, constant: 6),
+            filterStack.heightAnchor.constraint(equalToConstant: 20),
             scrollView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 8),
             scrollView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -8),
-            scrollView.topAnchor.constraint(equalTo: searchField.bottomAnchor, constant: 10),
+            scrollView.topAnchor.constraint(equalTo: filterStack.bottomAnchor, constant: 6),
             scrollView.bottomAnchor.constraint(equalTo: hintLabel.topAnchor, constant: -8),
             prefixLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
             prefixLabel.centerYAnchor.constraint(equalTo: hintLabel.centerYAnchor),
@@ -272,7 +319,7 @@ extension CommandPaletteView: NSTableViewDataSource, NSTableViewDelegate {
         let identifier = NSUserInterfaceItemIdentifier("commandPaletteRow")
         let cell = tableView.makeView(withIdentifier: identifier, owner: self) as? CommandPaletteRowView
             ?? CommandPaletteRowView(identifier: identifier)
-        cell.configure(result, styleSheet: styleSheet)
+        cell.configure(result, query: searchField.stringValue, styleSheet: styleSheet)
         return cell
     }
 
@@ -325,9 +372,30 @@ private final class CommandPaletteRowView: NSTableCellView {
 
     required init?(coder: NSCoder) { fatalError("init(coder:) is not used") }
 
-    func configure(_ result: QuickOpenResult, styleSheet: StyleSheet) {
-        titleLabel.stringValue = result.title
-        titleLabel.textColor = styleSheet.text
+    func configure(_ result: QuickOpenResult, query: String, styleSheet: StyleSheet) {
+        let cleanQuery = query.trimmingCharacters(in: .whitespacesAndNewlines)
+            .replacingOccurrences(of: ">", with: "")
+            .replacingOccurrences(of: "@", with: "")
+            .replacingOccurrences(of: "#", with: "")
+            .replacingOccurrences(of: "task:", with: "")
+            .replacingOccurrences(of: "file:", with: "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        if !cleanQuery.isEmpty,
+           let match = FuzzyMatcher.match(needle: cleanQuery, in: result.title) {
+            let attr = NSMutableAttributedString(string: result.title, attributes: [
+                .font: PanelFont.rowEmphasised,
+                .foregroundColor: styleSheet.text,
+            ])
+            for idx in match.positions {
+                if idx < attr.length {
+                    attr.addAttribute(.foregroundColor, value: styleSheet.accent, range: NSRange(location: idx, length: 1))
+                }
+            }
+            titleLabel.attributedStringValue = attr
+        } else {
+            titleLabel.stringValue = result.title
+            titleLabel.textColor = styleSheet.text
+        }
         metadataLabel.stringValue = result.subtitle.isEmpty ? result.kind.rawValue.capitalized : result.subtitle
         metadataLabel.textColor = styleSheet.textFaint
         toolTip = result.subtitle.isEmpty ? result.title : "\(result.title)\n\(result.subtitle)"

--- a/Sources/DownrightApp/Panels/LightboxWindow.swift
+++ b/Sources/DownrightApp/Panels/LightboxWindow.swift
@@ -186,6 +186,16 @@ private final class LightboxContentView: NSView {
         zoom(by: 1 + event.magnification, about: convert(event.locationInWindow, from: nil))
     }
 
+    override func smartMagnify(with event: NSEvent) {
+        let anchor = convert(event.locationInWindow, from: nil)
+        if abs(scale - fitScale) < 0.001 {
+            let targetScale = fitScale < 1 ? CGFloat(1.0) : CGFloat(2.0)
+            zoom(by: targetScale / max(0.01, scale), about: anchor)
+        } else {
+            resetZoom()
+        }
+    }
+
     override func mouseDown(with event: NSEvent) { didDrag = false }
 
     override func mouseDragged(with event: NSEvent) {
@@ -226,6 +236,18 @@ private final class LightboxContentView: NSView {
         case "0": resetZoom()
         case "1":
             setZoom(scale: 1, offset: .zero)
+        case "left":
+            offset.width += 40
+            needsDisplay = true
+        case "right":
+            offset.width -= 40
+            needsDisplay = true
+        case "up":
+            offset.height -= 40
+            needsDisplay = true
+        case "down":
+            offset.height += 40
+            needsDisplay = true
         default: super.keyDown(with: event)
         }
     }

--- a/Sources/DownrightApp/Panels/TableEditorView.swift
+++ b/Sources/DownrightApp/Panels/TableEditorView.swift
@@ -448,8 +448,20 @@ final class TableEditorView: NSView, PanelSurface, NSTableViewDataSource, NSTabl
         let nextRow: Int
         let targetColumn: Int
         if nextColumn >= data.columnCount {
-            nextRow = min(values.count - 1, row + 1)
-            targetColumn = 0
+            if row + 1 >= values.count {
+                addRow(nil)
+                DispatchQueue.main.async { [weak self] in
+                    guard let self else { return }
+                    self.select(row: self.values.count - 1, column: 0)
+                    if let next = self.tableView.view(atColumn: 0, row: self.values.count - 1, makeIfNecessary: true) {
+                        self.window?.makeFirstResponder(next)
+                    }
+                }
+                return
+            } else {
+                nextRow = row + 1
+                targetColumn = 0
+            }
         } else if nextColumn < 0 {
             nextRow = max(0, row - 1)
             targetColumn = max(0, data.columnCount - 1)
@@ -460,6 +472,27 @@ final class TableEditorView: NSView, PanelSurface, NSTableViewDataSource, NSTabl
         select(row: nextRow, column: targetColumn)
         if let next = tableView.view(atColumn: targetColumn, row: nextRow, makeIfNecessary: true) {
             window?.makeFirstResponder(next)
+        }
+    }
+
+    private func advanceDown(from field: TableEditorCell) {
+        let row = field.tag / 10_000
+        let column = field.tag % 10_000
+        guard !values.isEmpty, let _ = data else { return }
+        if row + 1 >= values.count {
+            addRow(nil)
+            DispatchQueue.main.async { [weak self] in
+                guard let self else { return }
+                self.select(row: self.values.count - 1, column: column)
+                if let next = self.tableView.view(atColumn: column, row: self.values.count - 1, makeIfNecessary: true) {
+                    self.window?.makeFirstResponder(next)
+                }
+            }
+        } else {
+            select(row: row + 1, column: column)
+            if let next = tableView.view(atColumn: column, row: row + 1, makeIfNecessary: true) {
+                window?.makeFirstResponder(next)
+            }
         }
     }
 
@@ -479,6 +512,10 @@ final class TableEditorView: NSView, PanelSurface, NSTableViewDataSource, NSTabl
         field.onAdvance = { [weak self, weak field] forward in
             guard let self, let field else { return }
             self.advance(from: field, forward: forward)
+        }
+        field.onAdvanceDown = { [weak self, weak field] in
+            guard let self, let field else { return }
+            self.advanceDown(from: field)
         }
         field.setAccessibilityLabel("Table row \(row + 1), column \(column + 1)")
         field.setAccessibilityRole(.textField)
@@ -533,14 +570,18 @@ final class TableEditorView: NSView, PanelSurface, NSTableViewDataSource, NSTabl
 
 private final class TableEditorCell: NSTextField {
     var onAdvance: ((Bool) -> Void)?
+    var onAdvanceDown: (() -> Void)?
 
     override func keyDown(with event: NSEvent) {
         let isTab = event.keyCode == 48
         let isReturn = event.keyCode == 36 || event.keyCode == 76
-        guard isTab || isReturn else {
-            super.keyDown(with: event)
+        if isTab {
+            onAdvance?(!event.modifierFlags.contains(.shift))
+            return
+        } else if isReturn {
+            onAdvanceDown?()
             return
         }
-        onAdvance?(!event.modifierFlags.contains(.shift))
+        super.keyDown(with: event)
     }
 }

--- a/Sources/DownrightApp/Panels/UpdateStatusPill.swift
+++ b/Sources/DownrightApp/Panels/UpdateStatusPill.swift
@@ -11,13 +11,23 @@ import MarkdownRender
 /// badge.  All motion honors Reduce Motion.
 @MainActor
 final class UpdateStatusPill: NSButton {
+    enum Presentation {
+        case standard
+        /// The start window already has a strong task hierarchy. An update
+        /// failure stays actionable, but collapses to a quiet warning button
+        /// instead of competing with Open/New.
+        case compactWarning
+    }
+
     private enum Metrics {
         static let height: CGFloat = 26
         static let cornerRadius: CGFloat = 13
         static let horizontalPadding: CGFloat = 11
         static let iconSize: CGFloat = 13
+        static let compactWarningWidth: CGFloat = 34
     }
 
+    private let presentation: Presentation
     private let shell = NSView()
     /// The same hover/press wash every neighbouring toolbar control uses, so
     /// the pill answers the pointer instead of sitting inert among controls
@@ -45,7 +55,17 @@ final class UpdateStatusPill: NSButton {
             // unambiguous; the pill's own width constraint collapses it.
             return NSSize(width: 1, height: Metrics.height)
         }
-        let textWidth = ceil(label.attributedStringValue.size().width)
+        if presentation == .compactWarning, currentModel == .warning {
+            return NSSize(width: Metrics.compactWarningWidth, height: Metrics.height)
+        }
+        // NSTextField's attributed-string measurement can under-report a
+        // fallback glyph such as the warning copy at small sizes. fittingSize
+        // reflects the actual cell layout; retain the explicit measurement as
+        // a lower-bound guard for custom fonts/themes.
+        let textWidth = ceil(max(
+            label.fittingSize.width,
+            label.attributedStringValue.size().width
+        )) + 2
         let iconWidth: CGFloat = {
             if case .progress = currentModel { return Metrics.iconSize + 3 }
             return Metrics.iconSize + 3
@@ -53,7 +73,8 @@ final class UpdateStatusPill: NSButton {
         return NSSize(width: Metrics.horizontalPadding * 2 + iconWidth + textWidth, height: Metrics.height)
     }
 
-    init() {
+    init(presentation: Presentation = .standard) {
+        self.presentation = presentation
         self.sheet = UpdateStatusPill.makeSheet()
         super.init(frame: .zero)
         wantsLayer = true
@@ -74,6 +95,7 @@ final class UpdateStatusPill: NSButton {
         label.translatesAutoresizingMaskIntoConstraints = false
         label.font = PanelFont.system(11.5, weight: .semibold)
         label.maximumNumberOfLines = 1
+        label.usesSingleLineMode = true
         label.isEditable = false
         label.isSelectable = false
         label.isBezeled = false
@@ -88,6 +110,9 @@ final class UpdateStatusPill: NSButton {
         shell.addSubview(progressIndicator)
 
         isBordered = false
+        // The pill owns its content through `shell` and `label`; leaving the
+        // NSButton title in place draws a second, colliding string underneath.
+        title = ""
         setButtonType(.momentaryChange)
         focusRingType = .default
         target = self
@@ -244,6 +269,7 @@ final class UpdateStatusPill: NSButton {
             iconView.contentTintColor = sheet.accent
             label.textColor = sheet.textSecondary
             label.stringValue = "Update \(version)"
+            label.isHidden = false
             progressIndicator.stopAnimation(nil)
             progressIndicator.isHidden = true
             iconView.isHidden = false
@@ -257,6 +283,7 @@ final class UpdateStatusPill: NSButton {
             iconView.contentTintColor = sheet.accent
             label.textColor = sheet.text
             label.stringValue = "Restart to Update"
+            label.isHidden = false
             progressIndicator.stopAnimation(nil)
             progressIndicator.isHidden = true
             iconView.isHidden = false
@@ -268,6 +295,7 @@ final class UpdateStatusPill: NSButton {
         case .progress(let title, let fraction):
             label.textColor = sheet.textSecondary
             label.stringValue = title
+            label.isHidden = false
             iconView.isHidden = true
             progressIndicator.isHidden = false
             if let fraction {
@@ -289,19 +317,32 @@ final class UpdateStatusPill: NSButton {
             iconView.contentTintColor = warning
             label.textColor = warning
             label.stringValue = "Update Failed"
+            label.isHidden = presentation == .compactWarning
+            toolTip = presentation == .compactWarning
+                ? "Update failed — click for details"
+                : "Open the update panel"
             progressIndicator.stopAnimation(nil)
             progressIndicator.isHidden = true
             iconView.isHidden = false
-            shell.layer?.backgroundColor = warning
-                .panelAlpha(contrast ? 0.22 : 0.12, increaseContrast: false).cgColor
-            shell.layer?.borderWidth = contrast ? 1 : 0
-            shell.layer?.borderColor = warning.cgColor
+            if presentation == .compactWarning {
+                shell.layer?.backgroundColor = warning
+                    .panelAlpha(contrast ? 0.12 : 0.07, increaseContrast: false).cgColor
+                shell.layer?.borderWidth = 1
+                shell.layer?.borderColor = warning
+                    .withAlphaComponent(contrast ? 0.55 : 0.32).cgColor
+            } else {
+                shell.layer?.backgroundColor = warning
+                    .panelAlpha(contrast ? 0.22 : 0.12, increaseContrast: false).cgColor
+                shell.layer?.borderWidth = contrast ? 1 : 0
+                shell.layer?.borderColor = warning.cgColor
+            }
 
         case .informational(let version):
             iconView.image = NSImage(systemSymbolName: "info.circle.fill", accessibilityDescription: "Update information")
             iconView.contentTintColor = sheet.accent
             label.textColor = sheet.textSecondary
             label.stringValue = "Update \(version)"
+            label.isHidden = false
             progressIndicator.stopAnimation(nil)
             progressIndicator.isHidden = true
             iconView.isHidden = false

--- a/Sources/DownrightApp/Panels/UpdateWindowController.swift
+++ b/Sources/DownrightApp/Panels/UpdateWindowController.swift
@@ -2,6 +2,13 @@ import AppKit
 import MarkdownCore
 import MarkdownRender
 
+private enum UpdateWindowLayout {
+    static let width: CGFloat = 560
+    static let regularHeight: CGFloat = 600
+    static let failureHeight: CGFloat = 360
+    static let minimumHeight: CGFloat = 320
+}
+
 /// The one nonmodal update surface.  Documents stay usable while it is open;
 /// it never activates the app over another application, and closing it is
 /// always safe (any pending Sparkle choice resolves to "later").
@@ -18,16 +25,23 @@ final class UpdateWindowController: NSWindowController, NSWindowDelegate {
     convenience init(coordinator: UpdateCoordinator) {
         let view = UpdatePanelView(coordinator: coordinator)
         let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 560, height: 600),
+            contentRect: NSRect(
+                x: 0, y: 0,
+                width: UpdateWindowLayout.width,
+                height: UpdateWindowLayout.regularHeight
+            ),
             styleMask: [.titled, .closable, .fullSizeContentView],
             backing: .buffered,
             defer: false
         )
         window.title = "Updates"
         window.titlebarAppearsTransparent = true
-        window.titleVisibility = .visible
+        // The panel has its own branded header. Leaving the native title visible
+        // puts a second "Updates" label directly above it in the full-content
+        // titlebar and makes the icon/title stack look collided.
+        window.titleVisibility = .hidden
         window.isMovableByWindowBackground = true
-        window.minSize = NSSize(width: 480, height: 480)
+        window.minSize = NSSize(width: 480, height: UpdateWindowLayout.minimumHeight)
         window.isRestorable = false
         window.contentView = view
         window.center()
@@ -103,6 +117,11 @@ private final class UpdatePanelView: NSView {
 
     required init?(coder: NSCoder) { fatalError("not supported") }
 
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        refresh()
+    }
+
     private static func makeSheet() -> StyleSheet {
         StyleSheet(theme: ThemeStore.shared.current, appearance: NSApp.effectiveAppearance)
     }
@@ -111,6 +130,7 @@ private final class UpdatePanelView: NSView {
         super.viewDidChangeEffectiveAppearance()
         sheet = Self.makeSheet()
         window?.backgroundColor = sheet.background
+        layer?.backgroundColor = sheet.background.cgColor
         header.apply(sheet: sheet)
         footer.apply(sheet: sheet)
     }
@@ -139,6 +159,20 @@ private final class UpdatePanelView: NSView {
             contentView.bottomAnchor.constraint(equalTo: contentContainer.bottomAnchor),
         ])
         footer.update(coordinator: coordinator)
+        resizeForContent(content.kind)
+    }
+
+    private func resizeForContent(_ kind: UpdatePanelContent.Kind) {
+        guard let window else { return }
+        let desiredHeight: CGFloat = kind == .failed
+            ? UpdateWindowLayout.failureHeight
+            : UpdateWindowLayout.regularHeight
+        guard abs(window.frame.height - desiredHeight) > 0.5 else { return }
+
+        var frame = window.frame
+        frame.origin.y += (frame.height - desiredHeight) / 2
+        frame.size.height = desiredHeight
+        window.setFrame(frame, display: true, animate: false)
     }
 }
 
@@ -649,43 +683,130 @@ private final class UpdateStatusMessageView: NSView {
 @MainActor
 private final class UpdateFailureView: NSView {
     private let detailDisclosure = NSButton(title: "Technical Details", target: nil, action: nil)
+    private let detailPanel = NSView()
+    private let detailLabel = NSTextField(labelWithString: "")
 
     init(coordinator: UpdateCoordinator, sheet: StyleSheet) {
         super.init(frame: .zero)
         guard case .failed(let failure, _) = coordinator.phase else { return }
 
+        let danger = sheet.calloutColor(.danger)
+
+        let iconWell = NSView()
+        iconWell.translatesAutoresizingMaskIntoConstraints = false
+        iconWell.wantsLayer = true
+        iconWell.layer?.cornerRadius = 12
+        iconWell.layer?.masksToBounds = true
+        iconWell.layer?.backgroundColor = danger.withAlphaComponent(
+            sheet.increaseContrast ? 0.20 : 0.12
+        ).cgColor
+
+        let icon = NSImageView()
+        icon.translatesAutoresizingMaskIntoConstraints = false
+        icon.image = NSImage(
+            systemSymbolName: "exclamationmark.triangle.fill",
+            accessibilityDescription: "Update unavailable"
+        )
+        icon.contentTintColor = danger
+        icon.symbolConfiguration = NSImage.SymbolConfiguration(pointSize: 18, weight: .semibold)
+        icon.setAccessibilityRole(.image)
+        icon.setAccessibilityLabel("Update unavailable")
+        iconWell.addSubview(icon)
+        NSLayoutConstraint.activate([
+            iconWell.widthAnchor.constraint(equalToConstant: 40),
+            iconWell.heightAnchor.constraint(equalToConstant: 40),
+            icon.centerXAnchor.constraint(equalTo: iconWell.centerXAnchor),
+            icon.centerYAnchor.constraint(equalTo: iconWell.centerYAnchor),
+        ])
+
+        let status = NSTextField(labelWithString: "Update unavailable")
+        status.font = PanelFont.header
+        status.textColor = danger
+
+        let summary = NSTextField(wrappingLabelWithString: failure.message)
+        summary.font = PanelFont.system(15, weight: .semibold)
+        summary.textColor = sheet.text
+        summary.maximumNumberOfLines = 2
+        summary.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+
+        let reassurance = NSTextField(wrappingLabelWithString: "Your files are safe. Nothing was changed on disk.")
+        reassurance.font = PanelFont.row
+        reassurance.textColor = sheet.textSecondary
+        reassurance.maximumNumberOfLines = 2
+        reassurance.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+
+        let messageStack = NSStackView(views: [status, summary, reassurance])
+        messageStack.orientation = .vertical
+        messageStack.alignment = .leading
+        messageStack.spacing = 4
+        messageStack.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+
+        let hero = NSStackView(views: [iconWell, messageStack])
+        hero.orientation = .horizontal
+        hero.alignment = .centerY
+        hero.spacing = 12
+
+        detailLabel.stringValue = failure.technicalDetail ?? "Error code \(failure.code)"
+        detailLabel.font = PanelFont.monospaced(10.5)
+        detailLabel.textColor = sheet.textFaint
+        detailLabel.lineBreakMode = .byCharWrapping
+        detailLabel.maximumNumberOfLines = 3
+        detailLabel.translatesAutoresizingMaskIntoConstraints = false
+        detailPanel.translatesAutoresizingMaskIntoConstraints = false
+        detailPanel.wantsLayer = true
+        detailPanel.layer?.cornerRadius = 8
+        detailPanel.layer?.masksToBounds = true
+        detailPanel.layer?.backgroundColor = sheet.codeBackground.withAlphaComponent(0.72).cgColor
+        detailPanel.layer?.borderWidth = 1
+        detailPanel.layer?.borderColor = sheet.rule.withAlphaComponent(0.65).cgColor
+        detailPanel.isHidden = true
+        detailPanel.addSubview(detailLabel)
+        NSLayoutConstraint.activate([
+            detailLabel.leadingAnchor.constraint(equalTo: detailPanel.leadingAnchor, constant: 10),
+            detailLabel.trailingAnchor.constraint(equalTo: detailPanel.trailingAnchor, constant: -10),
+            detailLabel.topAnchor.constraint(equalTo: detailPanel.topAnchor, constant: 8),
+            detailLabel.bottomAnchor.constraint(equalTo: detailPanel.bottomAnchor, constant: -8),
+        ])
+
         let stack = NSStackView()
         stack.translatesAutoresizingMaskIntoConstraints = false
         stack.orientation = .vertical
         stack.alignment = .leading
-        stack.spacing = 8
+        stack.spacing = 14
         addSubview(stack)
-
-        let summary = NSTextField(wrappingLabelWithString: failure.message)
-        summary.font = PanelFont.system(13, weight: .medium)
-        summary.textColor = sheet.accent
-        summary.translatesAutoresizingMaskIntoConstraints = false
-        stack.addArrangedSubview(summary)
-
-        let explanation = NSTextField(wrappingLabelWithString: "Nothing has been changed on disk. You can try again, or check later.")
-        explanation.font = PanelFont.row
-        explanation.textColor = sheet.textSecondary
-        stack.addArrangedSubview(explanation)
 
         detailDisclosure.translatesAutoresizingMaskIntoConstraints = false
         detailDisclosure.setButtonType(.pushOnPushOff)
-        detailDisclosure.bezelStyle = .inline
+        detailDisclosure.isBordered = false
         detailDisclosure.font = PanelFont.secondary
+        detailDisclosure.contentTintColor = sheet.textSecondary
+        detailDisclosure.image = NSImage(
+            systemSymbolName: "chevron.right",
+            accessibilityDescription: "Show technical details"
+        )
+        detailDisclosure.imagePosition = .imageLeading
+        detailDisclosure.imageHugsTitle = true
+        detailDisclosure.alignment = .left
+        detailDisclosure.toolTip = "Show technical details"
+        detailDisclosure.wantsLayer = true
+        detailDisclosure.layer?.cornerRadius = 7
+        detailDisclosure.layer?.masksToBounds = true
+        detailDisclosure.layer?.backgroundColor = sheet.text.withAlphaComponent(
+            sheet.increaseContrast ? 0.12 : 0.07
+        ).cgColor
+        detailDisclosure.layer?.borderWidth = 1
+        detailDisclosure.layer?.borderColor = sheet.text.withAlphaComponent(0.14).cgColor
+        detailDisclosure.attributedTitle = NSAttributedString(
+            string: detailDisclosure.title,
+            attributes: [
+                .font: detailDisclosure.font as Any,
+                .foregroundColor: sheet.textSecondary,
+            ]
+        )
+        detailDisclosure.heightAnchor.constraint(equalToConstant: 28).isActive = true
+        detailDisclosure.setContentHuggingPriority(.required, for: .horizontal)
         detailDisclosure.target = self
         detailDisclosure.action = #selector(toggleDetail)
-        stack.addArrangedSubview(detailDisclosure)
-
-        let detailLabel = NSTextField(wrappingLabelWithString: failure.technicalDetail ?? "\(failure.code)")
-        detailLabel.font = PanelFont.monospaced(10.5)
-        detailLabel.textColor = sheet.textFaint
-        detailLabel.isHidden = true
-        detailLabel.translatesAutoresizingMaskIntoConstraints = false
-        stack.addArrangedSubview(detailLabel)
 
         let copy = UpdatePanelButton(title: "Copy Diagnostics", kind: .secondary) {
             NSPasteboard.general.clearContents()
@@ -695,22 +816,49 @@ private final class UpdateFailureView: NSView {
             )
         }
         copy.setAccessibilityLabel("Copy diagnostics")
-        stack.addArrangedSubview(copy)
+        copy.heightAnchor.constraint(equalToConstant: 28).isActive = true
+
+        let diagnosticsActions = NSStackView(views: [detailDisclosure, copy])
+        diagnosticsActions.orientation = .horizontal
+        diagnosticsActions.alignment = .centerY
+        diagnosticsActions.spacing = 8
+
+        stack.addArrangedSubview(hero)
+        stack.addArrangedSubview(diagnosticsActions)
+        stack.addArrangedSubview(detailPanel)
+
+        // Keep the body on one horizontal grid when the disclosure opens. A
+        // hidden NSView has no fitting width, so relying on stack alignment
+        // alone lets AppKit shrink the whole stack to the diagnostic label.
+        for view in [hero, diagnosticsActions, detailPanel] {
+            view.widthAnchor.constraint(equalTo: stack.widthAnchor).isActive = true
+        }
 
         NSLayoutConstraint.activate([
             stack.leadingAnchor.constraint(equalTo: leadingAnchor),
             stack.trailingAnchor.constraint(equalTo: trailingAnchor),
-            stack.topAnchor.constraint(equalTo: topAnchor),
-            stack.bottomAnchor.constraint(equalTo: bottomAnchor),
+            stack.centerYAnchor.constraint(equalTo: centerYAnchor),
+            stack.topAnchor.constraint(greaterThanOrEqualTo: topAnchor),
+            stack.bottomAnchor.constraint(lessThanOrEqualTo: bottomAnchor),
         ])
     }
 
     required init?(coder: NSCoder) { fatalError("not supported") }
 
     @objc private func toggleDetail() {
-        guard let detail = subviews.first?.subviews.compactMap({ $0 as? NSTextField }).last else { return }
-        detail.isHidden.toggle()
-        detailDisclosure.state = detail.isHidden ? .off : .on
+        detailPanel.isHidden.toggle()
+        detailDisclosure.state = detailPanel.isHidden ? .off : .on
+        detailDisclosure.image = NSImage(
+            systemSymbolName: detailPanel.isHidden ? "chevron.right" : "chevron.down",
+            accessibilityDescription: detailPanel.isHidden
+                ? "Show technical details"
+                : "Hide technical details"
+        )
+        detailDisclosure.toolTip = detailPanel.isHidden
+            ? "Show technical details"
+            : "Hide technical details"
+        needsLayout = true
+        superview?.needsLayout = true
     }
 }
 
@@ -743,6 +891,7 @@ final class UpdatePanelButton: NSButton {
     enum Kind: Equatable { case primary, secondary }
 
     private let kind: Kind
+    private let buttonTitle: String
     var isPrimary: Bool { kind == .primary }
     private var sheet: StyleSheet
     /// `target` is weak; without a strong reference the action object would
@@ -751,15 +900,20 @@ final class UpdatePanelButton: NSButton {
 
     init(title: String, kind: Kind, sheet: StyleSheet? = nil, action: @escaping () -> Void) {
         self.kind = kind
+        self.buttonTitle = title
         self.sheet = sheet ?? StyleSheet(theme: ThemeStore.shared.current, appearance: NSApp.effectiveAppearance)
         let actionTarget = ActionTarget(action)
         self.actionTarget = actionTarget
         super.init(frame: .zero)
         self.title = title
-        bezelStyle = .rounded
-        font = PanelFont.system(12, weight: .medium)
+        setButtonType(.momentaryPushIn)
+        isBordered = false
+        font = PanelFont.system(12, weight: .semibold)
         controlSize = .regular
         focusRingType = .default
+        wantsLayer = true
+        layer?.cornerRadius = 8
+        layer?.masksToBounds = true
         target = actionTarget
         self.action = #selector(ActionTarget.run(_:))
         setAccessibilityRole(.button)
@@ -770,14 +924,27 @@ final class UpdatePanelButton: NSButton {
 
     func apply(sheet: StyleSheet) {
         self.sheet = sheet
+        let titleColor: NSColor
         switch kind {
         case .primary:
+            titleColor = .white
             contentTintColor = .white
-            bezelColor = sheet.accent
+            layer?.backgroundColor = sheet.accent.cgColor
+            layer?.borderColor = sheet.accent.blended(withFraction: 0.18, of: .white)?.cgColor
         case .secondary:
+            titleColor = sheet.text
             contentTintColor = sheet.text
-            bezelColor = sheet.surface
+            layer?.backgroundColor = sheet.text.withAlphaComponent(0.12).cgColor
+            layer?.borderColor = sheet.text.withAlphaComponent(0.20).cgColor
         }
+        layer?.borderWidth = 1
+        attributedTitle = NSAttributedString(
+            string: buttonTitle,
+            attributes: [
+                .font: font as Any,
+                .foregroundColor: titleColor,
+            ]
+        )
     }
 }
 

--- a/Sources/DownrightApp/Panels/VersionTimelineView.swift
+++ b/Sources/DownrightApp/Panels/VersionTimelineView.swift
@@ -300,8 +300,14 @@ final class VersionTimelineView: NSView {
         hoveredIndex = index
         // The tooltip names the version the pointer is over, which is the one
         // thing a tick cannot say by itself.
-        toolTip = index.flatMap { versions.element(at: $0) }.map {
-            "\(RelativeTime.stamp($0.date)) · \(RelativeTime.long($0.date))"
+        toolTip = index.flatMap { versions.element(at: $0) }.map { record in
+            let kind = kindLabel(record.kind)
+            if let selected = selectedRecord {
+                let diff = Int(record.date.timeIntervalSince(selected.date))
+                let deltaStr = diff == 0 ? "selected" : (diff > 0 ? "+\(diff)s" : "\(diff)s")
+                return "\(kind) (\(deltaStr)) · \(RelativeTime.stamp(record.date)) · \(RelativeTime.long(record.date))"
+            }
+            return "\(kind) · \(RelativeTime.stamp(record.date)) · \(RelativeTime.long(record.date))"
         }
         needsDisplay = true
     }

--- a/Sources/MarkdownRender/Fragments/CalloutFragment.swift
+++ b/Sources/MarkdownRender/Fragments/CalloutFragment.swift
@@ -78,7 +78,8 @@ final class CalloutFragment: DownrightFragment {
         let band = bandRect(at: point, reservedInset: reservedInset)
 
         if kind != nil {
-            cg.fillRect(continuous(band), color: color.withAlphaComponent(0.055),
+            let tintAlpha: CGFloat = style.theme.appearance == .light ? 0.042 : 0.060
+            cg.fillRect(continuous(band), color: color.withAlphaComponent(tintAlpha),
                         radius: RenderMetrics.calloutCornerRadius)
         }
         cg.fillRect(ruleRect(band, width: ruleWidth), color: color, radius: ruleWidth / 2)

--- a/Sources/MarkdownRender/Fragments/CodeBlockFragment.swift
+++ b/Sources/MarkdownRender/Fragments/CodeBlockFragment.swift
@@ -162,13 +162,17 @@ final class CodeBlockFragment: DownrightFragment {
     private func drawCopyControl(in band: CGRect, style: StyleSheet, language: String, in cg: CGContext) {
         guard context?.hoveredFragmentRange == payload.sourceRange else { return }
         let copy = Self.copyButtonRect(in: band, style: style, language: language)
-        cg.fillRect(copy, color: style.codeRule.withAlphaComponent(0.22), radius: 6)
         let copied = context?.copiedCodeRange == payload.sourceRange
+        let bgColor = copied
+            ? style.accent.withAlphaComponent(0.20)
+            : style.codeRule.withAlphaComponent(0.22)
+        cg.fillRect(copy, color: bgColor, radius: 6)
         let symbol = copied ? "checkmark" : "doc.on.doc"
         let description = copied ? "Copied" : "Copy code"
         if let image = NSImage(systemSymbolName: symbol, accessibilityDescription: description)?
-            .withSymbolConfiguration(.init(pointSize: 12, weight: .medium)) {
-            let tinted = image.tinted(style.textSecondary)
+            .withSymbolConfiguration(.init(pointSize: 12, weight: copied ? .bold : .medium)) {
+            let iconColor = copied ? style.accent : style.textSecondary
+            let tinted = image.tinted(iconColor)
             draw(image: tinted, in: copy.insetBy(dx: 8, dy: 8), in: cg)
         }
     }

--- a/Sources/MarkdownRender/Fragments/TableFragment.swift
+++ b/Sources/MarkdownRender/Fragments/TableFragment.swift
@@ -585,7 +585,8 @@ final class TableRowFragment: DownrightFragment {
             // hierarchy as code and failed-object blocks.
             cg.fillRect(frame, color: style.surface.withAlphaComponent(0.62))
         } else if context?.hoveredTableRow == row.range {
-            cg.fillRect(frame, color: style.text.withAlphaComponent(0.04))
+            let hoverAlpha: CGFloat = style.theme.appearance == .light ? 0.038 : 0.055
+            cg.fillRect(frame, color: style.text.withAlphaComponent(hoverAlpha), radius: 3)
         }
 
         if layout.isStacked {

--- a/Tests/DownrightAppTests/StartWindowTests.swift
+++ b/Tests/DownrightAppTests/StartWindowTests.swift
@@ -25,12 +25,12 @@ struct StartWindowTests {
         let labels = buttons(in: window.contentView).compactMap { $0.accessibilityLabel() }
         #expect(labels.contains("Open File"))
         #expect(labels.contains("New Document"))
-        // Ellipsis on the start screen reads as truncated text.
-        #expect(labels.contains(where: { $0.contains("…") || $0.contains("...") }) == false)
+        let text = textFields(in: window.contentView).map(\.stringValue)
+        #expect(text.contains("You can also drop a file anywhere") == false)
     }
 
     @Test
-    func primaryActionsSizeToTheirOwnContent() throws {
+    func primaryActionsUseBalancedControlWells() throws {
         let controller = StartWindowController(recents: [])
         defer { controller.close() }
 
@@ -55,17 +55,13 @@ struct StartWindowTests {
 
         #expect(abs(openCenter.y - createCenter.y) < 0.5)
         #expect(createCenter.x > openCenter.x)
-        // Each button hugs its own content.  A fixed constant clipped "New
-        // Document" mid-word (a fixed 164pt missed it); an equal-width pin
-        // stretched "Open File"'s label-to-shortcut gap into whitespace and
-        // left "New Document" with zero headroom.  Both regressions fail
-        // here: neither button may be stretched beyond its own intrinsic
-        // width, and neither may fall short of it.
-        #expect(abs(open.frame.width - open.intrinsicContentSize.width) < 1)
-        #expect(abs(create.frame.width - create.intrinsicContentSize.width) < 1)
-        // "New Document" is the longer label, so its button is wider; a
-        // re-introduced shared constant would flatten this ordering.
-        #expect(open.frame.width < create.frame.width)
+        // Open and New are peer entry points. Keep their wells equal so the
+        // longer title does not accidentally become the visual primary.
+        #expect(abs(open.frame.width - StartLayout.actionButtonWidth) < 1)
+        #expect(abs(create.frame.width - StartLayout.actionButtonWidth) < 1)
+        #expect(abs(open.frame.width - create.frame.width) < 1)
+        #expect(open.frame.height == StartLayout.buttonHeight)
+        #expect(create.frame.height == StartLayout.buttonHeight)
     }
 
     @Test
@@ -91,8 +87,14 @@ struct StartWindowTests {
         // Matching the two buttons' widths used to stretch this from the
         // 12pt design constant to ~48pt of dead air.
         let gap = shortcut.frame.minX - title.frame.maxX
-        #expect(gap >= 10)
+        // The compact keycap group keeps a deliberate 8pt optical gap after
+        // the title without making the shortcut feel detached from its label.
+        #expect(gap >= 8)
         #expect(gap <= 22)
+        #expect(shortcut.frame.width >= 30)
+        #expect(shortcut.frame.height >= 20)
+        let shortcutInOpen = shortcut.convert(shortcut.bounds, to: open)
+        #expect(shortcutInOpen.maxX <= open.bounds.maxX - 12)
     }
 
     @Test
@@ -132,6 +134,33 @@ struct StartWindowTests {
         let labels = buttons(in: window.contentView).compactMap { $0.accessibilityLabel() }
         #expect(labels.contains("Open Editing Keys"))
         #expect(labels.contains(where: { $0.contains("92C5F190") }) == false)
+    }
+
+    @Test
+    func recentRowsUseDocumentIconsAndContextMenuForClearing() throws {
+        let recent = RecentDocument(
+            path: "/tmp/downright-start-context.md",
+            displayName: "note",
+            firstHeading: "Planning",
+            lastOpened: Date(),
+            wordCount: 1
+        )
+        let controller = StartWindowController(recents: [recent])
+        defer { controller.close() }
+
+        let window = try #require(controller.window)
+        window.contentView?.layoutSubtreeIfNeeded()
+
+        let labels = buttons(in: window.contentView).compactMap { $0.accessibilityLabel() }
+        #expect(labels.contains("Clear recent files") == false)
+
+        let documentIcons = imageViews(in: window.contentView).filter {
+            $0.accessibilityLabel() == "Markdown document"
+        }
+        #expect(documentIcons.count == 1)
+
+        let menus = menus(in: window.contentView)
+        #expect(menus.contains { $0.items.map(\.title) == ["Clear Recent Files…"] })
     }
 
     @Test
@@ -320,7 +349,9 @@ struct StartWindowTests {
             path: path,
             displayName: "note",
             firstHeading: "Planning",
-            lastOpened: Date().addingTimeInterval(-7_200),
+            lastOpened: Calendar.current.date(
+                byAdding: .day, value: -1, to: Date()
+            ) ?? Date().addingTimeInterval(-86_400),
             wordCount: 3
         )
         let controller = StartWindowController(recents: [older])
@@ -469,9 +500,22 @@ struct StartWindowTests {
         return button + view.subviews.flatMap { buttons(in: $0) }
     }
 
-    private func textFields(in view: NSView) -> [NSTextField] {
+    private func textFields(in view: NSView?) -> [NSTextField] {
+        guard let view else { return [] }
         let direct = (view as? NSTextField).map { [$0] } ?? []
         return direct + view.subviews.flatMap { textFields(in: $0) }
+    }
+
+    private func imageViews(in view: NSView?) -> [NSImageView] {
+        guard let view else { return [] }
+        let direct = (view as? NSImageView).map { [$0] } ?? []
+        return direct + view.subviews.flatMap { imageViews(in: $0) }
+    }
+
+    private func menus(in view: NSView?) -> [NSMenu] {
+        guard let view else { return [] }
+        let direct = view.menu.map { [$0] } ?? []
+        return direct + view.subviews.flatMap { menus(in: $0) }
     }
 }
 
@@ -497,6 +541,43 @@ struct RecentRowSubtitleTests {
     func headingAndFolder() {
         let row = recent(path: "/w/watchtest/notes.md", name: "notes", heading: "Agent output")
         #expect(RecentRowCopy.subtitle(for: row, title: "notes") == "Agent output  ·  watchtest")
+    }
+
+    @Test("A stale joined heading is repaired for the welcome row")
+    func malformedJoinedHeading() {
+        let row = recent(
+            path: "/tmp/downright-live-selection-2.md",
+            name: "downright-live-selection-2",
+            heading: "ThiDownright renderer showcase"
+        )
+        #expect(
+            RecentRowCopy.subtitle(for: row, title: "downright-live-selection-2")
+                == "Downright renderer showcase  ·  tmp"
+        )
+    }
+
+    @Test("Recent timestamps use calendar labels")
+    func calendarTimestamps() {
+        let calendar = Calendar.current
+        let today = calendar.startOfDay(for: Date()).addingTimeInterval(12 * 60 * 60)
+        let yesterday = calendar.date(byAdding: .day, value: -1, to: today)!
+        let older = calendar.date(byAdding: .day, value: -3, to: today)!
+
+        #expect(RecentRowCopy.timestamp(for: RecentDocument(
+            path: "/today.md", displayName: "today", firstHeading: "",
+            lastOpened: today, wordCount: 0
+        )) == "Today")
+        #expect(
+            RecentRowCopy.timestamp(for: RecentDocument(
+                path: "/yesterday.md", displayName: "yesterday", firstHeading: "",
+                lastOpened: yesterday, wordCount: 0
+            )) == "Yesterday"
+        )
+        let olderLabel = RecentRowCopy.timestamp(for: RecentDocument(
+            path: "/older.md", displayName: "older", firstHeading: "",
+            lastOpened: older, wordCount: 0
+        ))
+        #expect(olderLabel.contains("ago") == false)
     }
 
     /// `README` in `Downright/` whose first heading is "Downright" would read

--- a/Tests/DownrightAppTests/WindowChromeTests.swift
+++ b/Tests/DownrightAppTests/WindowChromeTests.swift
@@ -246,7 +246,11 @@ struct WindowChromeTests {
         #expect(!find.isOn, "find should rest unlit with its panel closed")
         #expect(cluster.arrangedSubviews.contains { $0 is ActivityIndicatorView })
         #expect(cluster.arrangedSubviews.contains { $0 is TaskProgressRing })
-        #expect(cluster.arrangedSubviews.contains { $0 is UpdateStatusPill })
+        let updatePill = try #require(
+            cluster.arrangedSubviews.first { $0 is UpdateStatusPill } as? UpdateStatusPill,
+            "update status pill is not in the trailing cluster"
+        )
+        #expect(updatePill.title.isEmpty, "the custom pill must not draw NSButton's title")
         #expect(!toolbar.items.contains { $0.itemIdentifier.rawValue == "contents" })
         #expect(!toolbar.items.contains { $0.itemIdentifier.rawValue == "inspector" })
         let overflow = try #require(


### PR DESCRIPTION
## Summary
- Refine the welcome and update surfaces with balanced actions, contextual recents, and clearer failure details.
- Add the Finder-aligned rolling DMG background and optional layout path.
- Keep release documentation and changelog aligned with the shipped behavior.

## Validation
- `SCRATCH=.build-release-final TEST_SCRATCH=.build-test-release-final RUN_DRBENCH=1 Scripts/check.sh` — 1,006 tests in 85 suites, debug/release benches passed.
- `Scripts/check-app.sh` built and verified the exact bundle; local macOS UI-test initialization timed out twice while enabling automation mode, so the required GitHub `app-acceptance` check is authoritative.
