### PR TITLE
docs: position Downright for agent Markdown review

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,1 @@
-# Downright is free, MIT, forever. Sponsorship is an invitation, never a gate.
-# This file puts a Sponsor button on the repo. Leave uncommitted for review.
 github: ezzy1630

--- a/README.md
+++ b/README.md
@@ -1,86 +1,88 @@
 <p align="center">
-  <img src="Resources/AppIcon.png" width="128" alt="Downright app icon">
+  <a href="https://downright.cc/">
+    <img src="Resources/AppIcon.png" width="128" alt="Downright app icon">
+  </a>
 </p>
 
 <h1 align="center">Downright</h1>
 
+<p align="center"><strong>The native Markdown app for macOS.</strong></p>
+
 <p align="center">
-  A fast, native Markdown reader and editor for macOS.<br>
-  Built for files that people and coding agents change together.
+  Read, edit, and review agent-written Markdown exactly as it exists on disk.<br>
+  Native rendering, live external-change diffs, Quick Look, and a powerful CLI.
 </p>
 
-<p align="center"><strong>macOS 14+ · Swift 6 · Native AppKit · MIT</strong></p>
+<p align="center">
+  <a href="https://downright.cc/download/"><img src="https://img.shields.io/badge/Download_for_macOS-007AFF?style=for-the-badge&amp;logo=apple&amp;logoColor=white" alt="Download Downright for macOS"></a>
+  <a href="https://github.com/ezzy1630/Downright"><img src="https://img.shields.io/github/stars/ezzy1630/Downright?style=for-the-badge&amp;logo=github&amp;label=Star" alt="Star Downright on GitHub"></a>
+  <a href="https://github.com/sponsors/ezzy1630"><img src="https://img.shields.io/badge/Sponsor-EA4AAA?style=for-the-badge&amp;logo=githubsponsors&amp;logoColor=white" alt="Sponsor Downright"></a>
+</p>
+
+<p align="center">
+  <strong>Free and open source · macOS 14+ · Signed and notarized · Offline · No account · MIT</strong>
+</p>
+
+<p align="center">
+  <a href="https://downright.cc/">Website</a> ·
+  <a href="https://github.com/ezzy1630/Downright/releases">Releases</a> ·
+  <a href="CHANGELOG.md">Changelog</a> ·
+  <a href="CONTRIBUTING.md">Contributing</a>
+</p>
 
 <p align="center">
   <a href="https://github.com/ezzy1630/Downright/actions/workflows/ci.yml"><img src="https://github.com/ezzy1630/Downright/actions/workflows/ci.yml/badge.svg" alt="CI status"></a>
-  <a href="https://github.com/ezzy1630/Downright/releases"><img src="https://img.shields.io/github/v/release/ezzy1630/Downright?display_name=tag&sort=semver" alt="Latest release"></a>
-  <a href="https://github.com/ezzy1630/Downright/releases"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fezzy1630%2FDownright%2Fautomation%2Fdownload-count%2Fdownloads.json&cacheSeconds=3600" alt="DMG downloads"></a>
+  <a href="https://github.com/ezzy1630/Downright/releases"><img src="https://img.shields.io/github/v/release/ezzy1630/Downright?display_name=tag&amp;sort=semver" alt="Latest release"></a>
+  <a href="https://downright.cc/download/"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fezzy1630%2FDownright%2Fautomation%2Fdownload-count%2Fdownloads.json&amp;cacheSeconds=3600" alt="DMG downloads"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-307afe" alt="MIT license"></a>
 </p>
-
-<p align="center"><a href="https://downright.cc/download/">Download the signed macOS release</a> · <a href="https://downright.cc/">downright.cc</a> · <a href="https://github.com/ezzy1630/homebrew-downright">Public Homebrew tap</a></p>
 
 ---
 
 <p align="center">
-  <img src="Docs/downright-renderer-showcase.png" alt="Downright rendering Markdown with native typography, syntax highlighting, math, Mermaid, tasks, and a density rail." width="1100">
+  <a href="https://downright.cc/">
+    <img src="Docs/downright-renderer-showcase.png" alt="Downright rendering Markdown with native typography, syntax highlighting, math, Mermaid, tasks, and a density rail." width="1100">
+  </a>
 </p>
 
-Downright opens Markdown as a calm document, keeps its source exact, and shows
-external edits without pulling you out of the page. It works offline, has no
-account requirement, and never uses a WebView.
+## Markdown has changed
 
-## Highlights
+Coding agents produce plans, implementation notes, reports, and documentation
+faster than anyone can comfortably review them as raw text.
 
-| Read and edit | Review agent output |
+Downright turns those files into calm, native macOS documents while preserving
+their exact source. When Codex, Claude Code, or another coding agent rewrites
+the file you are reading, Downright shows precisely what changed—without
+uploading the document, creating a vault, or replacing your filesystem with a
+database.
+
+| Read naturally | Review agent work |
 |---|---|
-| Native CommonMark/GFM rendering | Live external-change tracking |
-| One adaptive rendered/source surface with stable selection and scroll | Word-level rendered diffs and conflict safety |
-| Math, Mermaid, tables, tasks, callouts, front matter, and images | Local snapshots, version timeline, and undoable task edits |
-| Liquid-glass Find and Tasks panels | Outline, structural zoom, and density navigation |
-
-| Work with the whole folder | Use Markdown everywhere |
-|---|---|
-| Optional folder workspace and sibling-file search without a vault | Quick Look previews and Finder thumbnails |
-| Clickable `file.swift:42` references and editor handoff | `down` and `md` terminal commands |
-| Themes that follow macOS Light/Dark mode | HTML/PDF export, Services, Spotlight metadata, and App Intents |
-| First-run setup for app association, CLI, and Quick Look | Optional on-device Apple Intelligence |
+| Native CommonMark and GFM rendering | Live external-change tracking |
+| Math, Mermaid, tables, tasks, callouts, front matter, images, and footnotes | Word-level rendered diffs and conflict safety |
+| One adaptive document and source surface | Local snapshots, version timeline, and undoable task edits |
+| Themes that follow macOS Light and Dark appearances | Outline, structural zoom, and density navigation |
+| Open one file immediately or use an optional folder workspace | Quick Look previews and Finder thumbnails |
+| Search sibling files without creating a vault | `down` and `md` terminal commands |
+| Click `file.swift:42` references and hand off to your editor | HTML/PDF export, Services, Spotlight metadata, and App Intents |
+| Keep every byte of the original Markdown in charge | Optional on-device Apple Intelligence |
 
 Supported files: `.md`, `.markdown`, `.mdown`, `.mkd`, `.mdx`, `.mdc`, `.qmd`,
 and `.rmd`.
 
-## Why Downright
+## Installation
 
-- **Exact source.** Rendering decorates the original text storage; it does not
-  rebuild or normalize the document.
-- **Safe live updates.** External writes refresh in place while preserving the
-  reading position. Dirty local edits are never silently replaced.
-- **Native and file-first.** TextKit 2, Core Text, SwiftMath, and native Mermaid
-  rendering keep the app and Quick Look extensions lean. Open one file with no
-  workspace setup, database, sync service, plugin runtime, or chat panel.
+### Download the app
 
-## Quick start
+Download the latest signed and notarized release from
+[downright.cc/download](https://downright.cc/download/).
 
-Requirements: macOS 14 or newer and a Swift 6 toolchain.
+1. Open `Downright.dmg`.
+2. Drag Downright into Applications.
+3. Launch it once to configure Markdown file associations, Quick Look, and the
+   CLI.
 
-Clone, build the complete app, and install it with Finder integration:
-
-```bash
-git clone https://github.com/ezzy1630/Downright.git
-cd Downright
-Scripts/bundle-xcode-app.sh
-APP_SOURCE=.build-xcode/Build/Products/Release/Downright.app Scripts/install.sh
-down README.md
-```
-
-This path requires Xcode and `xcodegen`; it embeds both the Quick Look preview
-and Finder thumbnail extensions. Launch Downright once after installation: the
-first-run setup offers default-app and CLI registration, registers Quick Look,
-and can repeat every step later under **Settings → General → System
-integration**. See [Quick Look](Docs/QUICKLOOK.md) and [Release](Docs/RELEASE.md)
-for details.
-
-## Install with Homebrew
+### Homebrew
 
 The public tap installs the same production app into `/Applications`:
 
@@ -94,9 +96,9 @@ request in the release asset download count.
 This is the developer tap. The tap-free `brew install --cask downright`
 command is not advertised until an official Homebrew Cask is accepted.
 
-## Install with curl or npm
+### Terminal installer
 
-The simplest install command downloads the latest signed main-channel build, verifies its
+The first-party installer downloads the latest signed build, verifies its
 published checksum and app signature, installs it into `/Applications`,
 registers the Finder integrations, and links `down` and `md` when possible:
 
@@ -104,24 +106,27 @@ registers the Finder integrations, and links `down` and `md` when possible:
 curl -fsSL https://downright.cc/install | bash
 ```
 
-If Node.js 18 or newer is already installed, the npm launcher runs that same
+If Node.js 18 or newer is already installed, the npm launcher runs the same
 first-party installer:
 
 ```bash
 npx --yes downright-installer
 ```
 
-Both paths leave Sparkle updates enabled in the installed app. Every subsequent
-verified push to `main` becomes the next Sparkle update; feature-branch pushes
-never reach users. The curl path
-needs no Node.js; the npm path is macOS-only and requires Node.js 18+.
+Every installation path leaves automatic Sparkle updates enabled. The curl
+path needs no Node.js; the npm path is macOS-only and requires Node.js 18+.
 
-For a faster SwiftPM development build without Finder extensions:
+## Why Downright
 
-```bash
-Scripts/bundle-app.sh
-open .build-main/bundle/Downright.app
-```
+- **Exact source.** Rendering decorates the original text storage; it does not
+  rebuild or normalize the document.
+- **Safe live updates.** External writes refresh in place while preserving the
+  reading position. Dirty local edits are never silently replaced.
+- **Native and file-first.** TextKit 2, Core Text, SwiftMath, and native Mermaid
+  rendering keep the app and Quick Look extensions lean. There is no WebView,
+  workspace requirement, sync service, plugin runtime, or chat panel.
+- **Designed for agent workflows.** Open plans from the terminal, follow edits
+  as they land, review word-level changes, and keep a local version timeline.
 
 ## Everyday commands
 
@@ -139,8 +144,7 @@ down doctor                               # diagnose app, CLI, Quick Look, and u
 
 `md` is installed as an alias for `down`. `down doctor --json` emits a
 machine-readable support report without modifying the machine; use
-`down doctor --app path/to/Downright.app` to inspect a development bundle.
-Run
+`down doctor --app path/to/Downright.app` to inspect a development bundle. Run
 `down --help` for every command.
 
 ## Keyboard essentials
@@ -159,7 +163,7 @@ All bindings are editable in **Settings → Keys**.
 
 ## Themes and appearance
 
-Downright follows macOS Light/Dark appearance by default. Light and dark
+Downright follows macOS Light and Dark appearances by default. Light and dark
 palettes are chosen separately under **Settings → Appearance** or
 **View → Theme**. Turning off **Follow macOS Appearance** deliberately keeps
 the selected light palette active.
@@ -170,6 +174,58 @@ custom JSON themes hot-reload from:
 ```text
 ~/Library/Application Support/Downright/Themes/
 ```
+
+## Privacy
+
+Opening, reading, editing, searching, diffing, and exporting are local. No
+account or telemetry is required. Optional Apple Intelligence actions are
+on-device, off by default, and receive only text selected by the user.
+
+See [Privacy](Docs/PRIVACY.md).
+
+## Support Downright
+
+Downright is built and maintained independently. It is free, MIT-licensed,
+offline-first, and contains no advertising or app telemetry.
+
+If Downright earns a place in your workflow, you can help sustain its
+development by:
+
+- [Starring the repository](https://github.com/ezzy1630/Downright)
+- [Sponsoring the project](https://github.com/sponsors/ezzy1630)
+- Sharing [downright.cc](https://downright.cc/) with someone who works in
+  Markdown
+
+Sponsorship helps cover signing, distribution, ongoing macOS compatibility,
+and the time required to keep Downright polished.
+
+## Development
+
+Requirements: macOS 14 or newer, Xcode, xcodegen, and a Swift 6 toolchain.
+
+Clone, build the complete app, and install it with Finder integration:
+
+```bash
+git clone https://github.com/ezzy1630/Downright.git
+cd Downright
+Scripts/bundle-xcode-app.sh
+APP_SOURCE=.build-xcode/Build/Products/Release/Downright.app Scripts/install.sh
+down README.md
+```
+
+For a faster SwiftPM development build without Finder extensions:
+
+```bash
+Scripts/bundle-app.sh
+open .build-main/bundle/Downright.app
+```
+
+The complete build requires Xcode and `xcodegen`; it embeds both the Quick Look
+preview and Finder thumbnail extensions. Launch Downright once after
+installation: the first-run setup offers default-app and CLI registration,
+registers Quick Look, and can repeat every step later under **Settings →
+General → System integration**. See [Quick Look](Docs/QUICKLOOK.md) and
+[Release](Docs/RELEASE.md) for details.
 
 ## Architecture
 
@@ -215,20 +271,16 @@ Scripts/verify-bundle.sh .build-main/bundle/Downright.app
 Scripts/check-app.sh
 ```
 
-## Privacy
-
-Opening, reading, editing, searching, diffing, and exporting are local. No
-account or telemetry is required. Optional Apple Intelligence actions are
-on-device, off by default, and receive only text selected by the user.
-
-See [Privacy](Docs/PRIVACY.md).
+See [CONTRIBUTING.md](CONTRIBUTING.md) before opening a pull request.
 
 ## Project status
 
-The current rolling release is tracked in [GitHub Releases](https://github.com/ezzy1630/Downright/releases); current polish is tracked under
-[Unreleased](CHANGELOG.md). The repository contains the app, CLI, Quick Look,
-updater, signing, notarization, DMG, and release automation. See [Status](Docs/STATUS.md)
-for known gaps and implementation notes.
+The current rolling release is tracked in
+[GitHub Releases](https://github.com/ezzy1630/Downright/releases), and current
+polish is tracked under [Unreleased](CHANGELOG.md). The repository contains
+the app, CLI, Quick Look extensions, updater, signing, notarization, DMG, and
+release automation. See [Status](Docs/STATUS.md) for known gaps and
+implementation notes.
 
 ## License
 


### PR DESCRIPTION
## Summary

- Reposition the README around reviewing Markdown written by Codex, Claude Code, and other coding agents.
- Make Download, Star, and Sponsor the prominent actions and link DMG download metrics to downright.cc/download.
- Put normal installation before development instructions while preserving the CLI, shortcuts, themes, architecture, privacy, testing, and release details.
- Add a clear sponsorship section and simplify `.github/FUNDING.yml` to the GitHub sponsor handle.

## Validation

- Parsed `.github/FUNDING.yml` and confirmed the expected handle.
- Confirmed all README local links and referenced assets exist.
- `git diff --check` passed.
- Confirmed the public website, download page, repository, and sponsor links respond successfully.
- No Swift build was run because this change only updates documentation and repository metadata.
