### PR TITLE
Document Downright's sponsorship policy

### DIFF
--- a/Docs/SPONSORING.md
+++ b/Docs/SPONSORING.md
@@ -1,0 +1,18 @@
+# Sponsor Downright
+
+Downright is free, MIT licensed, and built in public. It has no account requirement, telemetry, paid tier, or feature gate.
+
+Sponsorship pays for the unglamorous work that keeps a native Mac app dependable: signed and notarized releases, macOS compatibility, accessibility fixes, performance work, documentation, and time spent investigating bug reports. It also helps cover the recurring cost of shipping outside the Mac App Store.
+
+Sponsor on GitHub if Downright has made Markdown easier to live with on your Mac:
+
+[github.com/sponsors/ezzy1630](https://github.com/sponsors/ezzy1630)
+
+## What sponsorship means
+
+- Core features remain available to everyone.
+- Sponsors do not buy control of the roadmap.
+- A name or company link is optional. Quiet support is equally welcome.
+- Issues and pull requests are judged on their merits, not on sponsorship.
+
+If money is not the right contribution, a clear bug report, a GitHub star, a useful review, or a pull request helps too.

--- a/README.md
+++ b/README.md
@@ -197,7 +197,9 @@ development by:
   Markdown
 
 Sponsorship helps cover signing, distribution, ongoing macOS compatibility,
-and the time required to keep Downright polished.
+and the time required to keep Downright polished. The
+[sponsorship policy](Docs/SPONSORING.md) explains what support does and does not
+change.
 
 ## Development
 


### PR DESCRIPTION
## What changed

- Added a public sponsorship policy.
- Linked it from the existing README support section.

## Why

The repository already asks for sponsorship, but it did not explain what support funds or what sponsors can expect. The policy makes the boundaries explicit: Downright stays free and MIT licensed, core features are not gated, and sponsorship does not buy roadmap control.

## Validation

- `git diff --check`
- Reviewed the complete scoped diff
