### PR TITLE
Add the README film and restore system appearance for legacy settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,12 @@
 ---
 
 <p align="center">
-  <a href="https://downright.cc/">
-    <img src="Docs/downright-renderer-showcase.png" alt="Downright rendering Markdown with native typography, syntax highlighting, math, Mermaid, tasks, and a density rail." width="1100">
+  <a href="https://downright.cc/assets/downright-one-journey-master.mp4">
+    <img src="Docs/downright-readme-demo.gif" alt="Downright opens a Markdown file from Finder, renders it as a native Mac document, switches to exact source, and reviews an external rewrite." width="800">
   </a>
 </p>
+
+<p align="center"><a href="https://downright.cc/assets/downright-one-journey-master.mp4">Watch the 23-second product film</a></p>
 
 ## Markdown, treated like a Mac document
 

--- a/Sources/DownrightApp/Support/Preferences.swift
+++ b/Sources/DownrightApp/Support/Preferences.swift
@@ -12,6 +12,11 @@ final class Preferences {
         var darkThemeName: String = "Warm Dark"
         /// When true the light/dark theme pair follows the system appearance.
         var followsSystemAppearance: Bool = true
+        /// Tracks the one-time repair for settings written before following
+        /// macOS appearance became the stable default. Keeping the marker
+        /// lets a user opt out again after the repair without losing that
+        /// choice on every launch.
+        private var appearancePreferenceVersion: Int = 1
         /// Quick Look is a separate sandboxed process. Its default follows
         /// macOS, with an explicit override for readers who want a fixed mode.
         var previewAppearance: PreviewAppearance = .system
@@ -85,6 +90,11 @@ final class Preferences {
             themeName = get(.themeName, "Paper Light")
             darkThemeName = get(.darkThemeName, "Warm Dark")
             followsSystemAppearance = get(.followsSystemAppearance, true)
+            appearancePreferenceVersion = get(.appearancePreferenceVersion, 0)
+            if appearancePreferenceVersion < 1 {
+                followsSystemAppearance = true
+                appearancePreferenceVersion = 1
+            }
             previewAppearance = get(.previewAppearance, .system)
             typography = get(.typography, TypographyConfig.default)
             textSizeAdjustment = get(.textSizeAdjustment, 0)

--- a/Tests/DownrightAppTests/AppLayerTests.swift
+++ b/Tests/DownrightAppTests/AppLayerTests.swift
@@ -285,6 +285,14 @@ struct AppLayerTests {
     }
 
     @Test
+    func legacyPreferencesRestoreSystemAppearanceFollowing() throws {
+        let legacy = Data(#"{"followsSystemAppearance":false}"#.utf8)
+        let decoded = try JSONDecoder().decode(Preferences.Values.self, from: legacy)
+
+        #expect(decoded.followsSystemAppearance)
+    }
+
+    @Test
     func choosingAThemeDoesNotChangeTheAppearanceMode() {
         var values = Preferences.Values()
         values.followsSystemAppearance = true


### PR DESCRIPTION
## What changed

- replaces the static README showcase with the 10-second product demo
- links the README to the live 23-second film
- repairs legacy preferences so existing installs follow system appearance once
- keeps later user appearance choices intact with a version marker

## Checks

- branch CI: `swift` passed
- branch CI: `app-acceptance` passed
- staged diff check passed

Merging this PR triggers the signed rolling release pipeline.