### PR TITLE
Render external rewrites wholesale

### DIFF
--- a/Sources/DownrightApp/AI/MarkdownDocument.swift
+++ b/Sources/DownrightApp/AI/MarkdownDocument.swift
@@ -636,9 +636,9 @@ final class MarkdownDocument: NSObject {
         startAsyncReparse()
     }
 
-    func reparseNow() {
+    func reparseNow(wholesale: Bool = false) {
         reparseScheduled = false
-        reparseSynchronously(notifying: true, wholesale: false)
+        reparseSynchronously(notifying: true, wholesale: wholesale)
     }
 
     private func finishUndoRedo() {
@@ -910,7 +910,7 @@ final class MarkdownDocument: NSObject {
         adoptExternalBuffer(incoming)
         setDirty(false)
 
-        reparseNow()
+        reparseNow(wholesale: true)
         changes.apply(hunks: hunks, newText: incoming, oldText: baseline ?? previousText)
 
         let restored = ScrollAnchoring.offset(for: anchor, in: parsed)

--- a/Tests/DownrightAppTests/AsyncParseTests.swift
+++ b/Tests/DownrightAppTests/AsyncParseTests.swift
@@ -6,6 +6,24 @@ import MarkdownCore
 @Suite(.serialized)
 struct AsyncParseTests {
     @Test @MainActor
+    func externalAbsorbPublishesWholesaleRender() {
+        let document = MarkdownDocument()
+        let initial = "# One\n\nA calm paragraph.\n"
+        let incoming = "# One\n\nA rewritten paragraph with a different shape.\n"
+        document.adopt(text: initial, displayURL: nil)
+
+        var observedDirty: DirtySet?
+        document.onReparse = { _, dirty in observedDirty = dirty }
+        document.applyExternalText(
+            incoming,
+            hunks: TextDiff.hunks(old: initial, new: incoming)
+        )
+
+        #expect(document.text == incoming)
+        #expect(observedDirty?.isWholesale == true)
+    }
+
+    @Test @MainActor
     func semanticEditConvergesBeforeReadingTree() {
         let document = MarkdownDocument()
         document.adopt(text: "# Heading\n", displayURL: nil)


### PR DESCRIPTION
## What changed

External Markdown rewrites now publish a wholesale renderer update instead of incrementally decorating the previous TextKit surface.

## Why

A live rewrite could leave stale paragraph typography attached to the new AST, producing oversized body text in the production reader.

## Validation

- `Scripts/check.sh`
- 1,018 tests passed
- theme contrast and version consistency passed
- live local app check with the production document fixture confirmed normal typography after the rewrite
- added `externalAbsorbPublishesWholesaleRender` regression coverage
