### PR TITLE
Prepare native distribution and external image loading

### DIFF
--- a/Docs/INTEGRATIONS.md
+++ b/Docs/INTEGRATIONS.md
@@ -1,0 +1,34 @@
+# Integration contracts
+
+## Current stable entry points
+
+- `down FILE` opens a file in Downright.
+- `down open --line N FILE` opens at a one-based line.
+- `down open --reveal FILE` opens Finder and does not require Downright.app.
+- `down open --review FILE` opens Live mode with the local Review panel.
+- `down doctor [--json]` reports installation and integration state without
+  changing it.
+
+## Proposed `downright://` handoff
+
+This is documented as a security contract before it is registered in the app.
+The only proposed operation is:
+
+```text
+downright://open?path=%2Fabsolute%2Fpath%2Fto%2Ffile.md&line=42&review=1
+```
+
+Rules for a future implementation:
+
+1. Accept only the `downright` scheme and `open` host.
+2. Accept only `path`, positive decimal `line`, and `review=1`; reject unknown
+   query keys, fragments, user info, ports, commands, and shell syntax.
+3. Require an absolute file path, canonicalize it, and confirm it is an
+   existing regular Markdown file before opening.
+4. Never execute the URL contents, expand a command, or grant folder access.
+5. Treat the URL as an open request only; it cannot save, export, install,
+   modify settings, or send data.
+6. Register the scheme only after pure parser tests and installed-bundle QA.
+
+The CLI contract is the supported integration today. A URL scheme remains a
+separate, reviewable change because external links are an input boundary.

--- a/Docs/QUICKLOOK.md
+++ b/Docs/QUICKLOOK.md
@@ -44,6 +44,20 @@ qlmanage -r && qlmanage -r cache && killall Finder
 
 Settings → General → System integration repeats every step at any time.
 
+For a read-only terminal diagnosis of an installed bundle, its code-signing
+and Gatekeeper state, CLI aliases, Quick Look registrations, Markdown file
+associations, and Sparkle configuration, run:
+
+```bash
+down doctor
+down doctor --json > downright-doctor.json
+# Development bundle:
+down doctor --app .build-main/bundle/Downright.app --json
+```
+
+The command reports missing setup; it does not repair registrations, change
+the default application, or contact a service.
+
 ## What the preview does
 
 - Read-mode rendering with the app's full typography.

--- a/Docs/marketing/README.md
+++ b/Docs/marketing/README.md
@@ -1,0 +1,14 @@
+# Release and distribution drafts
+
+`Scripts/generate-release-marketing.mjs` turns the current changelog and
+canonical version source into a reviewable `release_marketing.json` draft.
+It is deliberately local and source-backed: it never posts to GitHub, social
+networks, directories, or email services, and it does not add telemetry.
+
+```bash
+node Scripts/generate-release-marketing.mjs --output Docs/marketing/release_marketing.json
+```
+
+Review the generated highlights against the exact signed app before using any
+channel copy. Public release, directory, social, and outreach actions remain
+human/account gates.

--- a/Docs/marketing/release_marketing.json
+++ b/Docs/marketing/release_marketing.json
@@ -1,0 +1,75 @@
+{
+  "schemaVersion": 1,
+  "generatedAt": "2026-08-18T01:16:10.032Z",
+  "source": {
+    "repository": "https://github.com/ezzy1630/Downright",
+    "commit": "92ff9615cd4da8f568a5ece60a027ef6ab580dfd",
+    "sourceDate": "2026-08-17",
+    "changelogSection": "Unreleased"
+  },
+  "release": {
+    "version": "1.0.16 (build 8)",
+    "status": "draft",
+    "title": "Downright 1.0.16",
+    "summary": "First-run setup panel. Downright now installs itself. On first launch it offers to become the default Markdown app and to install the down command line tool, and — with no decis...",
+    "highlights": [
+      {
+        "section": "Added",
+        "item": "First-run setup panel. Downright now installs itself. On first launch it offers to become the default Markdown app and to install the down command line tool, and — with no decision to make — registers its Quick Look extensions with Launch Services and pluginkit and resets Quick Look's caches so existing .md files pick up real Finder icons. Everything here previously lived only in Scripts/install.sh, which runs for people building from source and for nobody else: the shipping path of download the DMG, drag to Applications, double-click performed none of it."
+      },
+      {
+        "section": "Added",
+        "item": "Settings → General → System integration repeats every setup step, names the app currently holding the Markdown association, and opens the Quick Look pane of System Settings for the one switch macOS will not let an app throw."
+      },
+      {
+        "section": "Added",
+        "item": "Recent files say what they are about. Each row carries a second line with the document's first heading, so notes.md reads as \"Agent output\" and a folder of identically-named agent output stops being a column of interchangeable rows. The folder is shown behind it, or alone when there is no heading; neither is repeated when the two would say the same thing."
+      },
+      {
+        "section": "Changed",
+        "item": "The floating Tasks panel's empty state was clipped at the bottom — the card was sized to a fixed minimum taller than its content, and the centered \"Add task\" button rode past the rounded lower edge. The panel now measures the empty chrome's full height (state, gap, button, and the bottom margin) so the card fits the whole thing."
+      },
+      {
+        "section": "Changed",
+        "item": "Finder thumbnails are drawn as pages rather than squares, from a fixed sRGB palette, with task progress shown as a bar. Below 72pt they draw ruled lines instead of text that would only be a smudge at that size."
+      },
+      {
+        "section": "Fixed",
+        "item": "Fixed footnote recovery inside fenced example code. The source scanner no longer ends a fence on an info string ( ruby inside ` ), which used to leak footnote-looking lines out of code blocks."
+      },
+      {
+        "section": "Fixed",
+        "item": "Fixed a main-thread freeze in the image lightbox. Remote (and large local) images now decode off the main thread; a slow server no longer hangs the app inside the click handler."
+      },
+      {
+        "section": "Fixed",
+        "item": "Fixed watcher events after close. A file-watcher event already in flight when its document closed scheduled one more external-write pass on the closed document; and an in-place link hop whose target vanished mid-flight now reopens the previous document instead of leaving a window that no longer tracks external writes."
+      }
+    ]
+  },
+  "channels": {
+    "github": {
+      "title": "Downright 1.0.16 — First-run setup panel. Downright now installs itself. On first launch it offers to become the default Markdown app and to install the down command line tool, and — with no decis...",
+      "body": "Downright 1.0.16 (build 8)\n\nFirst-run setup panel. Downright now installs itself. On first launch it offers to become the default Markdown app and to install the down command line tool, and — with no decis...\n\n- First-run setup panel. Downright now installs itself. On first launch it offers to become the default Markdown app and to install the down command line tool, and — with no decision to make — registers its Quick Look extensions with Launch Services and pluginkit and resets Quick Look's caches so existing .md files pick up real Finder icons. Everything here previously lived only in Scripts/install.sh, which runs for people building from source and for nobody else: the shipping path of download the DMG, drag to Applications, double-click performed none of it.\n- Settings → General → System integration repeats every setup step, names the app currently holding the Markdown association, and opens the Quick Look pane of System Settings for the one switch macOS will not let an app throw.\n- Recent files say what they are about. Each row carries a second line with the document's first heading, so notes.md reads as \"Agent output\" and a folder of identically-named agent output stops being a column of interchangeable rows. The folder is shown behind it, or alone when there is no heading; neither is repeated when the two would say the same thing.\n- The floating Tasks panel's empty state was clipped at the bottom — the card was sized to a fixed minimum taller than its content, and the centered \"Add task\" button rode past the rounded lower edge. The panel now measures the empty chrome's full height (state, gap, button, and the bottom margin) so the card fits the whole thing.\n- Finder thumbnails are drawn as pages rather than squares, from a fixed sRGB palette, with task progress shown as a bar. Below 72pt they draw ruled lines instead of text that would only be a smudge at that size.\n- Fixed footnote recovery inside fenced example code. The source scanner no longer ends a fence on an info string ( ruby inside ` ), which used to leak footnote-looking lines out of code blocks.\n- Fixed a main-thread freeze in the image lightbox. Remote (and large local) images now decode off the main thread; a slow server no longer hangs the app inside the click handler.\n- Fixed watcher events after close. A file-watcher event already in flight when its document closed scheduled one more external-write pass on the closed document; and an in-place link hop whose target vanished mid-flight now reopens the previous document instead of leaving a window that no longer tracks external writes.\n\nDownload: https://downright.cc/download/"
+    },
+    "website": {
+      "heading": "Downright 1.0.16",
+      "excerpt": "First-run setup panel. Downright now installs itself. On first launch it offers to become the default Markdown app and to install the down command line tool, and — with no decis...",
+      "sourceMarkdown": "/releases/1.0.16.md"
+    },
+    "social": {
+      "draft": "Downright 1.0.16: First-run setup panel. Downright now installs itself. On first launch it offers to become the default Markdown app and to install the down command line tool, and — with no decis... Read the source-backed release notes and download the signed macOS build at downright.cc/download/.",
+      "reviewRequired": true
+    }
+  },
+  "measurement": {
+    "downloadMetric": "GitHub Downright.dmg asset requests; not unique people or completed installs",
+    "telemetry": "none",
+    "attribution": "Use tagged links or landing-page referrers only; do not add device identifiers"
+  },
+  "humanReview": [
+    "Confirm every highlighted claim against the shipped app and release artifact.",
+    "Replace the draft download URL only after the signed public artifact is verified.",
+    "Approve channel copy before publication; this script never posts externally."
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -126,14 +126,21 @@ open .build-main/bundle/Downright.app
 
 ```bash
 down PLAN.md                              # open a file
+down open --line 42 --review PLAN.md      # open an agent plan at a line for review
+down open --reveal PLAN.md                # reveal a document in Finder
 printf '# Draft\n' | down                 # open piped Markdown
 down read --json README.md                # inspect without launching the app
 down outline --json README.md             # emit document structure
 down export --format html -o out.html README.md
 down check --target github Docs/sample.md # validate a render target
+down doctor                               # diagnose app, CLI, Quick Look, and updater setup
 ```
 
-`md` is installed as an alias for `down`. Run `down --help` for every command.
+`md` is installed as an alias for `down`. `down doctor --json` emits a
+machine-readable support report without modifying the machine; use
+`down doctor --app path/to/Downright.app` to inspect a development bundle.
+Run
+`down --help` for every command.
 
 ## Keyboard essentials
 

--- a/Scripts/check-homebrew-eligibility.mjs
+++ b/Scripts/check-homebrew-eligibility.mjs
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+
+const repository = process.env.HOMEBREW_REPOSITORY || "ezzy1630/Downright";
+const starsTarget = Number(process.env.HOMEBREW_STARS_TARGET || 75);
+const forksTarget = Number(process.env.HOMEBREW_FORKS_TARGET || 30);
+const watchersTarget = Number(process.env.HOMEBREW_WATCHERS_TARGET || 30);
+const url = `https://api.github.com/repos/${repository}`;
+
+if (process.argv.includes("--help")) {
+  console.log("Usage: node Scripts/check-homebrew-eligibility.mjs [--json]");
+  process.exit(0);
+}
+
+const response = await fetch(url, {
+  headers: { accept: "application/vnd.github+json", "user-agent": "downright-homebrew-readiness" },
+});
+if (!response.ok) throw new Error(`GitHub API returned ${response.status}`);
+const repo = await response.json();
+const result = {
+  repository,
+  observedAt: new Date().toISOString(),
+  publicSignals: {
+    stars: repo.stargazers_count,
+    forks: repo.forks_count,
+    watchers: repo.subscribers_count,
+    openIssues: repo.open_issues_count,
+  },
+  heuristic: {
+    starsTarget,
+    forksTarget,
+    watchersTarget,
+    meetsConfiguredSignals: repo.stargazers_count >= starsTarget && repo.forks_count >= forksTarget && repo.subscribers_count >= watchersTarget,
+    note: "A readiness heuristic is not Homebrew acceptance. Re-check current cask audit rules and independent-interest evidence before opening a PR.",
+  },
+  action: "monitor",
+};
+if (process.argv.includes("--json")) console.log(JSON.stringify(result, null, 2));
+else {
+  console.log(`${repository}: ${result.publicSignals.stars} stars, ${result.publicSignals.forks} forks, ${result.publicSignals.watchers} watchers`);
+  console.log(result.heuristic.meetsConfiguredSignals ? "Configured signal threshold reached; verify current Homebrew rules before submitting." : "Keep building independent public interest; do not submit yet.");
+}

--- a/Scripts/generate-release-marketing.mjs
+++ b/Scripts/generate-release-marketing.mjs
@@ -1,0 +1,159 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url));
+const repositoryRoot = resolve(scriptDirectory, "..");
+const changelogPath = resolve(repositoryRoot, "CHANGELOG.md");
+const versionPath = resolve(repositoryRoot, "Config/version.env");
+
+function optionValue(name) {
+  const index = process.argv.indexOf(name);
+  return index >= 0 ? process.argv[index + 1] : undefined;
+}
+
+function git(args) {
+  try {
+    return execFileSync("git", args, { cwd: repositoryRoot, encoding: "utf8" }).trim();
+  } catch {
+    return "";
+  }
+}
+
+function parseVersion(source) {
+  return Object.fromEntries(
+    source
+      .split("\n")
+      .map((line) => line.match(/^([A-Z_]+)=(.+)$/))
+      .filter(Boolean)
+      .map(([, key, value]) => [key, value])
+  );
+}
+
+function cleanMarkdown(value) {
+  return value
+    .replace(/\*\*(.*?)\*\*/g, "$1")
+    .replace(/`([^`]+)`/g, "$1")
+    .replace(/\[([^\]]+)\]\([^\)]+\)/g, "$1")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function parseChangelog(source) {
+  const releases = [];
+  let release;
+  let section;
+
+  for (const line of source.split("\n")) {
+    const releaseMatch = line.match(/^## \[([^\]]+)\]/);
+    if (releaseMatch) {
+      release = { name: releaseMatch[1], sections: [] };
+      releases.push(release);
+      section = undefined;
+      continue;
+    }
+    const sectionMatch = line.match(/^### (.+)$/);
+    if (sectionMatch && release) {
+      section = { name: sectionMatch[1], items: [] };
+      release.sections.push(section);
+      continue;
+    }
+    const itemMatch = line.match(/^[-*] (.+)$/);
+    if (itemMatch && section) section.items.push(cleanMarkdown(itemMatch[1]));
+    if (/^\s{2,}\S/.test(line) && section?.items.length) {
+      section.items[section.items.length - 1] = cleanMarkdown(
+        `${section.items.at(-1)} ${line.trim()}`
+      );
+    }
+  }
+  return releases;
+}
+
+function score(section, item) {
+  const words = item.toLowerCase();
+  let value = section === "Added" ? 3 : section === "Changed" ? 2 : 1;
+  if (/agent|external|quick look|finder|cli|native|source|review|security|release/.test(words)) value += 2;
+  if (/fixed|hardened|crash|xss|safe|signature/.test(words)) value += 1;
+  return value;
+}
+
+function buildDraft() {
+  const version = parseVersion(readFileSync(versionPath, "utf8"));
+  const release = parseChangelog(readFileSync(changelogPath, "utf8"))[0] ?? { name: "Unreleased", sections: [] };
+  const highlights = release.sections
+    .flatMap((section) => section.items.map((item) => ({ section: section.name, item, score: score(section.name, item) })))
+    .sort((left, right) => right.score - left.score)
+    .slice(0, 8);
+  const versionLabel = `${version.MARKETING_VERSION} (build ${version.CURRENT_PROJECT_VERSION})`;
+  const first = highlights[0]?.item ?? "Native Markdown reading and editing for macOS.";
+  const summary = first.length > 180 ? `${first.slice(0, 177)}...` : first;
+  const commit = git(["rev-parse", "HEAD"]);
+  const sourceDate = git(["show", "-s", "--format=%cs", "HEAD"]) || new Date().toISOString().slice(0, 10);
+
+  return {
+    schemaVersion: 1,
+    generatedAt: new Date().toISOString(),
+    source: {
+      repository: "https://github.com/ezzy1630/Downright",
+      commit,
+      sourceDate,
+      changelogSection: release.name,
+    },
+    release: {
+      version: versionLabel,
+      status: release.name === "Unreleased" ? "draft" : "release",
+      title: `Downright ${version.MARKETING_VERSION}`,
+      summary,
+      highlights: highlights.map(({ section, item }) => ({ section, item })),
+    },
+    channels: {
+      github: {
+        title: `Downright ${version.MARKETING_VERSION} — ${summary}`,
+        body: [
+          `Downright ${versionLabel}`,
+          "",
+          summary,
+          "",
+          ...highlights.map(({ item }) => `- ${item}`),
+          "",
+          "Download: https://downright.cc/download/",
+        ].join("\n"),
+      },
+      website: {
+        heading: `Downright ${version.MARKETING_VERSION}`,
+        excerpt: summary,
+        sourceMarkdown: `/releases/${version.MARKETING_VERSION}.md`,
+      },
+      social: {
+        draft: `Downright ${version.MARKETING_VERSION}: ${summary} Read the source-backed release notes and download the signed macOS build at downright.cc/download/.`,
+        reviewRequired: true,
+      },
+    },
+    measurement: {
+      downloadMetric: "GitHub Downright.dmg asset requests; not unique people or completed installs",
+      telemetry: "none",
+      attribution: "Use tagged links or landing-page referrers only; do not add device identifiers",
+    },
+    humanReview: [
+      "Confirm every highlighted claim against the shipped app and release artifact.",
+      "Replace the draft download URL only after the signed public artifact is verified.",
+      "Approve channel copy before publication; this script never posts externally.",
+    ],
+  };
+}
+
+if (process.argv.includes("--help")) {
+  console.log("Usage: node Scripts/generate-release-marketing.mjs [--output path]");
+  process.exit(0);
+}
+
+const output = JSON.stringify(buildDraft(), null, 2) + "\n";
+const outputPath = optionValue("--output");
+if (outputPath) {
+  writeFileSync(resolve(repositoryRoot, outputPath), output, "utf8");
+} else {
+  process.stdout.write(output);
+}

--- a/Sources/DownrightApp/App/AppDelegate.swift
+++ b/Sources/DownrightApp/App/AppDelegate.swift
@@ -70,6 +70,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private let servicesProvider = DownrightServicesProvider()
     /// Set by `down --edit`; applies to the documents opened in this launch only.
     private var launchMode: RenderMode?
+    /// Set by `down --line`; applies to command-line documents in this launch only.
+    private var launchLine: Int?
+    /// Set by `down --review`; applies to command-line documents in this launch only.
+    private var launchReview = false
     /// Launch Services can deliver an open request between NSApplication's
     /// will-finish and did-finish callbacks. Keep that request alive until the
     /// app has installed its menus, preferences, and first-run surfaces rather
@@ -175,16 +179,26 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     @discardableResult
     private func openCommandLineFiles() -> Bool {
         var opened = 0
-        var arguments = ProcessInfo.processInfo.arguments.dropFirst().makeIterator()
-        while let argument = arguments.next() {
+        let arguments = Array(ProcessInfo.processInfo.arguments.dropFirst())
+        var index = 0
+        while index < arguments.count {
+            let argument = arguments[index]
             // `-NSDocumentRevisionsDebugMode YES` and friends arrive here too.
             if argument.hasPrefix("-") {
-                if argument == "--mode" { _ = arguments.next() }
+                if argument == "--mode" || argument == "--downright-line" {
+                    index += 2
+                } else {
+                    index += 1
+                }
                 continue
             }
             let url = URL(fileURLWithPath: argument).standardizedFileURL
-            guard FileManager.default.fileExists(atPath: url.path) else { continue }
-            if open(url) != nil { opened += 1 }
+            guard FileManager.default.fileExists(atPath: url.path) else {
+                index += 1
+                continue
+            }
+            if open(url, mode: launchMode, line: launchLine, review: launchReview) != nil { opened += 1 }
+            index += 1
         }
         return opened > 0
     }
@@ -227,8 +241,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     private func parseLaunchArguments() {
         let arguments = ProcessInfo.processInfo.arguments
-        guard let index = arguments.firstIndex(of: "--mode"), index + 1 < arguments.count else { return }
-        launchMode = RenderMode(rawValue: arguments[index + 1])
+        if let index = arguments.firstIndex(of: "--mode"), index + 1 < arguments.count {
+            launchMode = RenderMode(rawValue: arguments[index + 1])
+        }
+        if let index = arguments.firstIndex(of: "--downright-line"), index + 1 < arguments.count {
+            launchLine = Int(arguments[index + 1])
+        }
+        launchReview = arguments.contains("--downright-review")
     }
 
     // MARK: - Opening
@@ -271,6 +290,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     func open(
         _ url: URL,
         mode: RenderMode? = nil,
+        line: Int? = nil,
+        review: Bool = false,
         disposition: DocumentOpenDisposition = .tab,
         tabbingWith explicitHost: NSWindow? = nil
     ) -> DocumentWindowController? {
@@ -283,6 +304,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             existing.showWindow(nil)
             existing.window?.makeKeyAndOrderFront(nil)
             dismissStartWindow()
+            existing.applyCommandLineOpen(line: line, review: review)
             return existing
         }
 
@@ -310,6 +332,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             tabHost.addTabbedWindow(window, ordered: .above)
         }
         controller.window?.makeKeyAndOrderFront(nil)
+        controller.applyCommandLineOpen(line: line, review: review)
         return controller
     }
 

--- a/Sources/DownrightApp/App/DocumentWindowController+CommandLine.swift
+++ b/Sources/DownrightApp/App/DocumentWindowController+CommandLine.swift
@@ -1,0 +1,24 @@
+import AppKit
+
+/// Applies navigation requested by `down open` after the document's first
+/// layout pass has installed its source text view.
+@MainActor
+extension DocumentWindowController {
+    func applyCommandLineOpen(line: Int?, review: Bool) {
+        guard line != nil || review else { return }
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            if let line {
+                let text = markdownDocument.text as NSString
+                let lines = text.components(separatedBy: "\n")
+                let targetLine = min(max(1, line) - 1, max(0, lines.count - 1))
+                var offset = 0
+                for index in 0..<targetLine {
+                    offset += lines[index].utf16.count + 1
+                }
+                jump(to: min(offset, text.length), label: "Line \(line)", animated: false)
+            }
+            if review { ensureReviewPanelVisible() }
+        }
+    }
+}

--- a/Sources/DownrightApp/App/DocumentWindowController+Review.swift
+++ b/Sources/DownrightApp/App/DocumentWindowController+Review.swift
@@ -38,6 +38,13 @@ extension DocumentWindowController: ReviewPanelViewDelegate {
         installTrailing(panel, title: Command.reviewPanel.panelTitle)
     }
 
+    /// Command-line review requests are idempotent: reopening an already
+    /// visible panel should leave it visible rather than toggling it closed.
+    func ensureReviewPanelVisible() {
+        guard reviewPanel == nil else { return }
+        showReviewPanel()
+    }
+
     func configureReviewPanel(_ panel: ReviewPanelView) {
         panel.sourceText = markdownDocument.text
         guard let url = markdownDocument.url else {

--- a/Sources/MarkdownRender/Fragments/BoundedImageCache.swift
+++ b/Sources/MarkdownRender/Fragments/BoundedImageCache.swift
@@ -58,6 +58,37 @@ final class BoundedImageCache<Key: Hashable> {
         return image
     }
 
+    /// Pure lookup that never runs the `create` closure.  The draw path must
+    /// only ever see this: `image(for:keyCost:create:)` may perform I/O in
+    /// `create`, and doing that on the main thread is what stalled the app
+    /// when an uncached image scrolled into view.
+    func cached(_ key: Key) -> NSImage? {
+        lock.lock()
+        defer { lock.unlock() }
+        guard var hit = entries[key] else { return nil }
+        stamp &+= 1
+        hit.stamp = stamp
+        entries[key] = hit
+        return hit.image
+    }
+
+    /// Records a value produced off the main thread (e.g. a background
+    /// decode).  Mirrors the admission rules of `image(for:keyCost:create:)`:
+    /// a value too large for the budget is not retained.
+    func store(_ image: NSImage, for key: Key, keyCost: Int = 0) {
+        let cost = Self.cost(of: image) + max(1, keyCost)
+        guard cost <= totalCostLimit else { return }
+        lock.lock()
+        stamp &+= 1
+        if let replaced = entries.updateValue(
+            Entry(image: image, cost: cost, stamp: stamp), forKey: key) {
+            totalCost -= replaced.cost
+        }
+        totalCost += cost
+        trimLocked()
+        lock.unlock()
+    }
+
     func removeAll() {
         lock.lock()
         entries.removeAll(keepingCapacity: true)
@@ -125,26 +156,104 @@ enum MarkdownFragmentImageCaches {
 /// Loads only the pixels needed by the image viewport.  The returned image
 /// keeps the source pixel dimensions as its point size so layout remains
 /// stable even though its decoded representation is downsampled.
+///
+/// Decoding is a background job.  The draw path may only call `cachedImage`,
+/// which is a pure in-memory lookup: the old sync loader ran
+/// `CGImageSourceCreateWithURL` — a full disk read and decode — on the main
+/// thread inside `drawObject`, so the first time an uncached image scrolled
+/// into view the whole app blocked for however long the read took.  On a
+/// large image, a network volume, or an iCloud placeholder that read is
+/// seconds, which is the intermittent beachball.
 final class ImageRenderCache {
     private struct Key: Hashable {
         let url: URL
-        let fileSize: Int64?
-        let modified: Date?
         let maxPixelDimension: Int
     }
 
-    private let cache = BoundedImageCache<Key>(countLimit: 96, totalCostLimit: 32 * 1024 * 1024)
+    /// Disk identity of a cached decode, so a file that changed on disk is
+    /// re-decoded rather than served stale.  Only read by the background
+    /// loader, which is the one place a stat is allowed.
+    private struct Freshness: Hashable {
+        let fileSize: Int64?
+        let modified: Date?
+    }
 
-    func image(for url: URL, maxPixelDimension: Int) -> NSImage? {
-        let values = try? url.resourceValues(forKeys: [.fileSizeKey, .contentModificationDateKey])
-        let key = Key(
-            url: url.standardizedFileURL,
-            fileSize: values?.fileSize.map(Int64.init),
-            modified: values?.contentModificationDate,
-            maxPixelDimension: max(1, maxPixelDimension))
-        return cache.image(for: key, keyCost: url.path.utf8.count) {
-            Self.downsampledImage(at: key.url, maxPixelDimension: key.maxPixelDimension)
+    private let cache = BoundedImageCache<Key>(countLimit: 96, totalCostLimit: 32 * 1024 * 1024)
+    private var freshness: [URL: Freshness] = [:]
+    /// Decodes in flight, keyed by the same identity `cachedImage` looks up,
+    /// so a page of repeated images (or a split view showing one document
+    /// twice) starts one decode instead of one per fragment.  Every caller's
+    /// completion fires when the shared decode lands.
+    private var inFlight: [Key: [(@Sendable @MainActor (NSImage?) -> Void)]] = [:]
+    private let lock = NSLock()
+
+    private func key(for url: URL, maxPixelDimension: Int) -> Key {
+        Key(url: url.standardizedFileURL, maxPixelDimension: max(1, maxPixelDimension))
+    }
+
+    /// Pure cache lookup — never touches the filesystem, so it can never
+    /// stall layout or drawing.  This is the only image access the draw path
+    /// uses; a miss means "schedule an async load", never "read it now".
+    func cachedImage(for url: URL, maxPixelDimension: Int) -> NSImage? {
+        cache.cached(key(for: url, maxPixelDimension: maxPixelDimension))
+    }
+
+    /// Decodes `url` off the main thread, records it in the cache, then calls
+    /// `completion` on the main actor with the result (nil when the file is
+    /// missing or unreadable).  Concurrent requests for the same image share
+    /// one decode.
+    func loadImageAsync(
+        for url: URL,
+        maxPixelDimension: Int,
+        completion: @escaping @Sendable @MainActor (NSImage?) -> Void
+    ) {
+        let key = key(for: url, maxPixelDimension: maxPixelDimension)
+        lock.lock()
+        if var callbacks = inFlight[key] {
+            callbacks.append(completion)
+            inFlight[key] = callbacks
+            lock.unlock()
+            return
         }
+        inFlight[key] = [completion]
+        lock.unlock()
+
+        DispatchQueue.global(qos: .userInitiated).async {
+            let image = self.decodeIfNeeded(for: key)
+            let callbacks: [(@Sendable @MainActor (NSImage?) -> Void)]
+            self.lock.lock()
+            callbacks = self.inFlight.removeValue(forKey: key) ?? []
+            self.lock.unlock()
+            DispatchQueue.main.async {
+                MainActor.assumeIsolated {
+                    for callback in callbacks { callback(image) }
+                }
+            }
+        }
+    }
+
+    /// Runs on the background queue.  Re-decodes when the file is not cached
+    /// yet or changed on disk since it was cached; otherwise returns the
+    /// cached decode (re-decoding only if eviction dropped it).
+    private func decodeIfNeeded(for key: Key) -> NSImage? {
+        let url = key.url
+        let current = Self.freshness(of: url)
+        let cached = cache.cached(key)
+        lock.lock()
+        let changed = freshness[url] != current
+        if changed { freshness[url] = current }
+        lock.unlock()
+        if let cached, !changed { return cached }
+        guard let image = Self.downsampledImage(at: url, maxPixelDimension: key.maxPixelDimension) else {
+            return nil
+        }
+        cache.store(image, for: key, keyCost: url.path.utf8.count)
+        return image
+    }
+
+    private static func freshness(of url: URL) -> Freshness {
+        let values = try? url.resourceValues(forKeys: [.fileSizeKey, .contentModificationDateKey])
+        return Freshness(fileSize: values?.fileSize.map(Int64.init), modified: values?.contentModificationDate)
     }
 
     private static func downsampledImage(at url: URL, maxPixelDimension: Int) -> NSImage? {

--- a/Sources/MarkdownRender/Fragments/ImageFragment.swift
+++ b/Sources/MarkdownRender/Fragments/ImageFragment.swift
@@ -1,6 +1,20 @@
 import AppKit
 import MarkdownCore
 
+/// Lets an image's async-load completion reach its text view without carrying
+/// a non-Sendable reference across the background queue.  The completion runs
+/// on the main actor, where the weak view is valid; the box only exists to
+/// make the handoff honest under strict concurrency.
+private final class ImageLoadCompletionBox: @unchecked Sendable {
+    weak var view: MarkdownTextView?
+    let sourceRange: NSRange
+
+    init(view: MarkdownTextView?, sourceRange: NSRange) {
+        self.view = view
+        self.sourceRange = sourceRange
+    }
+}
+
 /// Images (§11.3): rounded corners, a restrained shadow, alt text as a
 /// caption.  Clicking opens a lightbox, which the view posts through the
 /// delegate rather than presenting itself — the render package owns no windows.
@@ -11,6 +25,9 @@ final class ImageFragment: DownrightFragment {
 
     private enum LoadResult {
         case loaded(NSImage)
+        /// Not in the cache yet; a background decode is in flight and will
+        /// invalidate this fragment's layout when it lands.
+        case loading
         case missing
         case blocked
     }
@@ -50,12 +67,26 @@ final class ImageFragment: DownrightFragment {
                 cg.setLineWidth(1)
                 cg.stroke(rect.insetBy(dx: 0.5, dy: 0.5))
             }
+        } else if case .loading = result {
+            // A quiet placeholder while the background decode runs.  It is
+            // replaced within a frame for a local file; the loader invalidates
+            // this fragment, so the picture lands without the reader watching
+            // the page jump.
+            cg.saveGState()
+            cg.setFillColor(style.codeBackground.withAlphaComponent(0.55).cgColor)
+            cg.addPath(CGPath(
+                roundedRect: rect,
+                cornerWidth: RenderMetrics.imageCornerRadius,
+                cornerHeight: RenderMetrics.imageCornerRadius,
+                transform: nil))
+            cg.fillPath()
+            cg.restoreGState()
         } else {
             // §8.4's trust instrument applied to images: a picture the agent
             // says it wrote and did not is visibly absent, not silently blank.
             let failure: FailedObject = switch result {
             case .blocked: blocked
-            case .missing, .loaded: missing
+            case .missing, .loaded, .loading: missing
             }
             drawFailedObject(failure, in: rect, style: style, in: cg)
         }
@@ -136,10 +167,38 @@ final class ImageFragment: DownrightFragment {
         guard LocalAssetPolicy.allows(
             request, authorizer: context?.localAssetAuthorizer
         ) else { return .blocked }
-        guard let image = MarkdownFragmentImageCaches.images.image(
-            for: request.url, maxPixelDimension: targetPixelDimension
-        ) else { return .missing }
+        let dimension = targetPixelDimension
+        guard let image = MarkdownFragmentImageCaches.images.cachedImage(
+            for: request.url, maxPixelDimension: dimension
+        ) else {
+            // Never read the file here: this runs during draw and layout on
+            // the main thread.  Schedule a background decode and draw a
+            // placeholder until it lands.
+            scheduleAsyncLoad(request.url, dimension: dimension)
+            return .loading
+        }
         return .loaded(image)
+    }
+
+    /// Asks the background loader for this image.  When it arrives the
+    /// fragment's layout is invalidated, so `overrideHeight` re-evaluates to
+    /// the picture's real size and the frame redraws it in place.
+    ///
+    /// The cache dedupes decodes by URL, so repeated misses during a slow
+    /// load share one background read; a failed load is retried on the next
+    /// layout pass because the cache still misses.
+    private func scheduleAsyncLoad(_ url: URL, dimension: Int) {
+        let box = ImageLoadCompletionBox(view: context?.textView, sourceRange: payload.sourceRange)
+        MarkdownFragmentImageCaches.images.loadImageAsync(
+            for: url, maxPixelDimension: dimension
+        ) { _ in
+            // A nil result means the file is missing; the fragment keeps its
+            // placeholder and the next layout pass retries.
+            guard let view = box.view else { return }
+            // `invalidateFragments` re-lays-out the range (so `overrideHeight`
+            // re-evaluates to the picture's real size) and marks it for redraw.
+            view.invalidateFragments(in: box.sourceRange)
+        }
     }
 
     private var viewportHeightCap: CGFloat {

--- a/Sources/down/main.swift
+++ b/Sources/down/main.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import drdownright
 
@@ -109,12 +110,31 @@ func launch(_ paths: [String], options: MarkdownCLI.OpenOptions) -> Int32 {
     if options.background { openArguments.append("-g") }
     if options.wait { openArguments.append("-W") }
     openArguments.append(contentsOf: paths)
-    if options.edit { openArguments.append(contentsOf: ["--args", "--mode", "live"]) }
+    var appArguments: [String] = []
+    if options.edit { appArguments.append(contentsOf: ["--mode", "live"]) }
+    if let line = options.line { appArguments.append(contentsOf: ["--downright-line", String(line)]) }
+    if options.review { appArguments.append("--downright-review") }
+    if !appArguments.isEmpty { openArguments.append(contentsOf: ["--args"] + appArguments) }
     let process = Process()
     process.executableURL = URL(fileURLWithPath: "/usr/bin/open")
     process.arguments = openArguments
     do { try process.run(); process.waitUntilExit(); return process.terminationStatus }
     catch { return 70 }
+}
+
+/// Reveals files in Finder without requiring Downright to be installed.
+@discardableResult
+func reveal(_ paths: [String]) -> Int32 {
+    guard !paths.isEmpty else { return 64 }
+    guard !paths.contains("-") else {
+        writeError("--reveal requires file paths, not stdin", status: 64)
+    }
+    let urls = paths.map { URL(fileURLWithPath: ($0 as NSString).expandingTildeInPath).standardizedFileURL }
+    for url in urls where !FileManager.default.fileExists(atPath: url.path) {
+        writeError("\(url.path): no such file", status: 66)
+    }
+    NSWorkspace.shared.activateFileViewerSelecting(urls)
+    return 0
 }
 
 /// The command an installed hook should run.
@@ -211,7 +231,19 @@ case .outline(let json, let paths):
             }
         }
     }
+case .doctor(let json, let appPath):
+    let report = DownDoctor.run(appPath: appPath)
+    if json {
+        guard let output = try? DownDoctor.json(report) else { writeError("cannot encode doctor report", status: 70) }
+        print(output)
+    } else {
+        print(DownDoctor.humanReadable(report))
+    }
+    exit(report.hasFailures ? 1 : 0)
 case .open(let options, let paths):
+    if options.reveal {
+        exit(reveal(paths))
+    }
     var paths = paths
     if paths.contains("-") {
         guard let piped = stdinFile() else { writeError("stdin is not available", status: 66) }

--- a/Sources/drdownright/Doctor.swift
+++ b/Sources/drdownright/Doctor.swift
@@ -1,0 +1,303 @@
+import AppKit
+import Foundation
+import UniformTypeIdentifiers
+
+/// A diagnostic result that is safe to print in a terminal or serialize for a
+/// support report. The doctor never repairs the machine; it only reports what
+/// is installed and which integration contract is missing.
+public enum DoctorStatus: String, Codable, Sendable {
+    case pass
+    case warning
+    case failure
+    case unavailable
+}
+
+public struct DoctorCheck: Codable, Equatable, Sendable {
+    public let id: String
+    public let status: DoctorStatus
+    public let message: String
+    public let details: [String]
+
+    public init(id: String, status: DoctorStatus, message: String, details: [String] = []) {
+        self.id = id
+        self.status = status
+        self.message = message
+        self.details = details
+    }
+}
+
+public struct DoctorReport: Codable, Equatable, Sendable {
+    public let appPath: String?
+    public let version: String?
+    public let checks: [DoctorCheck]
+
+    public var hasFailures: Bool {
+        checks.contains { $0.status == .failure }
+    }
+
+    public init(appPath: String?, version: String?, checks: [DoctorCheck]) {
+        self.appPath = appPath
+        self.version = version
+        self.checks = checks
+    }
+}
+
+public enum DownDoctor {
+    private struct CommandResult {
+        let status: Int32
+        let output: String
+    }
+
+    private static let appName = "Downright.app"
+    private static let bundleIdentifier = "com.ezzy.downright"
+    private static let previewIdentifier = "com.ezzy.downright.quicklook"
+    private static let thumbnailIdentifier = "com.ezzy.downright.thumbnail"
+    private static let markdownExtensions = ["md", "markdown", "mdown", "mkd", "mdx", "mdc", "qmd", "rmd"]
+    private static let commandDirectories = [
+        "/usr/local/bin",
+        "/opt/homebrew/bin",
+        FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".local/bin").path,
+    ]
+
+    /// Runs every diagnostic without making a repair or asking for a password.
+    public static func run(appPath: String? = nil) -> DoctorReport {
+        let app = resolveApp(explicitPath: appPath)
+        guard let app else {
+            return DoctorReport(
+                appPath: nil,
+                version: nil,
+                checks: [DoctorCheck(
+                    id: "installed-app",
+                    status: .failure,
+                    message: "Downright.app was not found in /Applications, ~/Applications, or the current bundle.",
+                    details: ["Install the signed app, then run down doctor again."]
+                )]
+            )
+        }
+
+        let info = infoDictionary(for: app)
+        let version = info?["CFBundleShortVersionString"] as? String
+        var checks: [DoctorCheck] = []
+
+        checks.append(DoctorCheck(
+            id: "installed-app",
+            status: .pass,
+            message: "Found \(app.path)",
+            details: version.map { ["Version \($0)"] } ?? []
+        ))
+        checks.append(bundleCheck(app: app, info: info))
+        checks.append(applicationLocationCheck(app: app))
+        checks.append(signatureCheck(app: app))
+        checks.append(gatekeeperCheck(app: app))
+        checks.append(notarizationCheck(app: app))
+        checks.append(commandLineCheck(app: app))
+        checks.append(pluginCheck(app: app, name: "Quick Look preview", identifier: previewIdentifier, bundleName: "DownrightQL.appex"))
+        checks.append(pluginCheck(app: app, name: "Finder thumbnail", identifier: thumbnailIdentifier, bundleName: "DownrightThumb.appex"))
+        checks.append(defaultAssociationCheck(app: app))
+        checks.append(utiCheck(info: info))
+        checks.append(updateChannelCheck(info: info))
+
+        return DoctorReport(appPath: app.path, version: version, checks: checks)
+    }
+
+    public static func json(_ report: DoctorReport) throws -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        return String(decoding: try encoder.encode(report), as: UTF8.self)
+    }
+
+    public static func humanReadable(_ report: DoctorReport) -> String {
+        var lines = ["Downright doctor"]
+        if let appPath = report.appPath { lines.append("App: \(appPath)") }
+        if let version = report.version { lines.append("Version: \(version)") }
+        lines.append("")
+        for check in report.checks {
+            lines.append("[\(check.status.label)] \(check.id): \(check.message)")
+            lines.append(contentsOf: check.details.map { "  - \($0)" })
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    /// Kept public so the parser semantics can be pinned without invoking
+    /// LaunchServices or pluginkit in a test process.
+    public static func pluginIsEnabled(listing: String, identifier: String) -> Bool {
+        guard let line = listing.split(separator: "\n").first(where: { $0.contains(identifier) }) else {
+            return false
+        }
+        return !line.trimmingCharacters(in: .whitespaces).hasPrefix("-")
+    }
+
+    private static func resolveApp(explicitPath: String?) -> URL? {
+        let currentBundle = URL(fileURLWithPath: CommandLine.arguments.first ?? "")
+            .standardizedFileURL
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let candidates = [
+            explicitPath.map { URL(fileURLWithPath: ($0 as NSString).expandingTildeInPath) },
+            URL(fileURLWithPath: "/Applications/\(appName)"),
+            FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent("Applications/\(appName)"),
+            currentBundle.pathExtension == "app" ? currentBundle : nil,
+        ].compactMap { $0 }
+        return candidates.first { FileManager.default.fileExists(atPath: $0.path) }
+    }
+
+    private static func infoDictionary(for app: URL) -> [String: Any]? {
+        let infoURL = app.appendingPathComponent("Contents/Info.plist")
+        guard let data = try? Data(contentsOf: infoURL),
+              let object = try? PropertyListSerialization.propertyList(from: data, format: nil),
+              let info = object as? [String: Any] else {
+            return nil
+        }
+        return info
+    }
+
+    private static func bundleCheck(app: URL, info: [String: Any]?) -> DoctorCheck {
+        guard let info else {
+            return DoctorCheck(id: "bundle", status: .failure, message: "Info.plist could not be read.")
+        }
+        let identifier = info["CFBundleIdentifier"] as? String
+        let executable = app.appendingPathComponent("Contents/MacOS/Downright")
+        guard identifier == bundleIdentifier else {
+            return DoctorCheck(id: "bundle", status: .failure, message: "Bundle identifier is \(identifier ?? "missing"), expected \(bundleIdentifier).")
+        }
+        guard FileManager.default.isExecutableFile(atPath: executable.path) else {
+            return DoctorCheck(id: "bundle", status: .failure, message: "The host executable is missing or not executable.")
+        }
+        return DoctorCheck(id: "bundle", status: .pass, message: "Bundle identity and host executable are present.")
+    }
+
+    private static func applicationLocationCheck(app: URL) -> DoctorCheck {
+        let path = app.resolvingSymlinksInPath().path
+        let homeApplications = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent("Applications").path + "/"
+        if path.hasPrefix("/Applications/") || path.hasPrefix(homeApplications) {
+            return DoctorCheck(id: "application-location", status: .pass, message: "Bundle is in an Applications folder.")
+        }
+        if path.contains("/AppTranslocation/") {
+            return DoctorCheck(id: "application-location", status: .failure, message: "Bundle is running from App Translocation; Quick Look and CLI registration will not persist.", details: ["Move Downright.app to /Applications and run doctor again."])
+        }
+        return DoctorCheck(id: "application-location", status: .warning, message: "Bundle is outside an Applications folder.", details: ["A development bundle can work, but system integrations may not register permanently."])
+    }
+
+    private static func signatureCheck(app: URL) -> DoctorCheck {
+        guard let result = run("/usr/bin/codesign", ["--verify", "--deep", "--strict", "--verbose=2", app.path]) else {
+            return DoctorCheck(id: "code-signature", status: .unavailable, message: "codesign is not available on this machine.")
+        }
+        return result.status == 0
+            ? DoctorCheck(id: "code-signature", status: .pass, message: "Code signature verifies.")
+            : DoctorCheck(id: "code-signature", status: .failure, message: "Code signature verification failed.", details: [result.output.trimmingCharacters(in: .whitespacesAndNewlines)].filter { !$0.isEmpty })
+    }
+
+    private static func gatekeeperCheck(app: URL) -> DoctorCheck {
+        guard let result = run("/usr/sbin/spctl", ["--assess", "--type", "execute", "--verbose=4", app.path]) else {
+            return DoctorCheck(id: "gatekeeper", status: .unavailable, message: "spctl is not available on this machine.")
+        }
+        return result.status == 0
+            ? DoctorCheck(id: "gatekeeper", status: .pass, message: "Gatekeeper accepts the app.")
+            : DoctorCheck(id: "gatekeeper", status: .warning, message: "Gatekeeper did not accept this bundle.", details: [result.output.trimmingCharacters(in: .whitespacesAndNewlines)].filter { !$0.isEmpty })
+    }
+
+    private static func notarizationCheck(app: URL) -> DoctorCheck {
+        guard let result = run("/usr/bin/xcrun", ["stapler", "validate", app.path]) else {
+            return DoctorCheck(id: "notarization", status: .unavailable, message: "xcrun stapler is not available on this machine.")
+        }
+        return result.status == 0
+            ? DoctorCheck(id: "notarization", status: .pass, message: "Notarization ticket validates.")
+            : DoctorCheck(id: "notarization", status: .warning, message: "No valid stapled notarization ticket was found.", details: ["This is expected for an unsigned development bundle.", result.output.trimmingCharacters(in: .whitespacesAndNewlines)].filter { !$0.isEmpty })
+    }
+
+    private static func commandLineCheck(app: URL) -> DoctorCheck {
+        let expected = app.appendingPathComponent("Contents/MacOS/down").resolvingSymlinksInPath().path
+        var matches: [String] = []
+        var foreign: [String] = []
+        for directory in commandDirectories {
+            for name in ["down", "md"] {
+                let link = URL(fileURLWithPath: directory).appendingPathComponent(name)
+                guard let destination = try? FileManager.default.destinationOfSymbolicLink(atPath: link.path) else { continue }
+                let resolved = URL(fileURLWithPath: destination, relativeTo: link.deletingLastPathComponent())
+                    .resolvingSymlinksInPath().path
+                if resolved == expected { matches.append(link.path) } else { foreign.append(link.path) }
+            }
+        }
+        if matches.isEmpty {
+            return DoctorCheck(id: "cli-path", status: .warning, message: "No down/md alias points to this app.", details: foreign.map { "Foreign or stale alias: \($0)" } + ["Install the CLI from Downright's setup panel to repair it."])
+        }
+        return DoctorCheck(id: "cli-path", status: .pass, message: "CLI aliases point to this app.", details: matches)
+    }
+
+    private static func pluginCheck(app: URL, name: String, identifier: String, bundleName: String) -> DoctorCheck {
+        let path = app.appendingPathComponent("Contents/PlugIns/\(bundleName)")
+        guard FileManager.default.fileExists(atPath: path.path) else {
+            return DoctorCheck(id: identifier, status: .warning, message: "\(name) extension is not bundled.", details: ["The SwiftPM development bundle cannot provide the .appex integration."])
+        }
+        guard let result = run("/usr/bin/pluginkit", ["-m", "-v", "-i", identifier]) else {
+            return DoctorCheck(id: identifier, status: .unavailable, message: "pluginkit is not available on this machine.")
+        }
+        guard pluginIsEnabled(listing: result.output, identifier: identifier) else {
+            return DoctorCheck(id: identifier, status: .warning, message: "\(name) is bundled but not enabled by pluginkit.", details: ["Run the app's setup integration or reopen the signed app in /Applications."])
+        }
+        return DoctorCheck(id: identifier, status: .pass, message: "\(name) is bundled and enabled.")
+    }
+
+    private static func defaultAssociationCheck(app: URL) -> DoctorCheck {
+        guard let markdown = UTType(filenameExtension: "md"),
+              let handler = NSWorkspace.shared.urlForApplication(toOpen: markdown) else {
+            return DoctorCheck(id: "default-markdown-app", status: .warning, message: "macOS has no default application for .md files.")
+        }
+        let expected = app.resolvingSymlinksInPath().standardizedFileURL
+        let actual = handler.resolvingSymlinksInPath().standardizedFileURL
+        if actual == expected {
+            return DoctorCheck(id: "default-markdown-app", status: .pass, message: "Downright is the default .md application.")
+        }
+        return DoctorCheck(id: "default-markdown-app", status: .warning, message: "macOS currently opens .md files with \(handler.lastPathComponent).", details: ["The app still supports Open With; choose Downright if you want it as the default."])
+    }
+
+    private static func utiCheck(info: [String: Any]?) -> DoctorCheck {
+        let documentTypes = info?["CFBundleDocumentTypes"] as? [[String: Any]] ?? []
+        let extensions = Set(documentTypes
+            .flatMap { $0["CFBundleTypeExtensions"] as? [String] ?? [] }
+            .map { $0.lowercased() })
+        let missing = markdownExtensions.filter { !extensions.contains($0) }
+        if missing.isEmpty {
+            return DoctorCheck(id: "markdown-types", status: .pass, message: "All advertised Markdown extensions are declared.", details: markdownExtensions.map { ".\($0)" })
+        }
+        return DoctorCheck(id: "markdown-types", status: .failure, message: "Bundle document types are missing advertised extensions.", details: missing.map { ".\($0)" })
+    }
+
+    private static func updateChannelCheck(info: [String: Any]?) -> DoctorCheck {
+        let feed = info?["SUFeedURL"] as? String
+        let key = info?["SUPublicEDKey"] as? String
+        guard let feed, !feed.isEmpty else {
+            return DoctorCheck(id: "update-channel", status: .warning, message: "Sparkle update feed is not configured in this bundle.")
+        }
+        guard let key, !key.isEmpty, !key.contains("PLACEHOLDER") else {
+            return DoctorCheck(id: "update-channel", status: .warning, message: "Sparkle feed exists but its EdDSA public key is still a placeholder.", details: [feed])
+        }
+        return DoctorCheck(id: "update-channel", status: .pass, message: "Sparkle feed and public key are configured.", details: [feed])
+    }
+
+    private static func run(_ launchPath: String, _ arguments: [String]) -> CommandResult? {
+        guard FileManager.default.isExecutableFile(atPath: launchPath) else { return nil }
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: launchPath)
+        process.arguments = arguments
+        let output = Pipe()
+        process.standardOutput = output
+        process.standardError = output
+        guard (try? process.run()) != nil else { return nil }
+        let data = output.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        return CommandResult(status: process.terminationStatus, output: String(decoding: data, as: UTF8.self))
+    }
+}
+
+private extension DoctorStatus {
+    var label: String {
+        switch self {
+        case .pass: return "PASS"
+        case .warning: return "WARN"
+        case .failure: return "FAIL"
+        case .unavailable: return "N/A"
+        }
+    }
+}

--- a/Sources/drdownright/MarkdownCLI.swift
+++ b/Sources/drdownright/MarkdownCLI.swift
@@ -38,6 +38,7 @@ public enum MarkdownCLI {
         case export(format: ExportFormat, output: String?, paths: [String])
         case check(json: Bool, target: BuiltInRenderTarget?, paths: [String])
         case outline(json: Bool, paths: [String])
+        case doctor(json: Bool, appPath: String?)
         case notify(NotifyOptions)
         case watch(WatchOptions, paths: [String])
         case hook(HookOptions)
@@ -50,6 +51,9 @@ public enum MarkdownCLI {
         public var background = false
         public var wait = false
         public var edit = false
+        public var line: Int? = nil
+        public var reveal = false
+        public var review = false
 
         public init() {}
     }
@@ -103,6 +107,7 @@ public enum MarkdownCLI {
         case unknownOption(String)
         case missingValue(String)
         case invalidFormat(String)
+        case invalidLine(String)
         case unexpectedArgument(String)
 
         public var description: String {
@@ -110,6 +115,7 @@ public enum MarkdownCLI {
             case .unknownOption(let value): return "unknown option \(value)"
             case .missingValue(let value): return "missing value for \(value)"
             case .invalidFormat(let value): return "unsupported export format \(value)"
+            case .invalidLine(let value): return "line must be a positive integer, got \(value)"
             case .unexpectedArgument(let value): return "unexpected argument \(value)"
             }
         }
@@ -125,6 +131,7 @@ public enum MarkdownCLI {
         case "export": return try parseExport(Array(arguments.dropFirst()))
         case "check": return try parseCheck(Array(arguments.dropFirst()))
         case "outline": return try parseOutline(Array(arguments.dropFirst()))
+        case "doctor": return try parseDoctor(Array(arguments.dropFirst()))
         case "open": return try parseOpen(Array(arguments.dropFirst()))
         case "notify": return try parseNotify(Array(arguments.dropFirst()))
         case "watch": return try parseWatch(Array(arguments.dropFirst()))
@@ -143,6 +150,7 @@ public enum MarkdownCLI {
           down export [--format html] [-o path] [file ...]
           down check [--json] [--target name] [file or folder ...]
           down outline [--json] [file ...]
+          down doctor [--json] [--app path]
           down notify [--focus] [--dry-run]
           down watch [--focus] [--debounce ms] [file or folder ...]
           down hook [--print | --install | --uninstall] [--scope user|project]
@@ -169,6 +177,9 @@ public enum MarkdownCLI {
           -b, --background  do not bring Downright to the front
           -w, --wait        wait for the app to exit
           -e, --edit        open in Live mode instead of Read mode
+          --line N          open at one-based line N
+          --reveal          reveal the file in Finder instead of opening it
+          --review          open in Live mode with the Review panel visible
           -h, --help        show this message
           -v, --version     show the version
 
@@ -187,31 +198,59 @@ public enum MarkdownCLI {
     private static func parseOpen(_ arguments: [String]) throws -> Action {
         var options = OpenOptions()
         var paths: [String] = []
-        var parsingOptions = true
-        for argument in arguments {
-            if parsingOptions, argument == "--" {
-                parsingOptions = false
+        var index = 0
+        while index < arguments.count {
+            let argument = arguments[index]
+            switch argument {
+            case "--":
+                paths.append(contentsOf: arguments[(index + 1)...])
+                index = arguments.count
                 continue
-            }
-            if parsingOptions {
-                switch argument {
-                case "-n", "--new": options.newWindow = true
-                case "-b", "--background": options.background = true
-                case "-w", "--wait": options.wait = true
-                case "-e", "--edit": options.edit = true
-                case "-h", "--help": return .help
-                case "-v", "--version": return .version
-                default:
-                    if argument.hasPrefix("-") && argument.count > 1 {
-                        throw ParseError.unknownOption(argument)
-                    }
-                    paths.append(argument)
+            case "-n", "--new": options.newWindow = true
+            case "-b", "--background": options.background = true
+            case "-w", "--wait": options.wait = true
+            case "-e", "--edit": options.edit = true
+            case "--line":
+                index += 1
+                guard index < arguments.count else { throw ParseError.missingValue(argument) }
+                let value = arguments[index]
+                guard let line = Int(value), line > 0 else {
+                    throw ParseError.invalidLine(value)
                 }
-            } else {
+                options.line = line
+            case "--reveal": options.reveal = true
+            case "--review": options.review = true; options.edit = true
+            case "-h", "--help": return .help
+            case "-v", "--version": return .version
+            default:
+                if argument.hasPrefix("-") && argument.count > 1 {
+                    throw ParseError.unknownOption(argument)
+                }
                 paths.append(argument)
             }
+            index += 1
         }
         return .open(options, paths: paths)
+    }
+
+    private static func parseDoctor(_ arguments: [String]) throws -> Action {
+        var json = false
+        var appPath: String?
+        var index = 0
+        while index < arguments.count {
+            switch arguments[index] {
+            case "--json": json = true
+            case "--app":
+                index += 1
+                guard index < arguments.count else { throw ParseError.missingValue("--app") }
+                appPath = arguments[index]
+            case "-h", "--help": return .help
+            case "-v", "--version": return .version
+            default: throw ParseError.unknownOption(arguments[index])
+            }
+            index += 1
+        }
+        return .doctor(json: json, appPath: appPath)
     }
 
     private static func parseRead(_ arguments: [String]) throws -> Action {

--- a/Tests/MarkdownCLITests/ExternalWriteTortureTests.swift
+++ b/Tests/MarkdownCLITests/ExternalWriteTortureTests.swift
@@ -1,0 +1,61 @@
+import Foundation
+import Testing
+
+/// Exercises the write shapes used by editors and coding agents without
+/// depending on a running app or a particular file-watcher implementation.
+/// The app-level watcher tests consume the same guarantees: complete bytes,
+/// atomic replacement, and the newest write winning after a burst.
+struct ExternalWriteTortureTests {
+    @Test func atomicRenameNeverExposesAStagingFileAsTheDocument() throws {
+        let root = try makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let document = root.appendingPathComponent("plan.md")
+        let staging = root.appendingPathComponent(".plan.md.tmp")
+        let expected = "# Agent plan\n\n- [ ] Review the changed section\n"
+
+        try Data(expected.utf8).write(to: staging)
+        try FileManager.default.moveItem(at: staging, to: document)
+
+        #expect(FileManager.default.fileExists(atPath: document.path))
+        #expect(!FileManager.default.fileExists(atPath: staging.path))
+        #expect(try String(contentsOf: document, encoding: .utf8) == expected)
+    }
+
+    @Test func rapidAtomicRewritesLeaveTheLastCompleteDocument() throws {
+        let root = try makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let document = root.appendingPathComponent("notes.md")
+
+        for revision in 0..<40 {
+            let staging = root.appendingPathComponent(".notes-\(revision).tmp")
+            let content = "# Revision \(revision)\n\nagent-write-\(revision) ✅\n"
+            try Data(content.utf8).write(to: staging)
+            if FileManager.default.fileExists(atPath: document.path) {
+                try FileManager.default.removeItem(at: document)
+            }
+            try FileManager.default.moveItem(at: staging, to: document)
+        }
+
+        #expect(try String(contentsOf: document, encoding: .utf8) == "# Revision 39\n\nagent-write-39 ✅\n")
+        let leftovers = try FileManager.default.contentsOfDirectory(atPath: root.path)
+            .filter { $0.hasSuffix(".tmp") }
+        #expect(leftovers.isEmpty)
+    }
+
+    @Test func rewritePreservesUtf8AndIntentionalLineEndings() throws {
+        let root = try makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let document = root.appendingPathComponent("mixed.md")
+        let expected = "# Café\r\n\r\n- [x] shipped\n- [ ] next — 日本語\r\n"
+
+        try Data(expected.utf8).write(to: document, options: .atomic)
+        #expect(try Data(contentsOf: document) == Data(expected.utf8))
+    }
+
+    private func makeRoot() throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("down-external-write-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        return root
+    }
+}

--- a/Tests/MarkdownCLITests/MarkdownCLITests.swift
+++ b/Tests/MarkdownCLITests/MarkdownCLITests.swift
@@ -15,6 +15,19 @@ struct MarkdownCLITests {
             == .check(json: true, target: .gitHub, paths: ["doc.md"]))
         #expect(try MarkdownCLI.parse(["outline", "--json", "doc.md"])
             == .outline(json: true, paths: ["doc.md"]))
+
+        var openOptions = MarkdownCLI.OpenOptions()
+        openOptions.line = 42
+        openOptions.review = true
+        openOptions.edit = true
+        #expect(try MarkdownCLI.parse(["open", "--line", "42", "--review", "doc.md"])
+            == .open(openOptions, paths: ["doc.md"]))
+        var revealOptions = MarkdownCLI.OpenOptions()
+        revealOptions.reveal = true
+        #expect(try MarkdownCLI.parse(["open", "--reveal", "doc.md"])
+            == .open(revealOptions, paths: ["doc.md"]))
+        #expect(try MarkdownCLI.parse(["doctor", "--json"]) == .doctor(json: true, appPath: nil))
+        #expect(try MarkdownCLI.parse(["doctor", "--app", "/tmp/Downright.app"]) == .doctor(json: false, appPath: "/tmp/Downright.app"))
     }
 
     @Test func badArgumentsHaveActionableErrors() {
@@ -23,6 +36,15 @@ struct MarkdownCLITests {
         }
         #expect(throws: MarkdownCLI.ParseError.missingValue("-o")) {
             try MarkdownCLI.parse(["export", "-o"])
+        }
+        #expect(throws: MarkdownCLI.ParseError.missingValue("--line")) {
+            try MarkdownCLI.parse(["open", "--line"])
+        }
+        #expect(throws: MarkdownCLI.ParseError.invalidLine("0")) {
+            try MarkdownCLI.parse(["open", "--line", "0"])
+        }
+        #expect(throws: MarkdownCLI.ParseError.missingValue("--app")) {
+            try MarkdownCLI.parse(["doctor", "--app"])
         }
     }
 
@@ -175,6 +197,21 @@ struct MarkdownCLITests {
         #expect(MarkdownCLI.compatibilityDiagnostics(for: markdown, target: .commonMark)
             .contains { $0.capability == .footnotes })
         #expect(MarkdownCLI.renderTarget(named: "CommonMark") == .commonMark)
+    }
+
+    @Test func doctorPluginParsingOnlyAcceptsOurEnabledRegistration() {
+        #expect(DownDoctor.pluginIsEnabled(
+            listing: "+ com.ezzy.downright.quicklook(1.0)\n- com.other.quicklook(1.0)",
+            identifier: "com.ezzy.downright.quicklook"
+        ))
+        #expect(!DownDoctor.pluginIsEnabled(
+            listing: "- com.ezzy.downright.quicklook(1.0)",
+            identifier: "com.ezzy.downright.quicklook"
+        ))
+        #expect(!DownDoctor.pluginIsEnabled(
+            listing: "+ com.other.quicklook(1.0)",
+            identifier: "com.ezzy.downright.quicklook"
+        ))
     }
 
     @Test func folderCheckSkipsBuildTrees() throws {

--- a/Tests/MarkdownRenderTests/BoundedImageCacheTests.swift
+++ b/Tests/MarkdownRenderTests/BoundedImageCacheTests.swift
@@ -5,6 +5,29 @@ import Testing
 
 @Suite("Bounded fragment image caches")
 struct BoundedImageCacheTests {
+    /// Writes a tiny real PNG and returns its URL, or records a failure.
+    private func makeTestImage() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("downright-image-cache-\(UUID().uuidString).png")
+        let image = NSImage(size: NSSize(width: 4, height: 4))
+        image.lockFocus()
+        NSColor.white.setFill()
+        NSRect(x: 0, y: 0, width: 4, height: 4).fill()
+        image.unlockFocus()
+        guard let tiff = image.tiffRepresentation,
+              let rep = NSBitmapImageRep(data: tiff),
+              let png = rep.representation(using: .png, properties: [:]) else {
+            throw CocoaError(.fileWriteUnknown)
+        }
+        try png.write(to: url)
+        return url
+    }
+
+    /// Main-actor-collected results for the async loader tests.  The
+    /// completions are `@Sendable`, so the collector has to be Sendable too.
+    private final class AsyncResults: @unchecked Sendable {
+        var values: [NSImage?] = []
+    }
     @Test("count and cost limits evict retained values")
     func limitsAreEnforced() {
         let cache = BoundedImageCache<String>(countLimit: 2, totalCostLimit: 8 * 1024)
@@ -46,5 +69,52 @@ struct BoundedImageCacheTests {
         }
         #expect(cache.countForTesting == beforeNil)
         #expect(builds == 5)
+    }
+
+    @Test("cached lookup is a pure miss and the async loader fills it")
+    func asyncLoadPopulatesCache() async throws {
+        let url = try makeTestImage()
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let cache = ImageRenderCache()
+        // The draw path's lookup must be a pure miss — no decode, no I/O.
+        #expect(cache.cachedImage(for: url, maxPixelDimension: 16) == nil)
+
+        let loaded = await withCheckedContinuation { continuation in
+            cache.loadImageAsync(for: url, maxPixelDimension: 16) { image in
+                continuation.resume(returning: image)
+            }
+        }
+        #expect(loaded != nil)
+        // The decode is now cached under the same identity the draw path uses.
+        #expect(cache.cachedImage(for: url, maxPixelDimension: 16) != nil)
+    }
+
+    @Test("concurrent requests for one image share the load and both complete")
+    func concurrentLoadsBothComplete() async throws {
+        let url = try makeTestImage()
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let cache = ImageRenderCache()
+        let results = await withCheckedContinuation { continuation in
+            let collected = AsyncResults()
+            let gate = DispatchGroup()
+            func request() {
+                gate.enter()
+                cache.loadImageAsync(for: url, maxPixelDimension: 16) { image in
+                    collected.values.append(image)
+                    gate.leave()
+                }
+            }
+            // Enter before scheduling so a fast decode can never leave the
+            // group under zero.
+            request()
+            request()
+            gate.notify(queue: .main) {
+                continuation.resume(returning: collected.values)
+            }
+        }
+        #expect(results.count == 2)
+        #expect(results.allSatisfy { $0 != nil })
     }
 }


### PR DESCRIPTION
## What changed

- Add read-only `down doctor` diagnostics for app identity, signing, Gatekeeper, CLI aliases, Quick Look, file associations, and Sparkle.
- Add `down open --line`, `--review`, and `--reveal` integration paths.
- Move uncached Markdown image decoding off the draw/layout path and deduplicate background loads.
- Add external-write and image-cache coverage.
- Add integration, Quick Look, release-marketing, and Homebrew-readiness documentation/scripts.

## Why

Downright needs a diagnosable native install and a safe workflow for reviewing files changed by agents or other processes. Image decoding must not block the main thread when uncached content scrolls into view.

## Validation

- `Scripts/check.sh`
- 1,017 tests across 86 suites
- Version, Sparkle scope, theme contrast, and benchmark checks
