### PR TITLE
Themed window chrome, warning amber, and a purple important slot

### DIFF
--- a/.github/workflows/download-count.yml
+++ b/.github/workflows/download-count.yml
@@ -1,0 +1,56 @@
+name: Refresh download counter
+
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "17 4 * * *"
+  workflow_dispatch:
+  workflow_run:
+    workflows:
+      - Release
+    types:
+      - completed
+
+permissions:
+  contents: write
+
+concurrency:
+  group: download-counter
+  cancel-in-progress: true
+
+jobs:
+  update:
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+
+      - name: Calculate the cumulative DMG count
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/download-counter"
+          Scripts/report-download-counts.sh --all --json > "$RUNNER_TEMP/download-counter/report.json"
+          TOTAL="$(jq -er '.downloads.acquisition_dmgs' "$RUNNER_TEMP/download-counter/report.json")"
+          jq -n --arg total "$TOTAL" \
+            '{schemaVersion: 1, label: "DMG downloads", message: $total, color: "307afe"}' \
+            > "$RUNNER_TEMP/download-counter/downloads.json"
+
+      - name: Publish the Shields endpoint
+        env:
+          BADGE_BRANCH: automation/download-count
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git switch --orphan "$BADGE_BRANCH"
+          git rm -rf --ignore-unmatch .
+          cp "$RUNNER_TEMP/download-counter/downloads.json" downloads.json
+          git add downloads.json
+          git commit -m "chore: refresh DMG download counter"
+          git push --force origin "HEAD:$BADGE_BRANCH"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -623,6 +623,15 @@ jobs:
         with:
           fetch-depth: 1
 
+      # `xmllint` left the ubuntu-latest image, and the verifier hard-requires
+      # it to prove the feed is well-formed.  Without this the gate aborts in
+      # ten seconds and every release goes red with the channel actually fine —
+      # which is worse than no gate, because a real failure looks identical.
+      - name: Install xmllint
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libxml2-utils
+
       - name: Verify the public Sparkle channel
         env:
           VERIFY_PUBLIC_UPDATE_ATTEMPTS: "45"

--- a/Docs/RELEASE.md
+++ b/Docs/RELEASE.md
@@ -127,13 +127,20 @@ GitHub records a `download_count` for every release asset. Run:
 ```bash
 Scripts/report-download-counts.sh
 Scripts/report-download-counts.sh --release 1.0.16-8-abcdef0 --json
+Scripts/report-download-counts.sh --all --json
 ```
 
-Use the sum of the rolling and versioned `.dmg` counts as the acquisition metric;
+Use the sum of all stable and versioned `.dmg` counts as the acquisition metric;
 this includes direct downloads and Homebrew cask installs. Do not add the
 Sparkle ZIP count to it: those archives are update downloads from existing
 installations. GitHub's counter is an asset-request count, not a unique-person
 or completed-install count.
+
+The README's DMG-download badge is backed by
+`.github/workflows/download-count.yml`. It refreshes daily, after each push to
+`main`, after a successful release, or on manual dispatch, and publishes the
+Shields-compatible endpoint to the `automation/download-count` branch so
+protected `main` does not need a scheduled write.
 
 ## DMG packaging
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 <p align="center">
   <a href="https://github.com/ezzy1630/Downright/actions/workflows/ci.yml"><img src="https://github.com/ezzy1630/Downright/actions/workflows/ci.yml/badge.svg" alt="CI status"></a>
   <a href="https://github.com/ezzy1630/Downright/releases"><img src="https://img.shields.io/github/v/release/ezzy1630/Downright?display_name=tag&sort=semver" alt="Latest release"></a>
+  <a href="https://github.com/ezzy1630/Downright/releases"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fezzy1630%2FDownright%2Fautomation%2Fdownload-count%2Fdownloads.json&cacheSeconds=3600" alt="DMG downloads"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-307afe" alt="MIT license"></a>
 </p>
 

--- a/Scripts/check-contrast.py
+++ b/Scripts/check-contrast.py
@@ -28,6 +28,7 @@ PALETTE_PAIRS = [
     ("calloutWarning", "background", 3.0, "calloutWarning"),
     ("calloutSuccess", "background", 3.0, "calloutSuccess"),
     ("calloutDanger", "background", 3.0, "calloutDanger"),
+    ("calloutImportant", "background", 3.0, "calloutImportant"),
     ("changeAdded", "background", 3.0, "changeAdded"),
     ("changeRemoved", "background", 3.0, "changeRemoved"),
     ("changeModified", "background", 3.0, "changeModified"),

--- a/Scripts/report-download-counts.sh
+++ b/Scripts/report-download-counts.sh
@@ -9,9 +9,10 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 RELEASE="latest"
 JSON=0
+ALL=0
 
 usage() {
-    echo "usage: Scripts/report-download-counts.sh [--release latest|TAG] [--json]" >&2
+    echo "usage: Scripts/report-download-counts.sh [--release latest|TAG] [--all] [--json]" >&2
 }
 
 while [ "$#" -gt 0 ]; do
@@ -23,6 +24,10 @@ while [ "$#" -gt 0 ]; do
             ;;
         --json)
             JSON=1
+            shift
+            ;;
+        --all)
+            ALL=1
             shift
             ;;
         -h|--help)
@@ -39,6 +44,11 @@ done
 command -v curl >/dev/null || { echo "curl is required" >&2; exit 1; }
 command -v jq >/dev/null || { echo "jq is required" >&2; exit 1; }
 
+CURL_ARGS=(-fsSL -H 'Accept: application/vnd.github+json')
+if [ -n "${GITHUB_TOKEN:-}" ]; then
+    CURL_ARGS+=(-H "Authorization: Bearer $GITHUB_TOKEN")
+fi
+
 REMOTE="$(git -C "$ROOT" config --get remote.origin.url || true)"
 REPOSITORY="$(printf '%s' "$REMOTE" | sed -E 's#^https://github.com/##; s#^git@github.com:##; s#\.git$##')"
 case "$REPOSITORY" in
@@ -46,13 +56,55 @@ case "$REPOSITORY" in
     *) echo "could not derive a GitHub repository from origin" >&2; exit 1 ;;
 esac
 
+if [ "$ALL" = "1" ]; then
+    # The releases endpoint defaults to 30 results. Keep following pages so
+    # the README counter remains cumulative as the project grows.
+    RELEASES_FILE="$(mktemp)"
+    trap 'rm -f "$RELEASES_FILE"' EXIT
+    PAGE=1
+    while :; do
+        RESPONSE="$(curl "${CURL_ARGS[@]}" \
+            "https://api.github.com/repos/$REPOSITORY/releases?per_page=100&page=$PAGE")"
+        COUNT="$(printf '%s' "$RESPONSE" | jq 'length')"
+        [ "$COUNT" -gt 0 ] || break
+        printf '%s\n' "$RESPONSE" >> "$RELEASES_FILE"
+        [ "$COUNT" -lt 100 ] && break
+        PAGE=$((PAGE + 1))
+    done
+
+    RELEASES="$(jq -s 'add // []' "$RELEASES_FILE")"
+    RELEASE_COUNT="$(printf '%s' "$RELEASES" | jq 'length')"
+    STABLE_DMGS="$(printf '%s' "$RELEASES" | jq -r '[.[] | .assets[]? | select(.name == "Downright.dmg") | .download_count] | add // 0')"
+    VERSIONED_DMGS="$(printf '%s' "$RELEASES" | jq -r '[.[] | .assets[]? | select(.name | test("^Downright-[0-9]+\\.[0-9]+\\.[0-9]+(-[0-9]+-[0-9a-f]+)?\\.dmg$")) | .download_count] | add // 0')"
+    ACQUISITION_DMGS=$((STABLE_DMGS + VERSIONED_DMGS))
+    UPDATE_ZIPS="$(printf '%s' "$RELEASES" | jq -r '[.[] | .assets[]? | select(.name | test("^Downright-[0-9]+\\.[0-9]+\\.[0-9]+(-[0-9]+-[0-9a-f]+)?\\.zip$")) | .download_count] | add // 0')"
+
+    if [ "$JSON" = "1" ]; then
+        printf '%s' "$RELEASES" | jq --arg repository "$REPOSITORY" \
+            --argjson stable_dmg_downloads "$STABLE_DMGS" \
+            --argjson versioned_dmg_downloads "$VERSIONED_DMGS" \
+            --argjson acquisition_downloads "$ACQUISITION_DMGS" \
+            --argjson sparkle_update_downloads "$UPDATE_ZIPS" \
+            '{repository: $repository, release: "all", release_count: length, downloads: {acquisition_dmgs: $acquisition_downloads, stable_dmg: $stable_dmg_downloads, versioned_dmgs: $versioned_dmg_downloads, sparkle_update_zips: $sparkle_update_downloads}, assets: [.[] | .tag_name as $release | .assets[]? | {release: $release, name, download_count, browser_download_url}]}'
+        exit 0
+    fi
+
+    echo "Repository: $REPOSITORY"
+    echo "Releases:   $RELEASE_COUNT"
+    echo "Acquisition downloads (all DMGs): $ACQUISITION_DMGS"
+    echo "  Stable DMGs:                     $STABLE_DMGS"
+    echo "  Versioned DMGs:                  $VERSIONED_DMGS"
+    echo "Update downloads (Sparkle ZIPs):   $UPDATE_ZIPS"
+    exit 0
+fi
+
 if [ "$RELEASE" = "latest" ]; then
     API_URL="https://api.github.com/repos/$REPOSITORY/releases/latest"
 else
     API_URL="https://api.github.com/repos/$REPOSITORY/releases/tags/$RELEASE"
 fi
 
-RESPONSE="$(curl -fsSL -H 'Accept: application/vnd.github+json' "$API_URL")"
+RESPONSE="$(curl "${CURL_ARGS[@]}" "$API_URL")"
 TAG="$(printf '%s' "$RESPONSE" | jq -r '.tag_name // empty')"
 [ -n "$TAG" ] || { echo "release not found: $RELEASE" >&2; exit 1; }
 

--- a/Sources/DownrightApp/AI/DocumentStateStore.swift
+++ b/Sources/DownrightApp/AI/DocumentStateStore.swift
@@ -217,6 +217,17 @@ final class DocumentStateStore {
         }
     }
 
+    /// Drops one entry and leaves the rest alone.  Matched on the canonical
+    /// path for the same reason `noteOpened` stores one: a file reached through
+    /// a symlink is the same recent everywhere, so forgetting it once has to
+    /// forget it however it was reached.
+    func removeRecent(path: String) {
+        let canonical = Self.canonicalPath(path)
+        let list = recents(limit: 200).filter { Self.canonicalPath($0.path) != canonical }
+        guard let data = try? JSONEncoder.snapshotEncoder.encode(list) else { return }
+        try? data.write(to: recentsURL, options: .atomic)
+    }
+
     func clearRecents() {
         try? fm.removeItem(at: recentsURL)
     }

--- a/Sources/DownrightApp/App/AppDelegate.swift
+++ b/Sources/DownrightApp/App/AppDelegate.swift
@@ -400,6 +400,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         controller.onNew = { [weak self] in self?.newDocument() }
         controller.onOpenGuide = { [weak self] in self?.openWelcomeDocument() }
         controller.onClearRecents = { [weak self] in self?.clearRecentDocuments(nil) }
+        controller.onRemoveRecent = { [weak self] path in self?.removeRecentDocument(path) }
         startWindow = controller
         controller.showWindow(nil)
     }
@@ -669,6 +670,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     @objc func clearRecentDocuments(_ sender: Any?) {
         DocumentStateStore.shared.clearRecents()
         startWindow?.reloadRecents([])
+    }
+
+    /// Forgetting one file re-reads the list rather than removing a row in
+    /// place: the store also drops entries whose file is gone, so the panel
+    /// after the write is the only list that is actually true.
+    private func removeRecentDocument(_ path: String) {
+        DocumentStateStore.shared.removeRecent(path: path)
+        startWindow?.reloadRecents(
+            DocumentStateStore.shared.recents(limit: StartWindowController.recentDisplayLimit)
+        )
     }
 
     @objc func selectLightTheme(_ sender: NSMenuItem) {

--- a/Sources/DownrightApp/App/CompareWindowController.swift
+++ b/Sources/DownrightApp/App/CompareWindowController.swift
@@ -78,9 +78,7 @@ final class CompareWindowController: NSWindowController {
             )
         }
 
-        let split = NSSplitView()
-        split.isVertical = true
-        split.dividerStyle = .thin
+        let split = ThemedSplitView(styleSheet: styleSheet)
         split.translatesAutoresizingMaskIntoConstraints = false
         split.addArrangedSubview(pane(titled: leftTitle, content: leftContainer))
         split.addArrangedSubview(pane(titled: rightTitle, content: rightContainer))

--- a/Sources/DownrightApp/App/DocumentWindowController.swift
+++ b/Sources/DownrightApp/App/DocumentWindowController.swift
@@ -30,7 +30,7 @@ final class DocumentWindowController: NSWindowController {
     // support extensions live in sibling files, and `private` is file-scoped.
     var primaryContainer: MarkdownContainerView!
     var splitContainer: MarkdownContainerView?
-    var splitViewContainer: NSSplitView?
+    var splitViewContainer: ThemedSplitView?
 
     // Persistent chrome
     let breadcrumbView = BreadcrumbView()
@@ -198,7 +198,7 @@ final class DocumentWindowController: NSWindowController {
         window.isRestorable = false
         window.minSize = NSSize(width: 520, height: 400)
         self.init(window: window)
-        applyWindowAppearance(for: ThemeStore.shared.current)
+        window.applyThemeAppearance(for: ThemeStore.shared.current)
         window.backgroundColor = activeStyleSheet.background
         window.delegate = self
         buildInterface()
@@ -769,7 +769,7 @@ final class DocumentWindowController: NSWindowController {
     private func observeTheme() {
         themeObservation = ThemeStore.shared.observe { [weak self] theme in
             guard let self, let window = self.window else { return }
-            self.applyWindowAppearance(for: theme)
+            window.applyThemeAppearance(for: theme)
             self.activeStyleSheet = Self.makeStyleSheet(theme: theme, appearance: window.effectiveAppearance)
             self.applyStyleSheet()
         }
@@ -783,21 +783,6 @@ final class DocumentWindowController: NSWindowController {
         )
     }
 
-    private func applyWindowAppearance(for theme: Theme) {
-        // Following macOS means native controls inherit macOS directly. Do not
-        // pin each window to the selected theme's appearance: that severs the
-        // system appearance chain even when the theme pair changes correctly.
-        if Preferences.shared.values.followsSystemAppearance {
-            window?.appearance = nil
-            return
-        }
-        switch theme.appearance {
-        case .light: window?.appearance = NSAppearance(named: .aqua)
-        case .dark: window?.appearance = NSAppearance(named: .darkAqua)
-        case .auto: window?.appearance = nil
-        }
-    }
-
     @objc private func accessibilityDisplayOptionsDidChange() {
         guard let window else { return }
         activeStyleSheet = Self.makeStyleSheet(
@@ -808,7 +793,7 @@ final class DocumentWindowController: NSWindowController {
     }
 
     @objc private func preferencesDidChange() {
-        applyWindowAppearance(for: ThemeStore.shared.current)
+        window?.applyThemeAppearance(for: ThemeStore.shared.current)
         activeStyleSheet = Self.makeStyleSheet(
             theme: ThemeStore.shared.current,
             appearance: window?.effectiveAppearance ?? NSApp.effectiveAppearance
@@ -860,6 +845,7 @@ final class DocumentWindowController: NSWindowController {
     func applyStyleSheet() {
         primaryContainer.styleSheet = activeStyleSheet
         splitContainer?.styleSheet = activeStyleSheet
+        splitViewContainer?.styleSheet = activeStyleSheet
         breadcrumbView.styleSheet = activeStyleSheet
         densityGutterView.styleSheet = activeStyleSheet
         statusBarView.styleSheet = activeStyleSheet
@@ -2349,9 +2335,7 @@ final class DocumentWindowController: NSWindowController {
         second.textView.scroll(toOffset: source.topVisibleOffset, position: .top, animated: false)
         splitContainer = second
 
-        let split = NSSplitView()
-        split.isVertical = true
-        split.dividerStyle = .thin
+        let split = ThemedSplitView(styleSheet: activeStyleSheet)
         split.translatesAutoresizingMaskIntoConstraints = false
 
         primaryContainer.removeFromSuperview()

--- a/Sources/DownrightApp/App/SetupWindowController.swift
+++ b/Sources/DownrightApp/App/SetupWindowController.swift
@@ -131,6 +131,13 @@ final class SetupWindowController: NSWindowController {
         window.isRestorable = false
         super.init(window: window)
 
+        // The card is painted in theme colours but its buttons are drawn by
+        // AppKit, so the appearance has to be settled before anything reads a
+        // colour — including the sheet the labels below are built from.
+        let theme = ThemeStore.shared.current
+        window.applyThemeAppearance(for: theme)
+        sheet = StyleSheet(theme: theme, appearance: window.effectiveAppearance)
+
         window.delegate = self
         let content = buildContent()
         window.contentView = content

--- a/Sources/DownrightApp/App/StartWindowController.swift
+++ b/Sources/DownrightApp/App/StartWindowController.swift
@@ -126,8 +126,11 @@ private final class KeycapBadgeField: NSTextField {
 /// The start window draws from the app's selected theme so the welcome surface
 /// agrees with the editor it hands off to.  One factory, three users.
 private enum StartTheme {
-    static func makeSheet() -> StyleSheet {
-        StyleSheet(theme: ThemeStore.shared.current, appearance: NSApp.effectiveAppearance)
+    /// Pass the view's own appearance once it is in a window: the start window
+    /// pins itself to the theme, so `NSApp`'s answer is only right before that
+    /// lands.
+    static func makeSheet(appearance: NSAppearance? = nil) -> StyleSheet {
+        StyleSheet(theme: ThemeStore.shared.current, appearance: appearance ?? NSApp.effectiveAppearance)
     }
 }
 
@@ -151,10 +154,30 @@ final class StartWindowController: NSWindowController {
     var onNew: (() -> Void)?
     var onOpenGuide: (() -> Void)?
     var onClearRecents: (() -> Void)?
+    var onRemoveRecent: ((String) -> Void)?
 
     /// Quiet text-button target for the recents header's Clear action.
     @objc func clearRecents(_ sender: Any?) {
         onClearRecents?()
+    }
+
+    // Row actions carry their path on the menu item, so one menu shape serves
+    // every row and nothing has to ask which one was clicked.
+
+    @objc func showRecentInFinder(_ sender: NSMenuItem) {
+        guard let path = sender.representedObject as? String else { return }
+        NSWorkspace.shared.activateFileViewerSelecting([URL(fileURLWithPath: path)])
+    }
+
+    @objc func copyRecentPath(_ sender: NSMenuItem) {
+        guard let path = sender.representedObject as? String else { return }
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(path, forType: .string)
+    }
+
+    @objc func removeRecent(_ sender: NSMenuItem) {
+        guard let path = sender.representedObject as? String else { return }
+        onRemoveRecent?(path)
     }
 
     private var startView: StartView? { window?.contentView as? StartView }
@@ -450,6 +473,7 @@ private final class StartView: NSView {
     /// throughout — the first responder is set before the animation runs.
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
+        window?.applyThemeAppearance(for: ThemeStore.shared.current)
         window?.backgroundColor = sheet.background
         keyObserver.map(NotificationCenter.default.removeObserver)
         keyObserver = nil
@@ -475,7 +499,8 @@ private final class StartView: NSView {
 
     override func viewDidChangeEffectiveAppearance() {
         super.viewDidChangeEffectiveAppearance()
-        sheet = Self.makeSheet()
+        window?.applyThemeAppearance(for: ThemeStore.shared.current)
+        sheet = StartTheme.makeSheet(appearance: effectiveAppearance)
         window?.backgroundColor = sheet.background
         hero.apply(sheet: sheet)
         recentPanel.apply(sheet: sheet)
@@ -956,8 +981,28 @@ private final class RecentDocumentsPanel: NSView {
         }
     }
 
-    fileprivate static func makeContextMenu(owner: StartWindowController) -> NSMenu {
+    /// The panel's own menu carries the one global action; a row adds the three
+    /// that need to know *which* file was clicked.  Right-clicking a single
+    /// entry and being offered nothing but "clear them all" answers a question
+    /// nobody asked, with the most destructive verb in the list.
+    fileprivate static func makeContextMenu(
+        owner: StartWindowController, recentPath: String? = nil
+    ) -> NSMenu {
         let menu = NSMenu()
+        if let recentPath {
+            let rowActions: [(String, Selector)] = [
+                ("Show in Finder", #selector(StartWindowController.showRecentInFinder(_:))),
+                ("Copy Path", #selector(StartWindowController.copyRecentPath(_:))),
+                ("Remove from Recents", #selector(StartWindowController.removeRecent(_:))),
+            ]
+            for (title, action) in rowActions {
+                let item = NSMenuItem(title: title, action: action, keyEquivalent: "")
+                item.target = owner
+                item.representedObject = recentPath
+                menu.addItem(item)
+            }
+            menu.addItem(.separator())
+        }
         let clear = NSMenuItem(
             title: "Clear Recent Files…",
             action: #selector(StartWindowController.clearRecents(_:)),
@@ -1593,7 +1638,7 @@ private final class RecentDocumentButton: NSButton {
         trailingStack.translatesAutoresizingMaskIntoConstraints = false
         shell.addSubview(trailingStack)
 
-        menu = RecentDocumentsPanel.makeContextMenu(owner: target)
+        menu = RecentDocumentsPanel.makeContextMenu(owner: target, recentPath: recent.path)
 
         let text = NSStackView(views: [titleLabel, subtitleLabel])
         text.orientation = .vertical

--- a/Sources/DownrightApp/App/ThemedSplitView.swift
+++ b/Sources/DownrightApp/App/ThemedSplitView.swift
@@ -1,0 +1,134 @@
+import AppKit
+import MarkdownRender
+
+/// A split view whose divider belongs to the theme.
+///
+/// `NSSplitView` paints a thin divider in a system grey that all but vanishes
+/// against a themed page: two columns of prose meet with no seam, and the one
+/// piece of chrome saying "this is draggable" is invisible.  Drawing it in
+/// `rule` puts the seam at the same weight as every other separator in the app,
+/// and hovering lifts a short segment of it into a grip.
+///
+/// Deliberately no animation: a hairline that crossfades on every pass of the
+/// pointer is a distraction in a window meant for reading, and the resize
+/// cursor AppKit already shows arrives at the same moment.
+final class ThemedSplitView: NSSplitView {
+    private enum Grip {
+        /// Length of the brightened segment along the divider.
+        static let length: CGFloat = 26
+        /// A hairline you must land on exactly is not an affordance.  Hover
+        /// resolves over a band wide enough to find without aiming.
+        static let slop: CGFloat = 3
+    }
+
+    var styleSheet: StyleSheet {
+        didSet { needsDisplay = true }
+    }
+
+    private var hoveredBand: NSRect?
+    private var hoverTracking: NSTrackingArea?
+
+    init(styleSheet: StyleSheet, isVertical: Bool = true) {
+        self.styleSheet = styleSheet
+        super.init(frame: .zero)
+        self.isVertical = isVertical
+        dividerStyle = .thin
+    }
+
+    required init?(coder: NSCoder) { fatalError("init(coder:) is not used") }
+
+    override var dividerColor: NSColor { styleSheet.rule }
+
+    override func drawDivider(in rect: NSRect) {
+        super.drawDivider(in: rect)
+        guard let hoveredBand, hoveredBand.intersects(rect) else { return }
+        styleSheet.marker.setFill()
+        let grip = gripRect(in: rect)
+        let radius = min(grip.width, grip.height) / 2
+        NSBezierPath(roundedRect: grip, xRadius: radius, yRadius: radius).fill()
+    }
+
+    /// The grip lives inside the divider rect, so it costs no layout, cannot be
+    /// clipped, and never shifts the panes on either side of it.
+    private func gripRect(in divider: NSRect) -> NSRect {
+        if isVertical {
+            let height = min(Grip.length, divider.height)
+            return NSRect(
+                x: divider.minX, y: divider.midY - height / 2,
+                width: divider.width, height: height
+            )
+        }
+        let width = min(Grip.length, divider.width)
+        return NSRect(
+            x: divider.midX - width / 2, y: divider.minY,
+            width: width, height: divider.height
+        )
+    }
+
+    /// The gaps between live panes.  Derived rather than cached because a drag
+    /// moves them continuously, and `min`/`max` keeps it correct whichever way
+    /// the coordinate system runs.
+    private var dividerBands: [NSRect] {
+        let panes = arrangedSubviews.filter { !isSubviewCollapsed($0) }
+        guard panes.count > 1 else { return [] }
+        return zip(panes, panes.dropFirst()).map { lead, follow in
+            if isVertical {
+                let start = min(lead.frame.maxX, follow.frame.minX)
+                let end = max(lead.frame.maxX, follow.frame.minX)
+                return NSRect(
+                    x: start, y: bounds.minY,
+                    width: max(dividerThickness, end - start), height: bounds.height
+                )
+            }
+            let start = min(lead.frame.maxY, follow.frame.minY)
+            let end = max(lead.frame.maxY, follow.frame.minY)
+            return NSRect(
+                x: bounds.minX, y: start,
+                width: bounds.width, height: max(dividerThickness, end - start)
+            )
+        }
+    }
+
+    // MARK: - Hover
+
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        // Remove only our own: `NSSplitView` installs areas of its own for the
+        // divider cursor, and clearing the lot takes the resize cursor with it.
+        if let hoverTracking { removeTrackingArea(hoverTracking) }
+        let area = NSTrackingArea(
+            rect: .zero,
+            options: [.mouseEnteredAndExited, .mouseMoved, .activeInKeyWindow, .inVisibleRect],
+            owner: self,
+            userInfo: nil
+        )
+        addTrackingArea(area)
+        hoverTracking = area
+    }
+
+    override func mouseMoved(with event: NSEvent) {
+        super.mouseMoved(with: event)
+        updateHover(at: convert(event.locationInWindow, from: nil))
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        super.mouseExited(with: event)
+        updateHover(at: nil)
+    }
+
+    private func updateHover(at point: NSPoint?) {
+        let band = point.flatMap { location in
+            dividerBands.first {
+                $0.insetBy(
+                    dx: isVertical ? -Grip.slop : 0,
+                    dy: isVertical ? 0 : -Grip.slop
+                ).contains(location)
+            }
+        }
+        // Redrawing on every pointer sample would repaint the seam continuously
+        // while someone is only reading; only a change of state is worth a pass.
+        guard band != hoveredBand else { return }
+        hoveredBand = band
+        needsDisplay = true
+    }
+}

--- a/Sources/DownrightApp/App/ThemedWindowAppearance.swift
+++ b/Sources/DownrightApp/App/ThemedWindowAppearance.swift
@@ -1,0 +1,34 @@
+import AppKit
+import MarkdownRender
+
+extension NSWindow {
+    /// Keeps AppKit's system-drawn chrome in step with the theme a window
+    /// paints itself with.
+    ///
+    /// A window that fills itself with `sheet.background` but never declares an
+    /// appearance inherits macOS's.  Choosing Paper Light under a dark system
+    /// therefore draws dark-mode push buttons and text fields onto cream, and a
+    /// button title styled for dark chrome disappears against it.  Any window
+    /// that paints a theme colour owes AppKit the matching appearance.
+    ///
+    /// Following macOS is the exception, for the reason document windows
+    /// already encode: the theme pair tracks the system there, so pinning would
+    /// sever the native appearance chain even when the theme changes correctly.
+    func applyThemeAppearance(for theme: Theme) {
+        let wanted: NSAppearance?
+        if Preferences.shared.values.followsSystemAppearance {
+            wanted = nil
+        } else {
+            switch theme.appearance {
+            case .light: wanted = NSAppearance(named: .aqua)
+            case .dark: wanted = NSAppearance(named: .darkAqua)
+            case .auto: wanted = nil
+            }
+        }
+        // Callers apply this from `viewDidChangeEffectiveAppearance`, which an
+        // assignment here would re-enter.  Settling for the value already in
+        // place ends that on the first pass.
+        guard wanted?.name != appearance?.name else { return }
+        appearance = wanted
+    }
+}

--- a/Sources/DownrightApp/Export/HTMLExporter.swift
+++ b/Sources/DownrightApp/Export/HTMLExporter.swift
@@ -526,6 +526,8 @@ struct HTMLExporter {
         .callout-caution .callout-title, .callout-danger .callout-title { color: \(hex(palette.calloutDanger)); }
         .callout-tip, .callout-success { border-left-color: \(hex(palette.calloutSuccess)); }
         .callout-note .callout-title, .callout-info .callout-title { color: \(hex(palette.calloutNote)); }
+        .callout-important { border-left-color: \(hex(palette.calloutImportant ?? palette.calloutDanger)); }
+        .callout-important .callout-title { color: \(hex(palette.calloutImportant ?? palette.calloutDanger)); }
         /* Subtle tint plus a left rule, never a heavy bordered card (§11.3). */
         .code {
           position: relative; margin: 1.4em 0;

--- a/Sources/DownrightApp/Panels/UpdateWindowController.swift
+++ b/Sources/DownrightApp/Panels/UpdateWindowController.swift
@@ -119,16 +119,20 @@ final class UpdatePanelView: NSView {
 
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
+        window?.applyThemeAppearance(for: ThemeStore.shared.current)
         refresh()
     }
 
-    private static func makeSheet() -> StyleSheet {
-        StyleSheet(theme: ThemeStore.shared.current, appearance: NSApp.effectiveAppearance)
+    /// Pass the view's own appearance once it is in a window: the panel pins
+    /// itself to the theme, so `NSApp`'s answer is only right before that lands.
+    private static func makeSheet(appearance: NSAppearance? = nil) -> StyleSheet {
+        StyleSheet(theme: ThemeStore.shared.current, appearance: appearance ?? NSApp.effectiveAppearance)
     }
 
     override func viewDidChangeEffectiveAppearance() {
         super.viewDidChangeEffectiveAppearance()
-        sheet = Self.makeSheet()
+        window?.applyThemeAppearance(for: ThemeStore.shared.current)
+        sheet = Self.makeSheet(appearance: effectiveAppearance)
         window?.backgroundColor = sheet.background
         layer?.backgroundColor = sheet.background.cgColor
         header.apply(sheet: sheet)

--- a/Sources/MarkdownRender/RenderContracts.swift
+++ b/Sources/MarkdownRender/RenderContracts.swift
@@ -380,6 +380,10 @@ public struct ThemePalette: Codable, Sendable, Equatable {
     public var calloutWarning: ThemeColor
     public var calloutSuccess: ThemeColor
     public var calloutDanger: ThemeColor
+    /// Added after the palette shipped, so a theme written against the earlier
+    /// schema still decodes.  Absent, `[!IMPORTANT]` keeps falling back to the
+    /// danger colour it used to share.
+    public var calloutImportant: ThemeColor?
 }
 
 public struct CodeTheme: Codable, Sendable, Equatable {

--- a/Sources/MarkdownRender/Theme/StyleSheet.swift
+++ b/Sources/MarkdownRender/Theme/StyleSheet.swift
@@ -92,7 +92,7 @@ public struct StyleSheet {
     }
 
     private let headingColors: [NSColor]
-    private let calloutColors: [NSColor]      // note, warning, success, danger
+    private let calloutColors: [NSColor]      // note, warning, success, danger, important
     private let changeColors: [NSColor]       // added, removed, modified
     private let codeColors: [SyntaxToken: NSColor]
 
@@ -210,6 +210,7 @@ public struct StyleSheet {
             resolver.resolve(palette.calloutWarning),
             resolver.resolve(palette.calloutSuccess),
             resolver.resolve(palette.calloutDanger),
+            resolver.resolve(palette.calloutImportant ?? palette.calloutDanger),
         ]
         changeColors = [
             resolver.resolve(palette.changeAdded),
@@ -358,14 +359,22 @@ public struct StyleSheet {
 
     public func headingColor(level: Int) -> NSColor { headingColors[StyleSheet.clampLevel(level) - 1] }
 
-    /// Fourteen callout kinds share four palette slots, grouped by what the
-    /// reader is meant to *do*: absorb, act carefully, confirm, or stop.
+    /// Fourteen callout kinds share five palette slots, grouped by what the
+    /// reader is meant to *do*: absorb, act carefully, confirm, stop, or take
+    /// note of emphasis.
+    ///
+    /// The severities follow GitHub, which is the flavour these callouts came
+    /// from and the one most machine-written Markdown is authored against:
+    /// `caution` is graver than `warning`, and `important` is emphasis rather
+    /// than danger.  The HTML exporter already grouped `caution` with `danger`;
+    /// this is the renderer agreeing with it.
     public func calloutColor(_ kind: CalloutKind) -> NSColor {
         switch kind {
         case .note, .info, .abstract, .quote, .example: return calloutColors[0]
-        case .warning, .caution, .question, .todo: return calloutColors[1]
+        case .warning, .question, .todo: return calloutColors[1]
         case .tip, .success: return calloutColors[2]
-        case .important, .danger, .bug: return calloutColors[3]
+        case .caution, .danger, .bug: return calloutColors[3]
+        case .important: return calloutColors[4]
         }
     }
 

--- a/Sources/MarkdownRender/Theme/ThemeStore.swift
+++ b/Sources/MarkdownRender/Theme/ThemeStore.swift
@@ -223,7 +223,8 @@ extension Theme {
             pathMissing: ThemeColor("system:systemRed"), searchHit: ThemeColor("system:systemBlue"),
             searchHitCurrent: ThemeColor("system:systemBlue"), calloutNote: ThemeColor("system:systemBlue"),
             calloutWarning: ThemeColor("system:systemOrange"), calloutSuccess: ThemeColor("system:systemGreen"),
-            calloutDanger: ThemeColor("system:systemRed")
+            calloutDanger: ThemeColor("system:systemRed"),
+            calloutImportant: ThemeColor("system:systemPurple")
         ),
         code: CodeTheme(
             keyword: ThemeColor("system:systemPink"), string: ThemeColor("system:systemRed"),

--- a/Sources/MarkdownRender/Theme/ThemeStore.swift
+++ b/Sources/MarkdownRender/Theme/ThemeStore.swift
@@ -222,7 +222,7 @@ extension Theme {
             changeRemoved: ThemeColor("system:systemRed"), changeModified: ThemeColor("system:systemBlue"),
             pathMissing: ThemeColor("system:systemRed"), searchHit: ThemeColor("system:systemBlue"),
             searchHitCurrent: ThemeColor("system:systemBlue"), calloutNote: ThemeColor("system:systemBlue"),
-            calloutWarning: ThemeColor("system:systemBlue"), calloutSuccess: ThemeColor("system:systemGreen"),
+            calloutWarning: ThemeColor("system:systemOrange"), calloutSuccess: ThemeColor("system:systemGreen"),
             calloutDanger: ThemeColor("system:systemRed")
         ),
         code: CodeTheme(

--- a/Sources/MarkdownRender/Theme/ThemeValidation.swift
+++ b/Sources/MarkdownRender/Theme/ThemeValidation.swift
@@ -72,7 +72,9 @@ extension Theme {
             ("palette.calloutWarningOnBackground", palette.calloutWarning, palette.background, 2.0),
             ("palette.calloutSuccessOnBackground", palette.calloutSuccess, palette.background, 2.0),
             ("palette.calloutDangerOnBackground", palette.calloutDanger, palette.background, 2.0),
-        ]
+        ] + (palette.calloutImportant.map {
+            [("palette.calloutImportantOnBackground", $0, palette.background, CGFloat(2.0))]
+        } ?? [])
         return roles.compactMap { path, foreground, background, minimum in
             guard foreground.isValid, background.isValid else { return nil }
             let ratio = ThemeContrast.ratio(

--- a/Sources/MarkdownRender/Themes/high-contrast.json
+++ b/Sources/MarkdownRender/Themes/high-contrast.json
@@ -28,7 +28,8 @@
     "calloutNote": "#0000cc",
     "calloutWarning": "#8a4b00",
     "calloutSuccess": "#006600",
-    "calloutDanger": "#cc0000"
+    "calloutDanger": "#cc0000",
+    "calloutImportant": "#7a0080"
   },
   "code": {
     "keyword": "#7a0080",

--- a/Sources/MarkdownRender/Themes/high-contrast.json
+++ b/Sources/MarkdownRender/Themes/high-contrast.json
@@ -26,7 +26,7 @@
     "searchHit": "#0000cc",
     "searchHitCurrent": "#0000cc",
     "calloutNote": "#0000cc",
-    "calloutWarning": "#0000cc",
+    "calloutWarning": "#8a4b00",
     "calloutSuccess": "#006600",
     "calloutDanger": "#cc0000"
   },

--- a/Sources/MarkdownRender/Themes/nord.json
+++ b/Sources/MarkdownRender/Themes/nord.json
@@ -26,7 +26,7 @@
     "searchHit": "#8fbcbb",
     "searchHitCurrent": "#88c0d0",
     "calloutNote": "#81a1c1",
-    "calloutWarning": "#81a1c1",
+    "calloutWarning": "#ebcb8b",
     "calloutSuccess": "#a3be8c",
     "calloutDanger": "#bf616a"
   },

--- a/Sources/MarkdownRender/Themes/nord.json
+++ b/Sources/MarkdownRender/Themes/nord.json
@@ -28,7 +28,8 @@
     "calloutNote": "#81a1c1",
     "calloutWarning": "#ebcb8b",
     "calloutSuccess": "#a3be8c",
-    "calloutDanger": "#bf616a"
+    "calloutDanger": "#bf616a",
+    "calloutImportant": "#b48ead"
   },
   "code": {
     "keyword": "#81a1c1",

--- a/Sources/MarkdownRender/Themes/paper-light.json
+++ b/Sources/MarkdownRender/Themes/paper-light.json
@@ -28,7 +28,8 @@
     "calloutNote": "#2f6fb0",
     "calloutWarning": "#945c0a",
     "calloutSuccess": "#2f7a46",
-    "calloutDanger": "#b03a34"
+    "calloutDanger": "#b03a34",
+    "calloutImportant": "#7a5cb8"
   },
   "code": {
     "keyword": "#8e4f7d",

--- a/Sources/MarkdownRender/Themes/paper-light.json
+++ b/Sources/MarkdownRender/Themes/paper-light.json
@@ -26,7 +26,7 @@
     "searchHit": "#2f6fb0",
     "searchHitCurrent": "#245fb8",
     "calloutNote": "#2f6fb0",
-    "calloutWarning": "#2f6fb0",
+    "calloutWarning": "#945c0a",
     "calloutSuccess": "#2f7a46",
     "calloutDanger": "#b03a34"
   },

--- a/Sources/MarkdownRender/Themes/solarized-light.json
+++ b/Sources/MarkdownRender/Themes/solarized-light.json
@@ -28,7 +28,8 @@
     "calloutNote": "#268bd2",
     "calloutWarning": "#a67d00",
     "calloutSuccess": "#788b00",
-    "calloutDanger": "#dc322f"
+    "calloutDanger": "#dc322f",
+    "calloutImportant": "#6c71c4"
   },
   "code": {
     "keyword": "#606e00",

--- a/Sources/MarkdownRender/Themes/solarized-light.json
+++ b/Sources/MarkdownRender/Themes/solarized-light.json
@@ -26,7 +26,7 @@
     "searchHit": "#268bd2",
     "searchHitCurrent": "#006d9c",
     "calloutNote": "#268bd2",
-    "calloutWarning": "#268bd2",
+    "calloutWarning": "#a67d00",
     "calloutSuccess": "#788b00",
     "calloutDanger": "#dc322f"
   },

--- a/Sources/MarkdownRender/Themes/system.json
+++ b/Sources/MarkdownRender/Themes/system.json
@@ -26,7 +26,7 @@
     "searchHit": "system:systemBlue",
     "searchHitCurrent": "system:systemBlue",
     "calloutNote": "system:systemBlue",
-    "calloutWarning": "system:systemBlue",
+    "calloutWarning": "system:systemOrange",
     "calloutSuccess": "system:systemGreen",
     "calloutDanger": "system:systemRed"
   },

--- a/Sources/MarkdownRender/Themes/system.json
+++ b/Sources/MarkdownRender/Themes/system.json
@@ -28,7 +28,8 @@
     "calloutNote": "system:systemBlue",
     "calloutWarning": "system:systemOrange",
     "calloutSuccess": "system:systemGreen",
-    "calloutDanger": "system:systemRed"
+    "calloutDanger": "system:systemRed",
+    "calloutImportant": "system:systemPurple"
   },
   "code": {
     "keyword": "system:systemPink",

--- a/Sources/MarkdownRender/Themes/warm-dark.json
+++ b/Sources/MarkdownRender/Themes/warm-dark.json
@@ -28,7 +28,8 @@
     "calloutNote": "#7fa9d9",
     "calloutWarning": "#cf9a55",
     "calloutSuccess": "#7fb77e",
-    "calloutDanger": "#d98a80"
+    "calloutDanger": "#d98a80",
+    "calloutImportant": "#bd9ad9"
   },
   "code": {
     "keyword": "#e0879f",

--- a/Sources/MarkdownRender/Themes/warm-dark.json
+++ b/Sources/MarkdownRender/Themes/warm-dark.json
@@ -26,7 +26,7 @@
     "searchHit": "#7fa9d9",
     "searchHitCurrent": "#6ea8ff",
     "calloutNote": "#7fa9d9",
-    "calloutWarning": "#7fa9d9",
+    "calloutWarning": "#cf9a55",
     "calloutSuccess": "#7fb77e",
     "calloutDanger": "#d98a80"
   },

--- a/Tests/DownrightAppTests/StartWindowTests.swift
+++ b/Tests/DownrightAppTests/StartWindowTests.swift
@@ -534,6 +534,41 @@ struct StartWindowTests {
         #expect(paragraph?.alignment == .center)
     }
 
+    @Test
+    func recentRowMenuActsOnTheRowRatherThanTheWholeList() throws {
+        let recent = RecentDocument(
+            path: "/tmp/downright-row-menu-fixture.md",
+            displayName: "fixture",
+            firstHeading: "Fixture",
+            lastOpened: Date(),
+            wordCount: 12
+        )
+        let controller = StartWindowController(recents: [recent])
+        defer { controller.close() }
+        let window = try #require(controller.window)
+        window.contentView?.layoutSubtreeIfNeeded()
+
+        // The assertion is that a row's menu is about *that file* and keeps the
+        // list-wide clear last, behind a separator — not that it holds three
+        // particular verbs.
+        let rowMenu = try #require(
+            menus(in: window.contentView)
+                .first { $0.items.contains { $0.title == "Remove from Recents" } }
+        )
+        #expect(rowMenu.items.last?.title == "Clear Recent Files…")
+        let fileActions = rowMenu.items.prefix { !$0.isSeparatorItem }
+        #expect(fileActions.allSatisfy { $0.representedObject as? String == recent.path })
+
+        let remove = try #require(rowMenu.items.first { $0.title == "Remove from Recents" })
+        #expect(remove.target === controller)
+        #expect(remove.action == #selector(StartWindowController.removeRecent(_:)))
+
+        var removed: String?
+        controller.onRemoveRecent = { removed = $0 }
+        controller.removeRecent(remove)
+        #expect(removed == recent.path)
+    }
+
     private func buttons(in view: NSView?) -> [NSButton] {
         guard let view else { return [] }
         let button = (view as? NSButton).map { [$0] } ?? []

--- a/Tests/DownrightAppTests/WindowChromeTests.swift
+++ b/Tests/DownrightAppTests/WindowChromeTests.swift
@@ -284,6 +284,26 @@ struct WindowChromeTests {
     }
 
     @Test
+    func splitDividerIsThemedChromeRatherThanSystemGrey() throws {
+        let controller = DocumentWindowController()
+        defer { controller.close() }
+
+        controller.toggleSplitView()
+        let split = try #require(controller.splitViewContainer)
+
+        // The seam between two panes of prose is a rule like any other, and
+        // AppKit's default grey reads as nothing against a themed page.
+        #expect(split.dividerColor == controller.activeStyleSheet.rule)
+
+        // It also has to keep up: a theme change that repaints the panes but
+        // leaves the hairline behind is the same bug one repaint later.
+        let dark = try #require(ThemeStore.shared.themes.first { $0.name == "Warm Dark" })
+        let sheet = StyleSheet(theme: dark, appearance: NSAppearance(named: .darkAqua) ?? .currentDrawing())
+        split.styleSheet = sheet
+        #expect(split.dividerColor == sheet.rule)
+    }
+
+    @Test
     func documentBarsReserveSpaceAboveTheDocument() throws {
         let controller = DocumentWindowController()
         defer { controller.close() }

--- a/Tests/MarkdownRenderTests/ThemeTests.swift
+++ b/Tests/MarkdownRenderTests/ThemeTests.swift
@@ -62,7 +62,9 @@ final class ThemeTests {
     func everyColourParses() {
         for theme in bundled() {
             #expect(theme.invalidColorPaths() == [], "\(theme.name) has unparseable colours")
-            #expect(theme.allColors().count == 24 + 17, "\(theme.name): unexpected colour count")
+            // 28 palette roles + 14 code tokens.  The count is the guard: a
+            // colour dropped from the schema would otherwise still validate.
+            #expect(theme.allColors().count == 28 + 14, "\(theme.name): unexpected colour count")
             for (path, color) in theme.allColors() {
                 #expect(color.validated() != nil, "\(theme.name).\(path) = \(color.raw)")
             }


### PR DESCRIPTION
## Summary

Theme-owned chrome that wasn't actually following the theme, plus the callout severity palette. Also carries the previously-unpushed live DMG download counter (402fc9d).

### Callout severities

`calloutWarning` held the note blue in **every** bundled theme, so `[!WARNING]` and `[!CAUTION]` read as informational. Because `calloutColor(.warning)` is also what Document Health, Asset Doctor, Document Lens, Render Targets, the front matter editor and the update pill resolve, every warning-severity row in the app was the same blue as info.

Each theme now names its own amber from its own palette, and a fifth `calloutImportant` role separates emphasis from danger. The result follows GitHub, which is the flavour most machine-written Markdown is authored against:

| Kind | Before | After |
| --- | --- | --- |
| `[!NOTE]` | blue | blue |
| `[!TIP]` | green | green |
| `[!IMPORTANT]` | red (with danger) | **purple** |
| `[!WARNING]` | blue | **amber** |
| `[!CAUTION]` | blue | **red** |

Colours come from each theme's own vocabulary — nord13/nord15, canonical Solarized violet, the existing keyword purple in High Contrast — not a generic swatch set. Solarized's canonical yellow `#b58900` misses the repo's 3.0:1 gate by 0.02, so it's darkened the same way that theme's green already was. All values pass `Scripts/check-contrast.py`.

`calloutImportant` is optional on `ThemePalette` so a user theme written against the earlier schema still decodes; absent, important falls back to danger exactly as it rendered before. The reflective colour walker picks it up when present, so validation and the contrast gate cover it with no second list to maintain.

Two things fell out of this: the HTML exporter already grouped `caution` with `danger`, so the renderer had been disagreeing with the app's own export (they now match), and `.callout-important` had no CSS rule at all in exports.

### Window appearance

Windows that paint `sheet.background` never declared an appearance, so choosing a light theme under a dark system left AppKit drawing dark-mode controls on cream — the setup card's button titles vanished. `DocumentWindowController` already encoded the rule including the don't-pin-while-following-macOS case; it moves to `NSWindow.applyThemeAppearance(for:)` and the setup, start and update windows adopt it.

### Split divider and recents menu

`NSSplitView`'s system grey reads as no seam at all against a themed page, so the split and compare dividers now draw in `sheet.rule` and lift a short segment into a grip on hover. Deliberately no animation.

A recents row's context menu offered only "Clear Recent Files…" — the most destructive verb available as the answer to right-clicking one file. Rows now get Show in Finder / Copy Path / Remove from Recents.

## Verification

`Scripts/check.sh` green: 1038 tests, exit 0. Contrast gate passes on all six themes for both new slots.

Confirmed in the running app against an isolated `DOWNRIGHT_SUPPORT_DIRECTORY`: all five severities distinct; setup card legible under Paper Light on a dark system (the case that was broken); split divider visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)