### PR TITLE
Refine start window anchoring, button styling, and update panel interactions

### DIFF
--- a/Sources/DownrightApp/App/StartWindowController.swift
+++ b/Sources/DownrightApp/App/StartWindowController.swift
@@ -13,9 +13,10 @@ enum StartLayout {
     // A fixed, well-proportioned welcome surface. The 556pt content column
     // maps cleanly to the 2x reference capture while leaving a quiet 28pt
     // window margin on either side.
-    static let windowSize = NSSize(width: 612, height: 540)
+    static let windowSize = NSSize(width: 612, height: 560)
     static let horizontalInset: CGFloat = 28
-    static let bottomInset: CGFloat = 28
+    static let topInset: CGFloat = 42
+    static let bottomInset: CGFloat = 24
     static let sectionSpacing: CGFloat = 18
     static let contentWidth: CGFloat = 556
     static let buttonHeight: CGFloat = 40
@@ -39,18 +40,20 @@ enum StartLayout {
 enum KeycapFormatter {
     static func format(shortcut: String, color: NSColor) -> NSAttributedString {
         let result = NSMutableAttributedString()
-        for char in shortcut {
+        let paragraph = NSMutableParagraphStyle()
+        paragraph.alignment = .center
+
+        for (index, char) in shortcut.enumerated() {
+            let isLast = index == shortcut.count - 1
             if char == "⌘" || char == "⇧" || char == "⌥" || char == "⌃" {
                 result.append(NSAttributedString(
                     string: String(char),
                     attributes: [
-                        .font: NSFont.systemFont(ofSize: 11, weight: .semibold),
+                        .font: NSFont.systemFont(ofSize: 11.5, weight: .semibold),
                         .foregroundColor: color,
-                        .baselineOffset: -0.3,
-                        // The small optical pause is intentional. A raw
-                        // `⌘O` reads as one ligature at this size; the badge
-                        // should read as two adjacent keys.
-                        .kern: 1.4,
+                        .paragraphStyle: paragraph,
+                        .baselineOffset: 0.0,
+                        .kern: isLast ? 0.0 : 1.2,
                     ]
                 ))
             } else {
@@ -61,12 +64,62 @@ enum KeycapFormatter {
                             ? NSFont.monospacedDigitSystemFont(ofSize: 11.5, weight: .semibold)
                             : NSFont.systemFont(ofSize: 11.5, weight: .semibold),
                         .foregroundColor: color,
-                        .baselineOffset: 0.1,
+                        .paragraphStyle: paragraph,
+                        .baselineOffset: 0.0,
                     ]
                 ))
             }
         }
         return result
+    }
+}
+
+/// An optical, symmetrical keycap badge that draws its shortcut text perfectly centered
+/// horizontally and vertically with continuous rounded corners and smooth borders.
+private final class KeycapBadgeField: NSTextField {
+    private var minWidthConstraint: NSLayoutConstraint!
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        wantsLayer = true
+        layer?.cornerRadius = 5
+        layer?.cornerCurve = .continuous
+        layer?.masksToBounds = true
+        alignment = .center
+        usesSingleLineMode = true
+        lineBreakMode = .byClipping
+        configurePassiveLabel(self)
+        minWidthConstraint = widthAnchor.constraint(greaterThanOrEqualToConstant: 30)
+        minWidthConstraint.isActive = true
+        heightAnchor.constraint(equalToConstant: 20).isActive = true
+        setContentHuggingPriority(.required, for: .horizontal)
+        setContentCompressionResistancePriority(.required, for: .horizontal)
+    }
+
+    required init?(coder: NSCoder) { nil }
+
+    func setMinWidth(_ minWidth: CGFloat) {
+        minWidthConstraint.constant = minWidth
+        invalidateIntrinsicContentSize()
+    }
+
+    override var intrinsicContentSize: NSSize {
+        let textSize = attributedStringValue.size()
+        let width = max(minWidthConstraint.constant, ceil(textSize.width) + 12)
+        return NSSize(width: width, height: 20)
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        let attrString = attributedStringValue
+        guard !attrString.string.isEmpty else { return }
+        let textSize = attrString.size()
+        let centeredRect = NSRect(
+            x: floor((bounds.width - textSize.width) / 2),
+            y: floor((bounds.height - textSize.height) / 2),
+            width: ceil(textSize.width),
+            height: ceil(textSize.height)
+        )
+        attrString.draw(in: centeredRect)
     }
 }
 
@@ -253,8 +306,6 @@ private final class StartView: NSView {
         contentStack.addArrangedSubview(hero)
         contentStack.addArrangedSubview(recentPanel)
 
-        let centerY = contentStack.centerYAnchor.constraint(equalTo: canvas.centerYAnchor, constant: -2)
-        centerY.priority = .defaultHigh
         let centerX = contentStack.centerXAnchor.constraint(equalTo: canvas.centerXAnchor)
         centerX.priority = .defaultHigh
 
@@ -272,13 +323,12 @@ private final class StartView: NSView {
                 lessThanOrEqualTo: canvas.trailingAnchor,
                 constant: -StartLayout.horizontalInset
             ),
-            contentStack.topAnchor.constraint(greaterThanOrEqualTo: canvas.topAnchor, constant: Self.titlebarClearance),
+            contentStack.topAnchor.constraint(equalTo: canvas.topAnchor, constant: StartLayout.topInset),
             contentStack.bottomAnchor.constraint(
                 lessThanOrEqualTo: canvas.bottomAnchor,
                 constant: -StartLayout.bottomInset
             ),
             centerX,
-            centerY,
             contentStack.widthAnchor.constraint(equalToConstant: StartLayout.contentWidth),
             hero.widthAnchor.constraint(equalTo: contentStack.widthAnchor),
             recentPanel.widthAnchor.constraint(equalTo: contentStack.widthAnchor),
@@ -1001,9 +1051,8 @@ private final class StartActionButton: NSButton {
     private let shell = NSView()
     private let iconView = NSImageView()
     private let titleLabel: NSTextField
-    private let shortcutLabel = NSTextField(labelWithString: "")
+    private let shortcutLabel = KeycapBadgeField()
     private let contentGroup = NSStackView()
-    private var shortcutWidth: NSLayoutConstraint!
     private var shortcutHint: String = ""
     private var isHovered = false
     private var isPressed = false
@@ -1042,6 +1091,7 @@ private final class StartActionButton: NSButton {
         addSubview(shell)
 
         iconView.translatesAutoresizingMaskIntoConstraints = false
+        iconView.imageScaling = .scaleProportionallyUpOrDown
         iconView.symbolConfiguration = NSImage.SymbolConfiguration(pointSize: 14, weight: .medium)
         iconView.image = NSImage(systemSymbolName: icon, accessibilityDescription: title)
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
@@ -1049,19 +1099,13 @@ private final class StartActionButton: NSButton {
         titleLabel.usesSingleLineMode = true
         titleLabel.lineBreakMode = .byTruncatingTail
         configurePassiveLabel(titleLabel)
+
         shortcutLabel.translatesAutoresizingMaskIntoConstraints = false
-        shortcutLabel.font = .systemFont(ofSize: 11, weight: .semibold)
-        shortcutLabel.alignment = .center
-        shortcutLabel.usesSingleLineMode = true
-        shortcutLabel.lineBreakMode = .byTruncatingTail
-        shortcutLabel.wantsLayer = true
-        shortcutLabel.layer?.cornerRadius = 5
-        shortcutLabel.layer?.cornerCurve = .continuous
-        shortcutLabel.layer?.masksToBounds = true
-        configurePassiveLabel(shortcutLabel)
+        shortcutLabel.setMinWidth(30)
+
         contentGroup.orientation = .horizontal
         contentGroup.alignment = .centerY
-        contentGroup.spacing = 10
+        contentGroup.spacing = 8
         contentGroup.detachesHiddenViews = true
         contentGroup.translatesAutoresizingMaskIntoConstraints = false
         contentGroup.addArrangedSubview(iconView)
@@ -1070,7 +1114,6 @@ private final class StartActionButton: NSButton {
         contentGroup.setCustomSpacing(12, after: titleLabel)
         shell.addSubview(contentGroup)
 
-        shortcutWidth = shortcutLabel.widthAnchor.constraint(greaterThanOrEqualToConstant: 32)
         NSLayoutConstraint.activate([
             shell.leadingAnchor.constraint(equalTo: leadingAnchor),
             shell.trailingAnchor.constraint(equalTo: trailingAnchor),
@@ -1084,10 +1127,6 @@ private final class StartActionButton: NSButton {
 
             iconView.widthAnchor.constraint(equalToConstant: 16),
             iconView.heightAnchor.constraint(equalToConstant: 16),
-            shortcutWidth,
-            // A low keycap is enough to signal the binding without becoming a
-            // second control inside the control.
-            shortcutLabel.heightAnchor.constraint(equalToConstant: 20),
         ])
 
         // The label must never be the thing that gives: a clipped "New Documen"
@@ -1126,7 +1165,6 @@ private final class StartActionButton: NSButton {
         shortcutHint = hint
         shortcutLabel.stringValue = hint
         shortcutLabel.isHidden = hint.isEmpty
-        shortcutWidth.isActive = !hint.isEmpty
         setAccessibilityHelp(hint.isEmpty ? nil : hint)
         invalidateIntrinsicContentSize()
         needsLayout = true
@@ -1469,7 +1507,7 @@ private final class RecentDocumentButton: NSButton {
     private let titleLabel: NSTextField
     private let subtitleLabel: NSTextField
     private let detailLabel: NSTextField
-    private let shortcutLabel = NSTextField(labelWithString: "")
+    private let shortcutLabel = KeycapBadgeField()
     private var isHovered = false
     private var isPressed = false
     private var sheet: StyleSheet
@@ -1544,16 +1582,8 @@ private final class RecentDocumentButton: NSButton {
 
         shortcutLabel.translatesAutoresizingMaskIntoConstraints = false
         shortcutLabel.stringValue = ordinal <= 9 ? "⌘\(ordinal)" : ""
-        shortcutLabel.font = .systemFont(ofSize: 11, weight: .semibold)
-        shortcutLabel.alignment = .center
-        shortcutLabel.usesSingleLineMode = true
-        shortcutLabel.lineBreakMode = .byTruncatingTail
-        shortcutLabel.wantsLayer = true
-        shortcutLabel.layer?.cornerRadius = 5
-        shortcutLabel.layer?.cornerCurve = .continuous
-        shortcutLabel.layer?.masksToBounds = true
+        shortcutLabel.setMinWidth(28)
         shortcutLabel.isHidden = ordinal > 9
-        configurePassiveLabel(shortcutLabel)
         shortcutLabel.setAccessibilityLabel("Keyboard shortcut \(shortcutLabel.stringValue)")
 
         let trailingStack = NSStackView(views: [detailLabel, shortcutLabel])
@@ -1586,9 +1616,6 @@ private final class RecentDocumentButton: NSButton {
             text.leadingAnchor.constraint(equalTo: documentIcon.trailingAnchor, constant: 7),
             text.trailingAnchor.constraint(lessThanOrEqualTo: trailingStack.leadingAnchor, constant: -12),
             text.centerYAnchor.constraint(equalTo: shell.centerYAnchor),
-
-            shortcutLabel.widthAnchor.constraint(greaterThanOrEqualToConstant: 28),
-            shortcutLabel.heightAnchor.constraint(equalToConstant: 20),
 
             trailingStack.trailingAnchor.constraint(equalTo: shell.trailingAnchor, constant: -12),
             trailingStack.centerYAnchor.constraint(equalTo: shell.centerYAnchor),

--- a/Sources/DownrightApp/Panels/UpdateWindowController.swift
+++ b/Sources/DownrightApp/Panels/UpdateWindowController.swift
@@ -3,9 +3,9 @@ import MarkdownCore
 import MarkdownRender
 
 private enum UpdateWindowLayout {
-    static let width: CGFloat = 560
-    static let regularHeight: CGFloat = 600
-    static let failureHeight: CGFloat = 360
+    static let width: CGFloat = 540
+    static let regularHeight: CGFloat = 480
+    static let failureHeight: CGFloat = 340
     static let minimumHeight: CGFloat = 320
 }
 
@@ -98,18 +98,18 @@ private final class UpdatePanelView: NSView {
         addSubview(footer)
 
         NSLayoutConstraint.activate([
-            header.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 20),
-            header.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -20),
-            header.topAnchor.constraint(equalTo: topAnchor, constant: 16),
+            header.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 22),
+            header.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -22),
+            header.topAnchor.constraint(equalTo: topAnchor, constant: 18),
 
-            contentContainer.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 20),
-            contentContainer.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -20),
-            contentContainer.topAnchor.constraint(equalTo: header.bottomAnchor, constant: 12),
+            contentContainer.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 22),
+            contentContainer.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -22),
+            contentContainer.topAnchor.constraint(equalTo: header.bottomAnchor, constant: 14),
 
-            footer.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 20),
-            footer.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -20),
-            footer.topAnchor.constraint(equalTo: contentContainer.bottomAnchor, constant: 12),
-            footer.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -16),
+            footer.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 22),
+            footer.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -22),
+            footer.topAnchor.constraint(equalTo: contentContainer.bottomAnchor, constant: 14),
+            footer.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -18),
         ])
         refresh()
         viewDidChangeEffectiveAppearance()
@@ -260,100 +260,115 @@ private final class UpdatePanelHeader: NSView {
 
 @MainActor
 private final class UpdatePanelFooter: NSView {
-    private let buttonsStack = NSStackView()
-    private var buttons: [NSButton] = []
+    private let leadingStack = NSStackView()
+    private let trailingStack = NSStackView()
+    private var buttons: [UpdatePanelButton] = []
 
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
-        buttonsStack.translatesAutoresizingMaskIntoConstraints = false
-        buttonsStack.orientation = .horizontal
-        buttonsStack.alignment = .centerY
-        buttonsStack.spacing = 8
-        addSubview(buttonsStack)
+        leadingStack.translatesAutoresizingMaskIntoConstraints = false
+        leadingStack.orientation = .horizontal
+        leadingStack.alignment = .centerY
+        leadingStack.spacing = 10
+
+        trailingStack.translatesAutoresizingMaskIntoConstraints = false
+        trailingStack.orientation = .horizontal
+        trailingStack.alignment = .centerY
+        trailingStack.spacing = 10
+
+        addSubview(leadingStack)
+        addSubview(trailingStack)
+
         NSLayoutConstraint.activate([
-            buttonsStack.trailingAnchor.constraint(equalTo: trailingAnchor),
-            buttonsStack.topAnchor.constraint(equalTo: topAnchor),
-            buttonsStack.bottomAnchor.constraint(equalTo: bottomAnchor),
+            leadingStack.leadingAnchor.constraint(equalTo: leadingAnchor),
+            leadingStack.centerYAnchor.constraint(equalTo: centerYAnchor),
+            leadingStack.topAnchor.constraint(greaterThanOrEqualTo: topAnchor),
+            leadingStack.bottomAnchor.constraint(lessThanOrEqualTo: bottomAnchor),
+
+            trailingStack.trailingAnchor.constraint(equalTo: trailingAnchor),
+            trailingStack.centerYAnchor.constraint(equalTo: centerYAnchor),
+            trailingStack.topAnchor.constraint(greaterThanOrEqualTo: topAnchor),
+            trailingStack.bottomAnchor.constraint(lessThanOrEqualTo: bottomAnchor),
+            trailingStack.leadingAnchor.constraint(greaterThanOrEqualTo: leadingStack.trailingAnchor, constant: 16),
+
+            heightAnchor.constraint(equalToConstant: 34),
         ])
     }
 
     required init?(coder: NSCoder) { fatalError("not supported") }
 
     func apply(sheet: StyleSheet) {
-        for button in buttons { (button as? UpdatePanelButton)?.apply(sheet: sheet) }
+        for button in buttons { button.apply(sheet: sheet) }
     }
 
     func update(coordinator: UpdateCoordinator) {
         for button in buttons {
-            buttonsStack.removeArrangedSubview(button)
+            leadingStack.removeArrangedSubview(button)
+            trailingStack.removeArrangedSubview(button)
             button.removeFromSuperview()
         }
         buttons = []
 
-        func add(title: String, key: String, kind: UpdatePanelButton.Kind = .secondary, action: @escaping () -> Void) {
+        func addLeading(title: String, action: @escaping () -> Void) {
+            let button = UpdatePanelButton(title: title, kind: .secondary) { action() }
+            button.setAccessibilityLabel(title)
+            buttons.append(button)
+            leadingStack.addArrangedSubview(button)
+        }
+
+        func addTrailing(title: String, kind: UpdatePanelButton.Kind = .secondary, action: @escaping () -> Void) {
             let button = UpdatePanelButton(title: title, kind: kind) { action() }
             button.setAccessibilityLabel(title)
             buttons.append(button)
-            if kind == .secondary,
-               buttonsStack.arrangedSubviews.contains(where: { ($0 as? UpdatePanelButton)?.isPrimary == true }) {
-                buttonsStack.insertArrangedSubview(button, at: 0)
-            } else {
-                buttonsStack.addArrangedSubview(button)
-            }
+            trailingStack.addArrangedSubview(button)
         }
 
         switch coordinator.phase {
         case .checking:
-            add(title: "Cancel", key: "xmark", action: { coordinator.userDidCancelCheck() })
+            addTrailing(title: "Cancel", action: { coordinator.userDidCancelCheck() })
         case .idle where coordinator.downloadedUpdate != nil:
-            add(title: "Update & Relaunch", key: "arrow.clockwise.circle.fill", kind: .primary) {
+            addTrailing(title: "Later") { coordinator.userDidChooseLater() }
+            addTrailing(title: "Update & Relaunch", kind: .primary) {
                 coordinator.userDidChooseInstall()
             }
-            add(title: "Later", key: "") { coordinator.userDidChooseLater() }
         case .available(let metadata, let stage):
-            let installTitle = stage == .notDownloaded ? "Update" : "Update & Relaunch"
-            add(title: installTitle, key: "arrow.down.circle.fill", kind: .primary) {
-                coordinator.userDidChooseInstall()
-            }
-            add(title: "Later", key: "") { coordinator.userDidChooseLater() }
             if !metadata.isCritical {
-                add(title: "Skip This Version", key: "") { coordinator.userDidChooseSkip() }
+                addLeading(title: "Skip This Version") { coordinator.userDidChooseSkip() }
+            }
+            addTrailing(title: "Later") { coordinator.userDidChooseLater() }
+            let installTitle = stage == .notDownloaded ? "Update" : "Update & Relaunch"
+            addTrailing(title: installTitle, kind: .primary) {
+                coordinator.userDidChooseInstall()
             }
         case .downloading:
-            add(title: "Cancel Download", key: "xmark") { coordinator.userDidCancelDownload() }
+            addTrailing(title: "Cancel Download") { coordinator.userDidCancelDownload() }
         case .extracting:
             break
         case .readyToRelaunch:
-            add(title: "Update & Relaunch", key: "arrow.clockwise.circle.fill", kind: .primary) {
+            addTrailing(title: "Later") { coordinator.userDidChooseLater() }
+            addTrailing(title: "Update & Relaunch", kind: .primary) {
                 coordinator.userDidChooseInstall()
             }
-            add(title: "Later", key: "") { coordinator.userDidChooseLater() }
         case .waitingForTermination:
-            add(title: "Retry Quit", key: "arrow.clockwise", kind: .primary) {
+            addTrailing(title: "Later") { coordinator.userDidChooseLater() }
+            addTrailing(title: "Retry Quit", kind: .primary) {
                 coordinator.userDidRetryTermination()
             }
-            // Later dismisses the panel; the pending install still happens on
-            // quit (the windowWillClose path discards the retry capability).
-            add(title: "Later", key: "") { coordinator.userDidChooseLater() }
         case .installing:
             break
         case .informational(let metadata):
-            add(title: "Learn More", key: "arrow.up.right.square", kind: .primary) {
+            addLeading(title: "Skip This Version") { coordinator.userDidChooseSkip() }
+            addTrailing(title: "Later") { coordinator.userDidChooseLater() }
+            addTrailing(title: "Learn More", kind: .primary) {
                 coordinator.userDidRequestLearnMore(metadata)
             }
-            add(title: "Later", key: "") { coordinator.userDidChooseLater() }
-            add(title: "Skip This Version", key: "") { coordinator.userDidChooseSkip() }
         case .upToDate:
-            // userDidChooseLater closes the panel (nothing is armed in the
-            // up-to-date state; the acknowledgement was already delivered).
-            add(title: "OK", key: "", kind: .primary) { coordinator.userDidChooseLater() }
+            addTrailing(title: "OK", kind: .primary) { coordinator.userDidChooseLater() }
         case .failed(_, let retryable):
+            addTrailing(title: "Later") { coordinator.userDidChooseLater() }
             if retryable {
-                add(title: "Retry", key: "arrow.clockwise", kind: .primary) { coordinator.userDidRetry() }
+                addTrailing(title: "Retry", kind: .primary) { coordinator.userDidRetry() }
             }
-            // Later closes the panel; closing fires windowWillClose, which
-            // delivers the pending acknowledgement exactly once.
-            add(title: "Later", key: "") { coordinator.userDidChooseLater() }
         case .idle:
             break
         }
@@ -512,12 +527,15 @@ private final class UpdateNotesView: NSView {
         notesCard.layer?.cornerRadius = 10
         notesCard.layer?.cornerCurve = .continuous
         notesCard.layer?.masksToBounds = true
-        notesCard.layer?.backgroundColor = sheet.codeBackground.withAlphaComponent(0.60).cgColor
+        let contrast = sheet.increaseContrast
+        notesCard.layer?.backgroundColor = sheet.text.withAlphaComponent(contrast ? 0.05 : 0.025).cgColor
         notesCard.layer?.borderWidth = 1
-        notesCard.layer?.borderColor = sheet.rule.cgColor
+        notesCard.layer?.borderColor = sheet.rule.withAlphaComponent(contrast ? 0.70 : 0.45).cgColor
+        notesCard.setContentHuggingPriority(.defaultLow, for: .vertical)
+        notesCard.setContentCompressionResistancePriority(.defaultLow, for: .vertical)
         stack.addArrangedSubview(notesCard)
         notesCard.widthAnchor.constraint(equalTo: stack.widthAnchor).isActive = true
-        notesCard.heightAnchor.constraint(greaterThanOrEqualToConstant: 220).isActive = true
+        notesCard.heightAnchor.constraint(greaterThanOrEqualToConstant: 180).isActive = true
 
         let scroll = NSScrollView()
         scroll.translatesAutoresizingMaskIntoConstraints = false
@@ -529,10 +547,10 @@ private final class UpdateNotesView: NSView {
         notesCard.addSubview(scroll)
 
         NSLayoutConstraint.activate([
-            scroll.leadingAnchor.constraint(equalTo: notesCard.leadingAnchor, constant: 6),
-            scroll.trailingAnchor.constraint(equalTo: notesCard.trailingAnchor, constant: -6),
-            scroll.topAnchor.constraint(equalTo: notesCard.topAnchor, constant: 6),
-            scroll.bottomAnchor.constraint(equalTo: notesCard.bottomAnchor, constant: -6),
+            scroll.leadingAnchor.constraint(equalTo: notesCard.leadingAnchor, constant: 8),
+            scroll.trailingAnchor.constraint(equalTo: notesCard.trailingAnchor, constant: -8),
+            scroll.topAnchor.constraint(equalTo: notesCard.topAnchor, constant: 8),
+            scroll.bottomAnchor.constraint(equalTo: notesCard.bottomAnchor, constant: -8),
         ])
 
         switch notesState {
@@ -592,11 +610,11 @@ private final class UpdateNotesView: NSView {
     static func releaseNotesTextView(for data: Data, sheet: StyleSheet) -> NSTextView {
         let sample = String(data: data.prefix(1_024), encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         if sample.hasPrefix("<"),
-           let attributed = try? NSAttributedString(
-               data: data,
-               options: [.documentType: NSAttributedString.DocumentType.html],
-               documentAttributes: nil
-           ) {
+            let attributed = try? NSAttributedString(
+                data: data,
+                options: [.documentType: NSAttributedString.DocumentType.html],
+                documentAttributes: nil
+            ) {
             let textView = NSTextView(frame: .zero)
             textView.textStorage?.setAttributedString(attributed)
             textView.isEditable = false
@@ -946,7 +964,6 @@ private final class UpdateFailureView: NSView {
             )
         }
         copy.setAccessibilityLabel("Copy diagnostics")
-        copy.heightAnchor.constraint(equalToConstant: 28).isActive = true
 
         let diagnosticsActions = NSStackView(views: [detailDisclosure, copy])
         diagnosticsActions.orientation = .horizontal
@@ -1024,9 +1041,15 @@ final class UpdatePanelButton: NSButton {
     private let buttonTitle: String
     var isPrimary: Bool { kind == .primary }
     private var sheet: StyleSheet
-    /// `target` is weak; without a strong reference the action object would
-    /// deallocate the moment the button is created.
     private let actionTarget: ActionTarget
+    private var isHovered = false
+    private var isPressed = false
+
+    override var intrinsicContentSize: NSSize {
+        let textWidth = (attributedTitle.size().width).rounded(.up)
+        let width = max(76, textWidth + 30)
+        return NSSize(width: width, height: 32)
+    }
 
     init(title: String, kind: Kind, sheet: StyleSheet? = nil, action: @escaping () -> Void) {
         self.kind = kind
@@ -1035,19 +1058,30 @@ final class UpdatePanelButton: NSButton {
         let actionTarget = ActionTarget(action)
         self.actionTarget = actionTarget
         super.init(frame: .zero)
-        self.title = title
+        self.title = ""
         setButtonType(.momentaryPushIn)
         isBordered = false
-        font = PanelFont.system(12, weight: .semibold)
-        controlSize = .regular
-        focusRingType = .default
+        focusRingType = .none
         wantsLayer = true
-        layer?.cornerRadius = 8
+        layer?.cornerRadius = 7
         layer?.cornerCurve = .continuous
         layer?.masksToBounds = true
         target = actionTarget
         self.action = #selector(ActionTarget.run(_:))
         setAccessibilityRole(.button)
+        setAccessibilityLabel(title)
+
+        translatesAutoresizingMaskIntoConstraints = false
+        heightAnchor.constraint(equalToConstant: 32).isActive = true
+        widthAnchor.constraint(greaterThanOrEqualToConstant: 76).isActive = true
+
+        addTrackingArea(NSTrackingArea(
+            rect: .zero,
+            options: [.activeInKeyWindow, .mouseEnteredAndExited, .inVisibleRect],
+            owner: self,
+            userInfo: nil
+        ))
+
         apply(sheet: self.sheet)
     }
 
@@ -1057,27 +1091,71 @@ final class UpdatePanelButton: NSButton {
         addCursorRect(bounds, cursor: .pointingHand)
     }
 
+    override func mouseDown(with event: NSEvent) {
+        guard isEnabled else { return }
+        isPressed = true
+        updateVisuals()
+        super.mouseDown(with: event)
+        isPressed = false
+        updateVisuals()
+    }
+
+    override func mouseEntered(with event: NSEvent) {
+        isHovered = true
+        updateVisuals()
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        isHovered = false
+        updateVisuals()
+    }
+
     func apply(sheet: StyleSheet) {
         self.sheet = sheet
+        updateVisuals()
+    }
+
+    private func updateVisuals() {
+        let sheet = self.sheet
+        let contrast = sheet.increaseContrast
+        let isFocused = window?.firstResponder === self && window?.isKeyWindow == true
+
+        let paragraph = NSMutableParagraphStyle()
+        paragraph.alignment = .center
+
         let titleColor: NSColor
         switch kind {
         case .primary:
             titleColor = .white
             contentTintColor = .white
-            layer?.backgroundColor = sheet.startWindowPrimaryAction.cgColor
-            layer?.borderColor = sheet.startWindowPrimaryAction.blended(withFraction: 0.18, of: .white)?.cgColor
+            let base = sheet.startWindowPrimaryAction
+            let fill: NSColor
+            if isPressed {
+                fill = base.blended(withFraction: 0.18, of: .black) ?? base
+            } else if isHovered {
+                fill = base.blended(withFraction: 0.08, of: .white) ?? base
+            } else {
+                fill = base
+            }
+            layer?.backgroundColor = fill.cgColor
+            layer?.borderWidth = isFocused ? 2 : 1
+            layer?.borderColor = (isFocused ? NSColor.white : base.blended(withFraction: 0.20, of: .white))?.withAlphaComponent(isFocused ? 0.9 : 0.4).cgColor
         case .secondary:
             titleColor = sheet.text
             contentTintColor = sheet.text
-            layer?.backgroundColor = sheet.text.withAlphaComponent(sheet.increaseContrast ? 0.12 : 0.06).cgColor
-            layer?.borderColor = sheet.rule.withAlphaComponent(sheet.increaseContrast ? 0.60 : 0.35).cgColor
+            let alpha: CGFloat = isPressed ? 0.14 : (isHovered ? 0.09 : 0.05)
+            layer?.backgroundColor = sheet.text.withAlphaComponent(contrast ? max(alpha, 0.12) : alpha).cgColor
+            layer?.borderWidth = isFocused ? 2 : 1
+            layer?.borderColor = (isFocused ? sheet.accent : sheet.rule)
+                .withAlphaComponent(isFocused ? 0.9 : (contrast ? 0.60 : 0.35)).cgColor
         }
-        layer?.borderWidth = 1
+
         attributedTitle = NSAttributedString(
             string: buttonTitle,
             attributes: [
-                .font: font as Any,
+                .font: PanelFont.system(13, weight: kind == .primary ? .semibold : .medium),
                 .foregroundColor: titleColor,
+                .paragraphStyle: paragraph,
             ]
         )
     }

--- a/Tests/DownrightAppTests/StartWindowTests.swift
+++ b/Tests/DownrightAppTests/StartWindowTests.swift
@@ -495,6 +495,45 @@ struct StartWindowTests {
         #expect(openedURL?.path == first.path)
     }
 
+    @Test
+    func heroStaysStickyAndAnchoredRegardlessOfRecentCount() throws {
+        let emptyController = StartWindowController(recents: [])
+        defer { emptyController.close() }
+        let emptyWindow = try #require(emptyController.window)
+        emptyWindow.contentView?.layoutSubtreeIfNeeded()
+        let emptyOpen = try #require(
+            buttons(in: emptyWindow.contentView).first { $0.accessibilityLabel() == "Open File" }
+        )
+        let emptyOpenFrame = emptyOpen.convert(emptyOpen.bounds, to: nil)
+
+        let oneRecent = RecentDocument(
+            path: "/tmp/single.md",
+            displayName: "single",
+            firstHeading: "Single Doc",
+            lastOpened: Date(),
+            wordCount: 10
+        )
+        let singleController = StartWindowController(recents: [oneRecent])
+        defer { singleController.close() }
+        let singleWindow = try #require(singleController.window)
+        singleWindow.contentView?.layoutSubtreeIfNeeded()
+        let singleOpen = try #require(
+            buttons(in: singleWindow.contentView).first { $0.accessibilityLabel() == "Open File" }
+        )
+        let singleOpenFrame = singleOpen.convert(singleOpen.bounds, to: nil)
+
+        // The top position of the hero actions must remain fixed and sticky regardless of recent file count.
+        #expect(abs(emptyOpenFrame.minY - singleOpenFrame.minY) < 1.0)
+    }
+
+    @Test
+    func keycapBadgesAreCenteredAndSymmetrical() throws {
+        let formatted = KeycapFormatter.format(shortcut: "⌘N", color: .white)
+        #expect(formatted.string == "⌘N")
+        let paragraph = formatted.attribute(.paragraphStyle, at: 0, effectiveRange: nil) as? NSParagraphStyle
+        #expect(paragraph?.alignment == .center)
+    }
+
     private func buttons(in view: NSView?) -> [NSButton] {
         guard let view else { return [] }
         let button = (view as? NSButton).map { [$0] } ?? []


### PR DESCRIPTION
### Summary of changes
- Anchored start window hero actions so they remain top-aligned and sticky regardless of recent items count.
- Refined button visuals, tracking areas, hover/press feedback, and accessibility attributes in update panel and start window.
- Centered and symmetrically formatted keyboard shortcut badges.
- Added tests in `StartWindowTests` ensuring sticky anchoring and keycap formatting behavior.