### PR TITLE
Everyday Trust: harden Markdown editing end to end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,22 @@ every release; Sparkle orders updates by it.
 
 ### Fixed
 
+- **Made saves fail closed around external file activity.** Downright now
+  distinguishes unchanged, changed, missing, and unreadable disk state; an
+  implicit save can no longer recreate a deleted file, swallow an atomic
+  replacement, or overwrite a generation that arrived at the save boundary.
+  Recovery offers explicit Save a Copy, Recreate File, Discard, and Cancel
+  choices, and preserves byte-level encoding and line-ending fidelity.
+- **Made Quick Look reads bounded under replacement races.** Preview and
+  fallback paths now enforce their byte ceiling on the read itself even when
+  a file grows or is atomically replaced after its metadata was inspected.
+- **Kept large external rewrites off the typing path.** Revision-checked
+  background parsing and incremental TextKit commits preserve selection and
+  scroll anchors while bounded real-window frame gates cover 10k–50k-line
+  documents, IME composition, split view, and concurrent scrolling.
+- **Repaired browser-rich paste boundaries.** HTML, WebArchive, RTF, and RTFD
+  imports preserve useful paragraph, list, table, code, and link structure
+  without guessing at unsupported image or vendor payloads.
 - **Fixed a crash on ordinary prose.** Any document containing a one-character
   word before `:digits` — "John 3:16", "meet at 9:30", `` `a:1` `` — fatally
   trapped the path-token scanner during the per-keystroke reparse.
@@ -74,6 +90,21 @@ every release; Sparkle orders updates by it.
 
 ### Added
 
+- **Calm, explicit document trust states.** The toolbar now communicates
+  Edited, Saving, briefly Saved, Changed on disk, Conflict, and Save failed,
+  with accessible labels and focused mutation provenance such as Paste,
+  Toggle Task, Replace, panel actions, and Undo.
+- **Contents / Outline is a first-class command.** It is visible in the
+  toolbar and overflow menu, remains available through View, the command
+  palette, accessibility, and configurable keybindings, and reuses the
+  pinnable inspector rather than adding a permanent sidebar.
+- **Universal clipboard flavors.** Copy now publishes lossless private
+  Markdown, plain text, RTF, and sanitized semantic HTML so native and browser
+  targets retain headings, lists, emphasis, links, tables, and code structure.
+- **Safe native rendering for common README HTML.** Presentational paragraphs,
+  headings, emphasis, links, local images, line breaks, disclosures, and basic
+  tables render in Document mode without executing HTML or changing source;
+  unknown and risky markup stays visible and inert.
 - **First-run setup panel.** Downright now installs itself. On first launch it
   offers to become the default Markdown app and to install the `down` command
   line tool, and — with no decision to make — registers its Quick Look
@@ -99,6 +130,12 @@ every release; Sparkle orders updates by it.
 
 ### Changed
 
+- The Welcome tour now derives every displayed shortcut from the configurable
+  command table, shows an honest Unassigned state, and remains accurate after
+  keybinding customization.
+- Development app bundles now use an isolated bundle identifier by default,
+  including their Quick Look extensions, so acceptance builds cannot displace
+  the installed daily-driver registration.
 - **Appearance now follows macOS reliably.** Theme selection no longer
   silently disables system following, the View menu exposes separate light
   and dark palettes, and Light/Dark transitions rebuild cached TextKit

--- a/Docs/MARKDOWN-COMPATIBILITY.md
+++ b/Docs/MARKDOWN-COMPATIBILITY.md
@@ -1,0 +1,27 @@
+# Markdown compatibility
+
+Downright treats the file's exact source as authoritative. Its portable
+baseline is CommonMark; GitHub-flavored Markdown is the default compatibility
+target for tables, task lists, strikethrough, autolinks, and ordinary README
+HTML. The Contents / Outline compatibility view can compare the open document
+with GitHub, CommonMark, and other built-in targets without changing the file.
+
+Downright extensions include math, Mermaid, callouts, wikilinks, front matter,
+footnotes, path tokens, and additional document extensions. They are ordinary
+source syntax, never a required proprietary dialect. Unsupported targets are
+reported with exact ranges and reversible proposals where a safe conversion is
+available; Downright does not silently normalize an extension away.
+
+## Raw HTML
+
+Document mode natively presents a conservative, non-executing subset commonly
+found in README files: aligned paragraphs, headings, strong and emphasized
+text, links, local images, line breaks, details and summaries, and basic table
+structure. The original tags remain in source and reappear at the caret for
+editing.
+
+Unknown tags, malformed markup, event attributes, executable URLs, and other
+unsafe input remain inert literal source. Remote image tags are never fetched;
+they remain visibly preserved while safe surrounding presentation can still be
+rendered. HTML export applies its own escaping rules and never treats raw file
+HTML as trusted output.

--- a/README.md
+++ b/README.md
@@ -69,6 +69,11 @@ performance, with the original Markdown remaining authoritative on disk.
 Supported files: `.md`, `.markdown`, `.mdown`, `.mkd`, `.mdx`, `.mdc`, `.qmd`,
 and `.rmd`.
 
+CommonMark is the portable baseline and GitHub-flavored Markdown is the default
+interchange target. Downright also renders opt-in extensions without rewriting
+them into a proprietary format. See [Markdown compatibility](Docs/MARKDOWN-COMPATIBILITY.md)
+for the exact boundary, including safe raw-HTML behavior.
+
 ## Installation
 
 ### Download the app

--- a/Resources/Welcome.md
+++ b/Resources/Welcome.md
@@ -17,8 +17,9 @@ the territory at the same time.
 
 ## Structural zoom
 
-Press ⌃⌘1. The document collapses to its top-level headings. ⌃⌘2 adds the level
-under those. ⌃⌘5 brings everything back.
+Press {{shortcut:zoomLevel1}}. The document collapses to its top-level headings.
+{{shortcut:zoomLevel2}} adds the level under those. {{shortcut:zoomLevel5}}
+brings everything back.
 
 Nothing is removed from the file, only from your eye. Use it on a long document
 when you want the argument before the detail.
@@ -28,7 +29,7 @@ when you want the argument before the detail.
 Click into this paragraph and type. The markers for the word you are in appear,
 and only those. Nothing else on the page moves.
 
-Press ⌘⇧E for Source Focus: the whole document becomes plain Markdown with line
+Press {{shortcut:sourceMode}} for Source Focus: the whole document becomes plain Markdown with line
 numbers, and Done brings you back. The caret keeps its place in both directions,
 and the file keeps its bytes.
 
@@ -38,16 +39,16 @@ A table:
 
 | Press | What happens |
 | --- | --- |
-| ⌘⇧K | Command palette, for anything you cannot remember |
-| ⌥⌘1 | Outline |
-| ⌥⌘3 | Tasks |
-| ⌘⇧O | Search the headings |
+| {{shortcut:commandPalette}} | Command palette, for anything you cannot remember |
+| {{shortcut:documentLens}} | {{command:documentLens}} |
+| {{shortcut:taskPanel}} | Tasks |
+| {{shortcut:nextHeading}} | Jump to the next heading |
 
 A task list. Click a box — it edits one character of the file, and undo puts it
 back:
 
 - [x] Open a Markdown file
-- [ ] Press ⌃⌘1, then ⌃⌘5
+- [ ] Press {{shortcut:zoomLevel1}}, then {{shortcut:zoomLevel5}}
 - [ ] Drag the gutter
 - [ ] Tick this box
 
@@ -72,9 +73,10 @@ it. One that does not is underlined, which is the point.[^paths]
 ## When something else writes the file
 
 Leave a file open, let an agent edit it, and come back. The changed regions are
-marked in the text and in the gutter, and ⌃⌘↓ walks through them one at a time.
+marked in the text and in the gutter, and {{shortcut:nextChange}} walks through
+them one at a time.
 
-Every outside write is snapshotted first. ⌥⌘V opens the version timeline, so a
+Every outside write is snapshotted first. {{shortcut:versionTimeline}} opens the version timeline, so a
 change you did not want is a change you can take back.
 
 > [!TIP]
@@ -82,7 +84,7 @@ change you did not want is a change you can take back.
 
 ## Where to go next
 
-Settings (⌘,) has seven panes and a search field. Keys is where every shortcut
+Settings ({{shortcut:preferences}}) has focused panes and a search field. Keys is where every shortcut
 printed here can be changed — these are only the defaults.
 
 You can close this document whenever you like. It is a copy, opened from a

--- a/Scripts/bundle-spotlight.sh
+++ b/Scripts/bundle-spotlight.sh
@@ -24,6 +24,8 @@ PLIST_VALUE() {
 
 VERSION="$(PLIST_VALUE CFBundleShortVersionString)"
 BUILD="$(PLIST_VALUE CFBundleVersion)"
+HOST_BUNDLE_IDENTIFIER="$(PLIST_VALUE CFBundleIdentifier)"
+SPOTLIGHT_BUNDLE_IDENTIFIER="$HOST_BUNDLE_IDENTIFIER.spotlight"
 
 echo "==> Building Spotlight importer ($SPOTLIGHT_CONFIGURATION)"
 swift build \
@@ -51,6 +53,7 @@ cp "$SOURCE" "$EXECUTABLE"
 sed \
     -e 's|\$(MARKETING_VERSION)|'"$VERSION"'|g' \
     -e 's|\$(CURRENT_PROJECT_VERSION)|'"$BUILD"'|g' \
+    -e 's|com\.ezzy\.downright\.spotlight|'"$SPOTLIGHT_BUNDLE_IDENTIFIER"'|g' \
     "$ROOT/Config/DownrightSpotlight-Info.plist" \
     > "$IMPORTER/Contents/Info.plist"
 cp "$ROOT/Resources/Spotlight/schema.xml" "$RESOURCES/schema.xml"
@@ -58,11 +61,11 @@ cp "$ROOT/Resources/Spotlight/schema.xml" "$RESOURCES/schema.xml"
 # The importer is nested code. Seal it before the host is sealed so both
 # ad-hoc development bundles and the production workflow have the same order.
 codesign --force --sign - \
-    --identifier com.ezzy.downright.spotlight.binary \
+    --identifier "$SPOTLIGHT_BUNDLE_IDENTIFIER.binary" \
     "$EXECUTABLE" 2>/dev/null \
     || echo "    (codesign unavailable, continuing unsigned)"
 codesign --force --sign - \
-    --identifier com.ezzy.downright.spotlight \
+    --identifier "$SPOTLIGHT_BUNDLE_IDENTIFIER" \
     "$IMPORTER" 2>/dev/null \
     || echo "    (codesign unavailable, continuing unsigned)"
 

--- a/Scripts/bundle-xcode-app.sh
+++ b/Scripts/bundle-xcode-app.sh
@@ -18,6 +18,16 @@ source "$ROOT/Config/version.env"
 PRODUCTION="${PRODUCTION:-0}"
 BUILD="$("$ROOT/Scripts/build-number.sh")"
 
+# Keep development artifacts distinct from the installed daily driver in
+# Launch Services and the Quick Look plug-in registry. Release builds retain
+# the public identifier; callers may give an explicit identifier for other
+# isolated acceptance channels.
+if [ "$PRODUCTION" = "1" ]; then
+    HOST_BUNDLE_IDENTIFIER="com.ezzy.downright"
+else
+    HOST_BUNDLE_IDENTIFIER="${DOWNRIGHT_HOST_BUNDLE_IDENTIFIER:-com.ezzy.downright.acceptance}"
+fi
+
 command -v xcodegen >/dev/null || {
     echo "xcodegen is required. Install it with: brew install xcodegen" >&2
     exit 1
@@ -46,10 +56,27 @@ xcodebuild \
     CODE_SIGNING_REQUIRED=NO \
     MARKETING_VERSION="$MARKETING_VERSION" \
     CURRENT_PROJECT_VERSION="$BUILD" \
+    DOWNRIGHT_HOST_BUNDLE_IDENTIFIER="$HOST_BUNDLE_IDENTIFIER" \
     DEBUG_INFORMATION_FORMAT="$DEBUG_INFORMATION_FORMAT" \
     build
 
 APP="$ROOT/$SCRATCH/Build/Products/$CONFIGURATION/Downright.app"
+
+if [ "$PRODUCTION" != "1" ]; then
+    # A development bundle must never poll the public Sparkle channel. Keep the
+    # framework linked so the shipped graph is exercised, but remove every
+    # updater input before the bundle is sealed.
+    for key in \
+        SUAutomaticallyUpdate \
+        SUEnableAutomaticChecks \
+        SUFeedURL \
+        SUPublicEDKey \
+        SURequireSignedFeed \
+        SUScheduledCheckInterval \
+        SUVerifyUpdateBeforeExtraction; do
+        /usr/libexec/PlistBuddy -c "Delete :$key" "$APP/Contents/Info.plist" 2>/dev/null || true
+    done
+fi
 
 echo "==> Embedding Sparkle.framework"
 # XcodeGen's `embed: true` for an SPM framework resolves the copy phase to a

--- a/Scripts/check-app.sh
+++ b/Scripts/check-app.sh
@@ -93,6 +93,16 @@ APP="$ROOT/$APP_ACCEPTANCE_SCRATCH/Build/Products/$CONFIGURATION/Downright.app"
     exit 1
 }
 
+# The acceptance identity must never inherit the production Sparkle channel.
+# Xcode expands the release plist before this script embeds and re-seals the
+# final bundle, so remove every updater input from that exact development app.
+if [ "$APP_ACCEPTANCE_PRODUCTION" = "0" ]; then
+    APP_INFO="$APP/Contents/Info.plist"
+    for key in SUAutomaticallyUpdate SUEnableAutomaticChecks SUFeedURL SUPublicEDKey SURequireSignedFeed SUScheduledCheckInterval SUVerifyUpdateBeforeExtraction; do
+        /usr/libexec/PlistBuddy -c "Delete :$key" "$APP_INFO" >/dev/null 2>&1 || true
+    done
+fi
+
 echo "==> Embedding the CLI and flattening Xcode resource bundles"
 swift build -c release --scratch-path "$SPOTLIGHT_SCRATCH" --product down
 CLI_BIN="$(swift build -c release --scratch-path "$SPOTLIGHT_SCRATCH" --product down --show-bin-path)/down"

--- a/Scripts/verify-bundle.sh
+++ b/Scripts/verify-bundle.sh
@@ -184,8 +184,11 @@ HOST_BUILD="$(host_build "$APP")"
 
 SPOTLIGHT_SHORT="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$SPOTLIGHT_PLIST" 2>/dev/null || echo '')"
 SPOTLIGHT_BUILD="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$SPOTLIGHT_PLIST" 2>/dev/null || echo '')"
+HOST_BUNDLE_ID="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$CONTENTS/Info.plist" 2>/dev/null || echo '')"
+SPOTLIGHT_BUNDLE_ID="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$SPOTLIGHT_PLIST" 2>/dev/null || echo '')"
 check "$([ "$SPOTLIGHT_SHORT" = "$HOST_SHORT" ] && echo 1 || echo 0)" "Spotlight importer marketing version matches host"
 check "$([ "$SPOTLIGHT_BUILD" = "$HOST_BUILD" ] && echo 1 || echo 0)" "Spotlight importer build version matches host"
+check "$([ "$SPOTLIGHT_BUNDLE_ID" = "$HOST_BUNDLE_ID.spotlight" ] && echo 1 || echo 0)" "Spotlight importer identifier follows host"
 
 for appex in "$CONTENTS"/PlugIns/*.appex; do
     [ -e "$appex" ] || continue
@@ -194,8 +197,17 @@ for appex in "$CONTENTS"/PlugIns/*.appex; do
     EXT_PLIST="$(appex_plist "$appex" || true)"
     EXT_SHORT="$(/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" "$EXT_PLIST" 2>/dev/null || echo "")"
     EXT_BUILD="$(/usr/libexec/PlistBuddy -c "Print :CFBundleVersion" "$EXT_PLIST" 2>/dev/null || echo "")"
+    EXT_BUNDLE_ID="$(/usr/libexec/PlistBuddy -c "Print :CFBundleIdentifier" "$EXT_PLIST" 2>/dev/null || echo "")"
     check "$([ "$EXT_SHORT" = "$HOST_SHORT" ] && echo 1 || echo 0)" "$(basename "$appex") marketing version matches host"
     check "$([ "$EXT_BUILD" = "$HOST_BUILD" ] && echo 1 || echo 0)" "$(basename "$appex") build version matches host"
+    case "$(basename "$appex")" in
+        DownrightQL.appex) EXPECTED_EXTENSION_ID="$HOST_BUNDLE_ID.quicklook" ;;
+        DownrightThumb.appex) EXPECTED_EXTENSION_ID="$HOST_BUNDLE_ID.thumbnail" ;;
+        *) EXPECTED_EXTENSION_ID="" ;;
+    esac
+    if [ -n "$EXPECTED_EXTENSION_ID" ]; then
+        check "$([ "$EXT_BUNDLE_ID" = "$EXPECTED_EXTENSION_ID" ] && echo 1 || echo 0)" "$(basename "$appex") identifier follows host"
+    fi
 done
 
 # Numeric, monotonically increasing CFBundleVersion is a release gate concern
@@ -229,7 +241,13 @@ if [ "$PRODUCTION" = "1" ]; then
     check "$([ "$VERIFY_BEFORE_EXTRACTION" = "true" ] && echo 1 || echo 0)" "update verified before extraction"
     check "$INTERVAL_OK" "scheduled update interval is positive"
 else
-    check 1 "updater-disabled configuration (dev bundle)"
+    DEV_UPDATER_KEYS=0
+    for key in SUAutomaticallyUpdate SUEnableAutomaticChecks SUFeedURL SUPublicEDKey SURequireSignedFeed SUScheduledCheckInterval SUVerifyUpdateBeforeExtraction; do
+        if /usr/libexec/PlistBuddy -c "Print :$key" "$CONTENTS/Info.plist" >/dev/null 2>&1; then
+            DEV_UPDATER_KEYS=$((DEV_UPDATER_KEYS + 1))
+        fi
+    done
+    check "$([ "$DEV_UPDATER_KEYS" -eq 0 ] && echo 1 || echo 0)" "updater-disabled configuration (dev bundle)"
 fi
 
 echo

--- a/Sources/DownrightApp/AI/FileWatcher.swift
+++ b/Sources/DownrightApp/AI/FileWatcher.swift
@@ -1,4 +1,5 @@
 import Foundation
+import CryptoKit
 
 /// Watches a single file for external rewrites (§8.1).
 ///
@@ -18,8 +19,22 @@ final class FileWatcher {
         var modified: Date
         var size: Int
         var inode: UInt64
+        /// A content signature closes the gap where an editor rewrites a file
+        /// in place without changing its size or filesystem timestamp.
+        var contentDigest: Data?
 
-        static let missing = Snapshot(modified: .distantPast, size: -1, inode: 0)
+        static let missing = Snapshot(
+            modified: .distantPast,
+            size: -1,
+            inode: 0,
+            contentDigest: nil
+        )
+
+        func withContentDigest(_ digest: Data) -> Snapshot {
+            var copy = self
+            copy.contentDigest = digest
+            return copy
+        }
     }
 
     enum Event {
@@ -49,9 +64,26 @@ final class FileWatcher {
     private var pollTimer: DispatchSourceTimer?
     private var lastSnapshot: Snapshot
     private var coalesceWorkItem: DispatchWorkItem?
+    /// A filesystem event is a strong signal that content should be checked
+    /// immediately. Keep that request when a polling tick happens to
+    /// coalesce with the event.
+    private var forceContentDigestOnNextCheck = false
     /// Writes we made ourselves must not come back to us as external changes.
     private var suppressUntil: Date = .distantPast
-    private var suppressedSnapshot: Snapshot?
+    /// The last snapshot observed while an own-write suppression window was
+    /// open.  This is deliberately separate from `lastSnapshot`: advancing the
+    /// baseline before deciding whether a snapshot is ours is the race that
+    /// used to swallow an external atomic replacement.
+    private var suppressedSnapshots: [Snapshot] = []
+    private var suppressionBaseline: Snapshot?
+    private var expectedOwnSnapshot: Snapshot?
+    private var ownWriteGeneration: UInt64 = 0
+    /// Metadata is the cheap path for ordinary polls. Every few polls we
+    /// still hash unchanged metadata so an in-place rewrite that preserves
+    /// inode, size, and timestamps is detected even on filesystems whose
+    /// event stream is unavailable. FSEvents and test probes force a hash.
+    private var pollProbeCount: UInt64 = 0
+    private let contentDigestPollStride: UInt64 = 4
     /// Bumped on every `stop()` so in-flight coalesced work becomes a no-op.
     private var generation: UInt64 = 0
 
@@ -114,6 +146,7 @@ final class FileWatcher {
         pollTimer = nil
         coalesceWorkItem?.cancel()
         coalesceWorkItem = nil
+        forceContentDigestOnNextCheck = false
     }
 
     /// Point the watcher at a different file (Save As, or following a rename).
@@ -124,6 +157,7 @@ final class FileWatcher {
             stopOnQueue()
             url = resolved
             lastSnapshot = FileWatcher.snapshot(of: resolved)
+            pollProbeCount = 0
             start()
         }
     }
@@ -133,16 +167,50 @@ final class FileWatcher {
     /// document — the toggle-a-checkbox case (§8.5) makes this obvious fast.
     func suppressOwnWrite(for interval: TimeInterval = 0.6) {
         onQueue {
+            ownWriteGeneration &+= 1
+            suppressionBaseline = lastSnapshot
+            expectedOwnSnapshot = nil
+            suppressedSnapshots.removeAll(keepingCapacity: true)
             suppressUntil = Date().addingTimeInterval(interval)
-            suppressedSnapshot = nil
         }
     }
 
-    /// Call after writing so the baseline matches what is now on disk.
-    func acknowledgeOwnWrite() {
+    /// Call after writing so the baseline can reconcile the replacement.  When
+    /// supplied, `contents` are the exact bytes Downright intended to write;
+    /// retaining them is what distinguishes a racing external replacement from
+    /// a successful own save even if no filesystem event arrived yet.
+    func acknowledgeOwnWrite(contents: Data? = nil) {
         onQueue {
-            lastSnapshot = FileWatcher.snapshot(of: url)
+            let actual = FileWatcher.snapshot(of: url)
+            // Passing the bytes written by the document layer lets us tell an
+            // external replacement that won the race before this callback from
+            // the bytes Downright intended to write.  Keep the no-argument API
+            // for existing callers; its snapshot remains the best available
+            // fallback when the caller cannot provide the payload.
+            expectedOwnSnapshot = contents.map {
+                actual.withContentDigest(FileWatcher.contentDigest(for: $0))
+            } ?? actual
+
+            if actual == expectedOwnSnapshot {
+                lastSnapshot = actual
+            } else if actual != lastSnapshot {
+                // The file on disk is not the payload we just wrote.  Retain it
+                // as an external observation for the reconciliation pass.
+                recordSuppressedSnapshot(actual)
+            }
             suppressUntil = Date().addingTimeInterval(0.25)
+        }
+    }
+
+    /// A guarded save failed before committing our payload. End suppression
+    /// immediately so the restored external generation is observed normally.
+    func cancelOwnWriteSuppression() {
+        onQueue {
+            expectedOwnSnapshot = nil
+            suppressedSnapshots.removeAll(keepingCapacity: true)
+            suppressUntil = .distantPast
+            forceContentDigestOnNextCheck = true
+            scheduleCheck(forceContentDigest: true)
         }
     }
 
@@ -227,7 +295,8 @@ final class FileWatcher {
             URL(fileURLWithPath: path).standardizedFileURL.path == target
         }
         guard matches else { return }
-        scheduleCheck()
+        recordCurrentSnapshotIfSuppressed()
+        scheduleCheck(forceContentDigest: true)
     }
 
     /// Whether a path under a watched directory is worth waking the owner for.
@@ -268,23 +337,133 @@ final class FileWatcher {
 
     // MARK: - Change detection
 
-    private func scheduleCheck() {
+    private func scheduleCheck(forceContentDigest: Bool = false) {
+        if forceContentDigest {
+            forceContentDigestOnNextCheck = true
+        }
         coalesceWorkItem?.cancel()
         let gen = generation
+        let writeGen = ownWriteGeneration
         let item = DispatchWorkItem { [weak self] in
-            guard let self, self.generation == gen else { return }
-            self.check()
+            guard let self,
+                  self.generation == gen,
+                  self.ownWriteGeneration == writeGen
+            else { return }
+            let shouldForceContentDigest = self.forceContentDigestOnNextCheck
+            self.forceContentDigestOnNextCheck = false
+            self.check(forceContentDigest: shouldForceContentDigest)
         }
         coalesceWorkItem = item
         queue.asyncAfter(deadline: .now() + coalesceInterval, execute: item)
     }
 
-    private func check() {
-        let now = FileWatcher.snapshot(of: url)
-        guard now != lastSnapshot else { return }
+    /// Synchronous filesystem probe used by deterministic integration tests.
+    /// Production notifications still arrive through FSEvents and the polling
+    /// safety net; this hook only avoids making race tests depend on scheduler
+    /// timing.
+    func checkNowForTesting() {
+        onQueue { check(forceContentDigest: true) }
+    }
 
+    /// A production-shaped metadata-only probe used by deterministic tests to
+    /// exercise the bounded same-metadata fallback without waiting 1.5s per
+    /// poll. Unlike `checkNowForTesting`, this does not force a content read.
+    func pollNowForTesting() {
+        onQueue { check(forceContentDigest: false) }
+    }
+
+    private func check(forceContentDigest: Bool = false) {
+        pollProbeCount &+= 1
+        let metadata = FileWatcher.metadata(of: url) ?? .missing
+        let metadataChanged = !FileWatcher.metadataMatches(metadata, lastSnapshot)
+        let periodicContentProbe = pollProbeCount % contentDigestPollStride == 0
+        let suppressionActive = Date() < suppressUntil
+        guard forceContentDigest || metadataChanged || periodicContentProbe || !suppressedSnapshots.isEmpty else {
+            return
+        }
+
+        let now = FileWatcher.snapshot(of: url, includeContentDigest: true)
+
+        if suppressionActive {
+            guard now != lastSnapshot else { return }
+            if let expectedOwnSnapshot, now == expectedOwnSnapshot {
+                // Consume our own replacement, but do not discard an external
+                // snapshot observed earlier in the same generation.
+                lastSnapshot = now
+            } else {
+                recordSuppressedSnapshot(now)
+            }
+            scheduleCheck()
+            return
+        }
+
+        if !suppressedSnapshots.isEmpty {
+            reconcileSuppressedChange(final: now)
+            return
+        }
+
+        guard now != lastSnapshot else { return }
         let previous = lastSnapshot
         lastSnapshot = now
+        deliver(event(for: now, previous: previous))
+    }
+
+    /// Reconciles observations made while an own-write window was open.  The
+    /// final snapshot is always committed, including when an external change
+    /// preceded our own bytes; this prevents a later poll from re-reporting the
+    /// suppressed own write.  Only the external snapshot is delivered.
+    private func reconcileSuppressedChange(final: Snapshot) {
+        let previous = suppressionBaseline ?? lastSnapshot
+        let expected = expectedOwnSnapshot
+        var candidates = suppressedSnapshots.filter {
+            $0 != expected && $0 != previous
+        }
+        if final != previous, final != expected {
+            candidates.append(final)
+        }
+        // Atomic replacement can expose a brief missing path between unlink
+        // and rename.  Once the expected own bytes are present, that transient
+        // is part of our save rather than an external removal event.
+        if final == expected, !candidates.isEmpty,
+           candidates.allSatisfy({ $0.size < 0 }) {
+            candidates.removeAll(keepingCapacity: true)
+        }
+        let observedExternal = candidates.last
+
+        suppressionBaseline = nil
+        expectedOwnSnapshot = nil
+        suppressedSnapshots.removeAll(keepingCapacity: true)
+        suppressUntil = .distantPast
+        lastSnapshot = final
+
+        if let observedExternal {
+            deliver(event(for: observedExternal, previous: previous))
+        }
+    }
+
+    private func recordSuppressedSnapshot(_ snapshot: Snapshot) {
+        guard snapshot != suppressionBaseline,
+              !suppressedSnapshots.contains(snapshot)
+        else { return }
+        suppressedSnapshots.append(snapshot)
+    }
+
+    private func recordCurrentSnapshotIfSuppressed() {
+        guard Date() < suppressUntil else { return }
+        let snapshot = FileWatcher.snapshot(of: url)
+        guard snapshot != lastSnapshot else { return }
+        if let expectedOwnSnapshot, snapshot == expectedOwnSnapshot {
+            lastSnapshot = snapshot
+        } else {
+            recordSuppressedSnapshot(snapshot)
+        }
+    }
+
+    private func deliver(_ event: Event) {
+        DispatchQueue.main.async { [handler] in handler(event) }
+    }
+
+    private func event(for now: Snapshot, previous: Snapshot) -> Event {
 
         // An atomic save deletes the original file before renaming the new one
         // in; if we act on the deletion we would close the document or report
@@ -302,8 +481,7 @@ final class FileWatcher {
            let relocated = FileWatcher.locate(previous, in: url.deletingLastPathComponent()) {
             retarget(to: relocated)
             let newURL = url
-            DispatchQueue.main.async { [handler] in handler(.renamed(to: newURL)) }
-            return
+            return .renamed(to: newURL)
         }
 
         let event: Event
@@ -315,33 +493,16 @@ final class FileWatcher {
             event = .changed
         }
 
-        if Date() < suppressUntil {
-            // Still inside the suppression window for our own write.
-            // Defer notification until the suppression window closes and
-            // acknowledgeOwnWrite has had an opportunity to update lastSnapshot.
-            scheduleCheck()
-            return
-        }
-
-        // Absorb a snapshot we already surfaced while the suppression window was
-        // open (FSEvents can retransmit), so the one external write is reported
-        // once, not repeatedly for each delivery.
-        if let suppressed = suppressedSnapshot, now == suppressed {
-            suppressedSnapshot = nil
-            return
-        }
-        suppressedSnapshot = nil
-
-        DispatchQueue.main.async { [handler] in handler(event) }
+        return event
     }
 
     /// Finds the file that used to be at the watched path, shallowly, in one
     /// directory.
     ///
-    /// Matched on the *whole* snapshot — inode, size, and modification time —
-    /// not on the inode alone: a rename changes none of the three, while an
-    /// inode number freed by a genuine deletion can be handed straight back to
-    /// an unrelated new file.
+    /// Matched on the *whole* snapshot — inode, size, modification time, and
+    /// content digest — not on the inode alone: a rename changes none of these,
+    /// while an inode number freed by a genuine deletion can be handed straight
+    /// back to an unrelated new file.
     ///
     /// Only ever runs when the watched file has just disappeared, so the cost
     /// is paid once per removal rather than once per event.  Capped because
@@ -353,20 +514,60 @@ final class FileWatcher {
         }
         for name in names.prefix(4096) {
             let candidate = directory.appendingPathComponent(name)
-            if snapshot(of: candidate) == wanted { return candidate }
+            guard let metadata = metadata(of: candidate),
+                  metadata.modified == wanted.modified,
+                  metadata.size == wanted.size,
+                  metadata.inode == wanted.inode
+            else { continue }
+            // Only hash a candidate whose inode/metadata could actually be the
+            // relocated file; a busy sibling directory should stay cheap.
+            if wanted.contentDigest == nil || snapshot(of: candidate) == wanted {
+                return candidate
+            }
         }
         return nil
     }
 
-    private static func snapshot(of url: URL) -> Snapshot {
+    private static func snapshot(of url: URL, includeContentDigest: Bool = true) -> Snapshot {
+        for _ in 0..<3 {
+            guard let before = metadata(of: url) else { return .missing }
+            guard includeContentDigest || before != .missing else { return .missing }
+            guard includeContentDigest else { return before }
+            guard let data = try? Data(contentsOf: url, options: .mappedIfSafe) else {
+                return before
+            }
+            guard let after = metadata(of: url) else { return .missing }
+            guard before == after else { continue }
+            return before.withContentDigest(contentDigest(for: data))
+        }
+
+        // A file that is being rewritten continuously is still represented by
+        // its latest metadata.  The next FSEvents/poll pass will retry the
+        // content signature once the writer settles.
+        return metadata(of: url) ?? .missing
+    }
+
+    private static func metadataMatches(_ lhs: Snapshot, _ rhs: Snapshot) -> Bool {
+        lhs.modified == rhs.modified
+            && lhs.size == rhs.size
+            && lhs.inode == rhs.inode
+    }
+
+    private static func metadata(of url: URL) -> Snapshot? {
         var st = stat()
-        guard stat(url.path, &st) == 0 else { return .missing }
+        guard stat(url.path, &st) == 0 else { return nil }
         let seconds = TimeInterval(st.st_mtimespec.tv_sec)
         let nanos = TimeInterval(st.st_mtimespec.tv_nsec) / 1_000_000_000
         return Snapshot(
             modified: Date(timeIntervalSince1970: seconds + nanos),
             size: Int(st.st_size),
-            inode: UInt64(st.st_ino)
+            inode: UInt64(st.st_ino),
+            contentDigest: nil
         )
     }
+
+    private static func contentDigest(for data: Data) -> Data {
+        Data(SHA256.hash(data: data))
+    }
+
 }

--- a/Sources/DownrightApp/AI/MarkdownDocument.swift
+++ b/Sources/DownrightApp/AI/MarkdownDocument.swift
@@ -12,13 +12,34 @@ enum SaveIntent {
     /// An explicit "keep my changes and write them over the file" decision,
     /// made by the user through the conflict bar.
     case keepMine
+    /// Recreates a path that is missing or replaces one that cannot currently
+    /// be read. This intent is only issued from the explicit recovery sheet;
+    /// autosave, close, quit, and task toggles must never choose it.
+    case recreateFile
 }
 
-enum SaveError: Error {
+enum SaveError: Error, LocalizedError {
     /// The save was refused because writing the buffer would clobber a newer
     /// on-disk version whose conflict had not been resolved.  The conflict has
     /// already been surfaced via `onExternalEvent`.
     case blockedByExternalConflict
+    /// The document disappeared after it was opened. A normal save must not
+    /// silently bring it back.
+    case fileMissing(URL)
+    /// The path still exists but could not be read, so overwriting it would be
+    /// an uninformed destructive action.
+    case fileUnreadable(URL, underlying: Error)
+
+    var errorDescription: String? {
+        switch self {
+        case .blockedByExternalConflict:
+            return "The file changed on disk. Review the conflict before saving."
+        case .fileMissing:
+            return "The original file is missing. Choose Save a Copy or explicitly recreate it."
+        case .fileUnreadable(_, let error):
+            return "The original file could not be read: \(error.localizedDescription)"
+        }
+    }
 }
 
 /// Owns the command boundary AppKit otherwise keeps private.  Storage delegate
@@ -61,6 +82,36 @@ final class MarkdownUndoManager: UndoManager {
 /// user's back.
 @MainActor
 final class MarkdownDocument: NSObject {
+    /// The save boundary's complete view of the backing path. Read failures
+    /// are data, not an absence of evidence: only `.unchanged` permits an
+    /// implicit write.
+    enum DiskState {
+        case unchanged(data: Data, fidelity: ByteFidelity)
+        case changed(text: String, hunks: [ChangeHunk], data: Data, fidelity: ByteFidelity)
+        case missing
+        case unreadable(Error)
+    }
+
+    /// One explicit state vocabulary for native chrome and accessibility.
+    /// Provenance is intentionally a short action label rather than a second
+    /// state machine; it is useful in a tooltip without cluttering the toolbar.
+    struct PresentationState: Equatable {
+        enum Phase: Equatable {
+            case neutral
+            case edited
+            case saving
+            case saved
+            case changedOnDisk
+            case conflict
+            case saveFailed
+        }
+
+        var phase: Phase
+        var provenance: String?
+        var detail: String?
+
+        static let neutral = PresentationState(phase: .neutral, provenance: nil, detail: nil)
+    }
     /// What an external write did while the buffer was dirty (§8.1).
     struct Conflict {
         var incomingText: String
@@ -108,11 +159,19 @@ final class MarkdownDocument: NSObject {
     private(set) var isDirty = false
     /// Hash of what is currently on disk, as far as we know.
     private(set) var diskHash: String = ""
+    /// Raw-byte generation token for save compare-and-swap. `diskHash` is a
+    /// text/review identity and deliberately cannot distinguish BOM or CRLF.
+    private var diskByteHash: String = ""
+    /// Last text generation successfully read from or committed to disk.
+    /// Recovery discard returns here rather than leaving discarded edits in a
+    /// buffer that a later keystroke could accidentally make savable again.
+    private var lastCommittedText: String = ""
     /// An external write the buffer has not yet been reconciled with.  Non-nil
     /// while a conflict bar is showing — and, critically, stays non-nil even if
     /// that bar is dismissed — so an implicit save never silently writes the
     /// buffer over the newer on-disk version.
     private(set) var pendingConflict: Conflict?
+    private(set) var presentationState: PresentationState = .neutral
 
     /// The document as the reader last **finished reviewing** it.
     ///
@@ -141,7 +200,10 @@ final class MarkdownDocument: NSObject {
     /// that runs past a second should not be silent.
     var onParseActivity: ((Bool) -> Void)?
     var onExternalEvent: ((ExternalEvent) -> Void)?
+    /// Deterministic filesystem-race seam. Production never assigns it.
+    var beforeSaveCommitForTesting: (() -> Void)?
     var onDirtyChanged: ((Bool) -> Void)?
+    var onPresentationStateChanged: ((PresentationState) -> Void)?
     /// Undo and redo mutate storage outside `MarkdownTextView`'s source-edit
     /// path. The owner uses this boundary to lock every visible viewport before
     /// the synchronous reparse changes layout.
@@ -175,17 +237,43 @@ final class MarkdownDocument: NSObject {
     /// Trailing quiet-period debounce for external writes.  See
     /// `handleExternalWrite()`.
     private var pendingExternalWrite: DispatchWorkItem?
+    /// Invalidates background read/diff work when a newer filesystem event
+    /// lands before the prepared snapshot reaches the main actor.
+    private var externalPreparationGeneration: UInt64 = 0
     private var isAbsorbingBurst = false
     private var reparseScheduled = false
     private var isApplyingExternalChange = false
+    /// NSTextStorage delivers its delegate callback on a later main-actor
+    /// turn. Keep the resulting source text with each callback token so a
+    /// local edit that lands before the callback cannot spend the token meant
+    /// for the external transaction. This also lets a converged synchronous
+    /// undo/redo consume its own callback instead of leaving a stale token
+    /// behind for the next real edit.
+    private var ignoredExternalStorageCallbackTexts: [String] = []
     private var isApplyingBatch = false
     private var suppressReparse = false
     private let parseCoordinator: MarkdownParseCoordinator
     private var parseTask: Task<Void, Never>?
     private var parseControlTask: Task<Void, Never>?
     private(set) var revision = MarkdownParseRevision.zero
+    /// Most recent immutable snapshot accepted from the asynchronous parse
+    /// lane. This distinguishes structure-only first paint from full parse
+    /// convergence in diagnostics and rendered-window acceptance.
+    private(set) var lastAsyncParseRevision: MarkdownParseRevision?
     private var isClosed = false
     private var preferencesObservation: NSObjectProtocol?
+    private var savedStateWorkItem: DispatchWorkItem?
+    private struct PendingExternalRestore {
+        var previousText: String
+        var selection: NSRange
+        var anchor: ScrollAnchor
+    }
+    private var pendingExternalRestore: PendingExternalRestore?
+    /// Source ranges actually mutated by an external reconciliation. Existing
+    /// attributed runs move with an incremental NSTextStorage edit, so AST
+    /// identity churn from shifted offsets must not force a document-wide
+    /// redecorate.
+    private var nextExternalDirtyOverride: DirtySet?
     /// After open's structure-only first paint, the next full async parse must
     /// restyle wholesale — structure trees are not decoration-compatible.
     private var forceNextDirtyWholesale = false
@@ -229,6 +317,7 @@ final class MarkdownDocument: NSObject {
             NotificationCenter.default.removeObserver(preferencesObservation)
         }
         parseTask?.cancel()
+        savedStateWorkItem?.cancel()
         let coordinator = parseCoordinator
         Task { await coordinator.shutdown() }
     }
@@ -251,7 +340,8 @@ final class MarkdownDocument: NSObject {
         // Read before touching any state: a file that vanishes between the
         // link-follow and the read must leave the document exactly as the
         // caller's `close()` left it, not half-torn-down.
-        let (text, fidelity) = try DocumentIO.read(contentsOf: canonical)
+        let snapshot = try DocumentIO.readSnapshot(contentsOf: canonical)
+        let (text, fidelity) = (snapshot.text, snapshot.fidelity)
 
         isClosed = false
         enqueueParseControl { await $0.resume() }
@@ -272,7 +362,11 @@ final class MarkdownDocument: NSObject {
         suppressReparse = false
 
         diskHash = DocumentIO.contentHash(text)
+        diskByteHash = DocumentIO.contentHash(snapshot.data)
+        lastCommittedText = text
         isDirty = false
+        lastAsyncParseRevision = nil
+        publishPresentationState(.neutral)
 
         // Structure-only first paint for outline/state. The controller paints
         // decorations after applying zoom/folds; full decoration converges on
@@ -287,7 +381,11 @@ final class MarkdownDocument: NSObject {
 
         startWatching(canonical)
         forceNextDirtyWholesale = true
-        startAsyncReparse()
+        // First full paint must not depend on the serial typing lane's
+        // resume/discard control messages for a document that may have just
+        // been reused in place. The immutable revision gate makes this direct
+        // parse safe, and subsequent edits return to the coalescing lane.
+        startPriorityAsyncReparse()
     }
 
     // MARK: - Review baseline (§8.1, §8.2)
@@ -367,6 +465,7 @@ final class MarkdownDocument: NSObject {
     /// call site reads as intent rather than as cleanup.
     func markChangesReviewed() {
         changes.clear()
+        if !isDirty, pendingConflict == nil { publishPresentationState(.neutral) }
     }
 
     /// Adopts text with no backing file — used by `Compare` windows and by the
@@ -383,12 +482,13 @@ final class MarkdownDocument: NSObject {
         suppressReparse = false
         reparseSynchronously(notifying: true, wholesale: true)
         isDirty = false
+        publishPresentationState(.neutral)
     }
 
     func save(intent: SaveIntent = .normal) throws {
         guard let url else {
             let error = CocoaError(.fileNoSuchFile)
-            onSaveFailure?(error)
+            publishSaveFailure(error)
             throw error
         }
         let text = storage.string
@@ -398,57 +498,171 @@ final class MarkdownDocument: NSObject {
         // checkbox toggle, close alert) funnels through here, and none of them
         // may make the keep-mine call for the user.  Surface any unresolved
         // conflict — or one detected right now — and refuse to write.
-        if intent == .normal, isDirty {
-            if let conflict = pendingConflict {
+        var expectedDiskData: Data?
+        if intent != .recreateFile {
+            if intent == .normal, let conflict = pendingConflict {
                 throw presentBlockingConflict(conflict, incoming: conflict.incomingText, incomingHash: nil)
             }
-            if let detected = detectExternalChange() {
+            switch inspectDiskState() {
+            case .unchanged(let data, let freshFidelity):
+                expectedDiskData = data
+                fidelity = freshFidelity
+            case .changed(let incoming, let hunks, let data, let freshFidelity):
+                if intent == .normal {
+                    let conflict = Conflict(
+                        incomingText: incoming,
+                        hunks: hunks,
+                        changedBlockCount: hunks.count
+                    )
+                    throw presentBlockingConflict(
+                        conflict, incoming: incoming,
+                        incomingHash: SnapshotStore.hash(incoming)
+                    )
+                }
+                // Keep Mine is explicit about content, not byte formatting.
+                // Preserve the latest readable encoding/BOM/line-ending facts.
+                expectedDiskData = data
+                fidelity = freshFidelity
+            case .missing:
+                let error = SaveError.fileMissing(url)
+                publishSaveFailure(error)
+                throw error
+            case .unreadable(let underlying):
+                let error = SaveError.fileUnreadable(url, underlying: underlying)
+                publishSaveFailure(error)
+                throw error
+            }
+        } else {
+            // The recovery choice authorizes creation only while the path is
+            // still missing/unreadable. If a readable generation has appeared
+            // since the sheet was shown, it is external state and wins.
+            switch inspectDiskState() {
+            case .missing, .unreadable:
+                break
+            case .unchanged(let data, let freshFidelity):
+                expectedDiskData = data
+                fidelity = freshFidelity
+            case .changed(let incoming, let hunks, _, _):
                 let conflict = Conflict(
-                    incomingText: detected.text,
-                    hunks: detected.hunks,
-                    changedBlockCount: detected.hunks.count
+                    incomingText: incoming, hunks: hunks, changedBlockCount: hunks.count
                 )
                 throw presentBlockingConflict(
-                    conflict, incoming: detected.text,
-                    incomingHash: SnapshotStore.hash(detected.text)
+                    conflict, incoming: incoming, incomingHash: SnapshotStore.hash(incoming)
                 )
             }
         }
 
-        watcher?.suppressOwnWrite()
-        defer { watcher?.acknowledgeOwnWrite() }
+        publishPresentationState(PresentationState(
+            phase: .saving, provenance: presentationState.provenance, detail: nil
+        ))
+        let encoded: Data
         do {
-            try DocumentIO.write(text, to: url, fidelity: fidelity)
+            encoded = try DocumentIO.encodedData(text, fidelity: fidelity)
         } catch {
-            onSaveFailure?(error)
+            publishSaveFailure(error)
             throw error
         }
+        beforeSaveCommitForTesting?()
+        watcher?.suppressOwnWrite()
+        do {
+            if let expectedDiskData {
+                try DocumentIO.replaceExistingAtomically(
+                    with: encoded, at: url, expected: expectedDiskData
+                )
+            } else {
+                // Only the explicit Recreate File recovery action may create
+                // or replace without an inspected existing generation.
+                try encoded.write(to: url, options: .atomic)
+            }
+        } catch {
+            watcher?.cancelOwnWriteSuppression()
+            if let ioError = error as? DocumentIOError,
+               case .targetChanged(_, let generations) = ioError {
+                for data in generations {
+                    if let decoded = try? DocumentIO.decodeSnapshot(data, sourceURL: url) {
+                        SnapshotStore.shared.record(decoded.text, for: url, kind: .external)
+                    }
+                }
+            }
+            switch inspectDiskState() {
+            case .changed(let incoming, let hunks, _, _):
+                let conflict = Conflict(
+                    incomingText: incoming, hunks: hunks, changedBlockCount: hunks.count
+                )
+                throw presentBlockingConflict(
+                    conflict, incoming: incoming, incomingHash: SnapshotStore.hash(incoming)
+                )
+            case .missing:
+                let missing = SaveError.fileMissing(url)
+                publishSaveFailure(missing)
+                throw missing
+            case .unreadable(let underlying):
+                let unreadable = SaveError.fileUnreadable(url, underlying: underlying)
+                publishSaveFailure(unreadable)
+                throw unreadable
+            case .unchanged:
+                break
+            }
+            publishSaveFailure(error)
+            throw error
+        }
+        watcher?.acknowledgeOwnWrite(contents: encoded)
 
         diskHash = DocumentIO.contentHash(text)
+        diskByteHash = DocumentIO.contentHash(encoded)
+        lastCommittedText = text
         pendingConflict = nil
         SnapshotStore.shared.record(text, for: url, kind: .local)
         setDirty(false)
         persistState()
+        publishSavedState()
     }
 
-    /// Re-reads the file and decides whether saving the buffer would clobber
-    /// bytes on disk that are newer than the last state we acknowledged.  A
-    /// plain dirty buffer (unsaved edits, file untouched) returns `nil`.
-    private func detectExternalChange() -> (text: String, hunks: [ChangeHunk])? {
-        guard let url, let (incoming, _) = try? DocumentIO.read(contentsOf: url) else { return nil }
+    /// Re-reads the path at the write boundary. Missing and unreadable are
+    /// distinct fail-closed states, never collapsed into "no change".
+    func inspectDiskState() -> DiskState {
+        guard let url else { return .missing }
+        let snapshot: (text: String, fidelity: ByteFidelity, data: Data)
+        do {
+            snapshot = try DocumentIO.readSnapshot(contentsOf: url)
+        } catch {
+            if !FileManager.default.fileExists(atPath: url.path) {
+                return .missing
+            }
+            return .unreadable(error)
+        }
+        let incoming = snapshot.text
         let incomingHash = SnapshotStore.hash(incoming)
-        guard incomingHash != diskHash else { return nil }
+        let incomingByteHash = DocumentIO.contentHash(snapshot.data)
+        guard incomingByteHash != diskByteHash else {
+            return .unchanged(data: snapshot.data, fidelity: snapshot.fidelity)
+        }
+        // The decoded generation is still the one we opened; only its byte
+        // representation changed externally. Adopt those facts even when the
+        // buffer has local edits, so the edit is saved using the latest BOM,
+        // encoding, and line endings rather than silently reverting them.
+        if incomingHash == diskHash {
+            diskByteHash = incomingByteHash
+            fidelity = snapshot.fidelity
+            return .unchanged(data: snapshot.data, fidelity: snapshot.fidelity)
+        }
         // If the disk already holds the buffer's bytes, writing is a no-op and
         // there is nothing being clobbered.  A trailing-newline-only difference
         // is likewise not a content change: it is an artifact `DocumentIO` will
         // reconcile on this very write, so it must not surface as a conflict or
         // block an autosave.
-        guard incomingHash != SnapshotStore.hash(storage.string),
-              !finalNewlineDifferenceOnly(storage.string, incoming) else {
+        guard incomingHash != SnapshotStore.hash(storage.string) else {
             diskHash = incomingHash
-            return nil
+            diskByteHash = incomingByteHash
+            fidelity = snapshot.fidelity
+            return .unchanged(data: snapshot.data, fidelity: snapshot.fidelity)
         }
-        return (incoming, TextDiff.hunks(old: storage.string, new: incoming))
+        return .changed(
+            text: incoming,
+            hunks: TextDiff.hunks(old: storage.string, new: incoming),
+            data: snapshot.data,
+            fidelity: snapshot.fidelity
+        )
     }
 
     /// True when `a` and `b` differ only by the presence of a single trailing
@@ -457,6 +671,13 @@ final class MarkdownDocument: NSObject {
     /// never reverts the user's trailing-newline edit and a save never blocks
     /// on a phantom conflict for one.
     private func finalNewlineDifferenceOnly(_ a: String, _ b: String) -> Bool {
+        Self.finalNewlineDifferenceOnlyValue(a, b)
+    }
+
+    nonisolated private static func finalNewlineDifferenceOnlyValue(
+        _ a: String,
+        _ b: String
+    ) -> Bool {
         func strippedNewline(_ s: String) -> String {
             if s.hasSuffix("\r\n") { return String(s.dropLast(2)) }
             if s.hasSuffix("\n") || s.hasSuffix("\r") { return String(s.dropLast()) }
@@ -475,6 +696,11 @@ final class MarkdownDocument: NSObject {
         pendingConflict = conflict
         if let incomingHash { diskHash = incomingHash }
         if let url { SnapshotStore.shared.record(incoming, for: url, kind: .external) }
+        publishPresentationState(PresentationState(
+            phase: .conflict,
+            provenance: presentationState.provenance,
+            detail: "Changed on disk"
+        ))
         onExternalEvent?(.conflict(conflict))
         return .blockedByExternalConflict
     }
@@ -495,8 +721,48 @@ final class MarkdownDocument: NSObject {
         }
     }
 
+    /// Explicit recovery action. No implicit path may call this.
+    func recreateMissingFile() -> Result<Void, Error> {
+        do {
+            try save(intent: .recreateFile)
+            return .success(())
+        } catch {
+            return .failure(error)
+        }
+    }
+
+    /// Explicitly abandons unsaved local changes after a failed save. The
+    /// in-memory text remains visible until the window closes, but it is no
+    /// longer eligible for autosave and the missing path is never resurrected.
+    func discardUnsavedChanges() {
+        let replacement: String
+        if let url, let snapshot = try? DocumentIO.readSnapshot(contentsOf: url) {
+            replacement = snapshot.text
+            fidelity = snapshot.fidelity
+            diskHash = DocumentIO.contentHash(snapshot.text)
+            diskByteHash = DocumentIO.contentHash(snapshot.data)
+            lastCommittedText = snapshot.text
+        } else {
+            replacement = lastCommittedText
+        }
+        suppressReparse = true
+        storage.beginEditing()
+        storage.replaceCharacters(
+            in: NSRange(location: 0, length: storage.length), with: replacement
+        )
+        storage.endEditing()
+        suppressReparse = false
+        undoManager.removeAllActions()
+        reparseSynchronously(notifying: true, wholesale: true)
+        pendingConflict = nil
+        setDirty(false)
+        publishPresentationState(.neutral)
+    }
+
     func close() {
         isClosed = true
+        savedStateWorkItem?.cancel()
+        pendingExternalRestore = nil
         cancelParseWork()
         cancelPendingExternalWrite()
         // Persist *before* discarding: closing a window is not a review, and the
@@ -569,7 +835,10 @@ final class MarkdownDocument: NSObject {
 
         let delta = (replacement as NSString).length - range.length
         changes.adjust(forEditIn: range, delta: delta)
-        if !isApplyingExternalChange { setDirty(true) }
+        if !isApplyingExternalChange {
+            noteMutation(undoManager.isApplyingUndoRedo ? "Undo" : (actionName ?? "Edit"))
+            setDirty(true)
+        }
         return true
     }
 
@@ -587,6 +856,7 @@ final class MarkdownDocument: NSObject {
         }
         guard !accepted.isEmpty else { return }
 
+        noteMutation(actionName)
         onWillApplyEdits?(accepted)
         isApplyingBatch = true
         defer { isApplyingBatch = false }
@@ -614,6 +884,58 @@ final class MarkdownDocument: NSObject {
         guard isDirty != value else { return }
         isDirty = value
         onDirtyChanged?(value)
+        if value, presentationState.phase != .conflict {
+            publishPresentationState(PresentationState(
+                phase: .edited,
+                provenance: presentationState.provenance ?? "Edit",
+                detail: nil
+            ))
+        }
+    }
+
+    /// Records the human-scale action that most recently changed source. This
+    /// is deliberately callable from view/controller seams (Paste, Replace,
+    /// panel actions) while parser and layout callbacks have no access to it.
+    func noteMutation(_ provenance: String) {
+        let value = provenance.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !value.isEmpty else { return }
+        publishPresentationState(PresentationState(
+            phase: isDirty ? .edited : presentationState.phase,
+            provenance: value,
+            detail: presentationState.detail
+        ))
+    }
+
+    private func publishPresentationState(_ state: PresentationState) {
+        savedStateWorkItem?.cancel()
+        savedStateWorkItem = nil
+        guard state != presentationState else { return }
+        presentationState = state
+        onPresentationStateChanged?(state)
+    }
+
+    private func publishSaveFailure(_ error: Error) {
+        publishPresentationState(PresentationState(
+            phase: .saveFailed,
+            provenance: presentationState.provenance,
+            detail: error.localizedDescription
+        ))
+        onSaveFailure?(error)
+    }
+
+    private func publishSavedState() {
+        let provenance = presentationState.provenance
+        publishPresentationState(PresentationState(
+            phase: .saved, provenance: provenance, detail: nil
+        ))
+        let item = DispatchWorkItem { [weak self] in
+            MainActor.assumeIsolated {
+                guard let self, !self.isDirty, self.pendingConflict == nil else { return }
+                self.publishPresentationState(.neutral)
+            }
+        }
+        savedStateWorkItem = item
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.25, execute: item)
     }
 
     // MARK: - Parsing (§3.5)
@@ -686,15 +1008,41 @@ final class MarkdownDocument: NSObject {
         }
     }
 
+    /// External replacement must not wait behind an obsolete, non-cancellable
+    /// initial parse. Run this one snapshot concurrently and rely on the same
+    /// immutable revision/text checks used by the serial typing lane.
+    private func startPriorityAsyncReparse() {
+        guard !suppressReparse, !isClosed else { return }
+        let request = MarkdownParseRequest(
+            text: storage.string,
+            previous: parsed,
+            revision: revision
+        )
+        let coordinator = parseCoordinator
+        Task.detached(priority: .userInitiated) { [weak self, coordinator] in
+            let result = await coordinator.runImmediately(request)
+            await self?.applyAsyncParse(result)
+        }
+    }
+
     private func applyAsyncParse(_ result: MarkdownParseResult) {
         guard !isClosed,
               result.revision == revision,
               result.text == storage.string,
               result.document.text == result.text else { return }
         parsed = result.document
-        let dirty = forceNextDirtyWholesale ? DirtySet.wholesale : result.dirty
+        lastAsyncParseRevision = result.revision
+        let dirty = nextExternalDirtyOverride
+            ?? (forceNextDirtyWholesale ? DirtySet.wholesale : result.dirty)
+        nextExternalDirtyOverride = nil
         forceNextDirtyWholesale = false
         onReparse?(result.document, dirty)
+        if let restore = pendingExternalRestore {
+            pendingExternalRestore = nil
+            let restored = ScrollAnchoring.offset(for: restore.anchor, in: result.document)
+            restoreOffsetHandler?(restored)
+            restoreSelection(restore.previousText, restore.selection, near: restored)
+        }
     }
 
     private func cancelParseWork() {
@@ -758,7 +1106,7 @@ final class MarkdownDocument: NSObject {
         onExternalWriteActivity?(false)
     }
 
-    private func handleWatchEvent(_ event: FileWatcher.Event) {
+    func handleWatchEvent(_ event: FileWatcher.Event) {
         // `FileWatcher` dispatches to the main queue; a block already in
         // flight when `close()` ran cannot be retracted, and `stop()` only
         // cancels work that has not started.  A late event on a closed
@@ -768,6 +1116,11 @@ final class MarkdownDocument: NSObject {
         guard !isClosed else { return }
         switch event {
         case .removed:
+            publishPresentationState(PresentationState(
+                phase: .changedOnDisk,
+                provenance: presentationState.provenance,
+                detail: "File missing"
+            ))
             onExternalEvent?(.fileRemoved)
         case .restored:
             onExternalEvent?(.fileRestored)
@@ -808,6 +1161,7 @@ final class MarkdownDocument: NSObject {
     /// Internal rather than private so tests can drive an agent's write burst
     /// without racing a real filesystem watcher.
     func handleExternalWrite() {
+        externalPreparationGeneration &+= 1
         pendingExternalWrite?.cancel()
         if !isAbsorbingBurst {
             isAbsorbingBurst = true
@@ -831,62 +1185,158 @@ final class MarkdownDocument: NSObject {
         absorbExternalWrite()
     }
 
+    private struct PreparedExternalWrite: @unchecked Sendable {
+        let generation: UInt64
+        let url: URL
+        let capturedText: String
+        let baseline: String
+        let incoming: String
+        let fidelity: ByteFidelity
+        let incomingHash: String
+        let incomingByteHash: String
+        let baselineHunks: [ChangeHunk]
+        let applicationHunks: [ChangeHunk]
+    }
+
     private func absorbExternalWrite() {
         pendingExternalWrite = nil
-        defer { endBurstIfNeeded() }
-        guard let url, let (incoming, freshFidelity) = try? DocumentIO.read(contentsOf: url) else { return }
-        let incomingHash = SnapshotStore.hash(incoming)
-        let currentText = storage.string
-        guard incomingHash != SnapshotStore.hash(currentText) else {
-            diskHash = incomingHash
+        guard let url else {
+            endBurstIfNeeded()
             return
         }
+        let generation = externalPreparationGeneration
+        let capturedText = storage.string
+        let baseline = effectiveBaselineText(fallback: capturedText)
 
-        // A newline is a byte-fidelity property (`DocumentIO` reconciles it at
-        // save time), not document content.  If the on-disk bytes differ from
-        // the buffer only by the presence of a final newline — the common case
-        // is an external tool touching the file while the user trimmed its
-        // trailing newline — rewriting the buffer wholesale would silently
-        // restore the newline and revert that edit.  Acknowledge the disk state
-        // and keep the buffer.
-        if finalNewlineDifferenceOnly(currentText, incoming) {
-            diskHash = incomingHash
-            fidelity = freshFidelity
-            return
-        }
-
-        SnapshotStore.shared.record(incoming, for: url, kind: .external)
-        diskHash = incomingHash
-
-        if isDirty {  // Never clobber (§8.1).  The bar is non-modal; the buffer is
-            // untouched until the user picks.  Track it at the document level
-            // so implicit saves refuse to clobber even after the bar is
-            // dismissed.
-            //
-            // A conflict is diffed against the *buffer*, not against the review
-            // baseline: the question on screen is "my version or theirs", and
-            // the reader's own unsaved edits are one side of it.
-            let hunks = TextDiff.hunks(old: currentText, new: incoming)
-            let conflict = Conflict(
-                incomingText: incoming, hunks: hunks, changedBlockCount: hunks.count
+        // File I/O, history reservation, and the two Myers diffs are pure or
+        // internally synchronized. Keeping them off the main actor is what
+        // lets a reader continue scrolling while a large agent rewrite lands.
+        Task.detached(priority: .userInitiated) { [weak self] in
+            guard let snapshot = try? DocumentIO.readSnapshot(contentsOf: url) else {
+                await self?.finishExternalPreparation(generation: generation, prepared: nil)
+                return
+            }
+            let incoming = snapshot.text
+            let freshFidelity = snapshot.fidelity
+            let incomingHash = SnapshotStore.hash(incoming)
+            let incomingByteHash = DocumentIO.contentHash(snapshot.data)
+            let currentHash = SnapshotStore.hash(capturedText)
+            if incomingHash != currentHash,
+               !Self.finalNewlineDifferenceOnlyValue(capturedText, incoming) {
+                SnapshotStore.shared.record(incoming, for: url, kind: .external)
+            }
+            let baselineHunks = incomingHash == currentHash
+                ? [] : TextDiff.hunks(old: baseline, new: incoming)
+            let applicationHunks = incomingHash == currentHash
+                ? [] : TextDiff.hunks(old: capturedText, new: incoming)
+            let prepared = PreparedExternalWrite(
+                generation: generation,
+                url: url,
+                capturedText: capturedText,
+                baseline: baseline,
+                incoming: incoming,
+                fidelity: freshFidelity,
+                incomingHash: incomingHash,
+                incomingByteHash: incomingByteHash,
+                baselineHunks: baselineHunks,
+                applicationHunks: applicationHunks
             )
-            pendingConflict = conflict
-            onExternalEvent?(.conflict(conflict))
+            await self?.finishExternalPreparation(generation: generation, prepared: prepared)
+        }
+    }
+
+    private func finishExternalPreparation(
+        generation: UInt64,
+        prepared: PreparedExternalWrite?
+    ) {
+        guard !isClosed else { return }
+        guard generation == externalPreparationGeneration else { return }
+        defer { endBurstIfNeeded() }
+        guard let prepared, url == prepared.url else { return }
+
+        // A local edit that landed while the background diff ran wins. The
+        // captured clean snapshot is no longer safe to apply, so compute the
+        // conflict against the current buffer on a fresh background turn.
+        guard storage.string == prepared.capturedText else {
+            let current = storage.string
+            externalPreparationGeneration &+= 1
+            let nextGeneration = externalPreparationGeneration
+            isAbsorbingBurst = true
+            Task.detached(priority: .userInitiated) { [weak self] in
+                let hunks = TextDiff.hunks(old: current, new: prepared.incoming)
+                await self?.finishPreparedConflict(
+                    generation: nextGeneration,
+                    incoming: prepared.incoming,
+                    incomingHash: prepared.incomingHash,
+                    hunks: hunks
+                )
+            }
             return
         }
 
-        // The clean-buffer case is diffed against the review baseline.  This is
-        // the fix for "five writes in three seconds": every one of them reports
-        // what changed since the reader last looked, so writes 1–4 do not
-        // disappear behind write 5.
-        let baseline = effectiveBaselineText(fallback: currentText)
-        let hunks = TextDiff.hunks(old: baseline, new: incoming)
+        guard prepared.incomingHash != SnapshotStore.hash(prepared.capturedText) else {
+            diskHash = prepared.incomingHash
+            diskByteHash = prepared.incomingByteHash
+            fidelity = prepared.fidelity
+            if !isDirty, pendingConflict == nil { publishPresentationState(.neutral) }
+            return
+        }
+        if finalNewlineDifferenceOnly(prepared.capturedText, prepared.incoming) {
+            diskHash = prepared.incomingHash
+            diskByteHash = prepared.incomingByteHash
+            fidelity = prepared.fidelity
+            return
+        }
+
+        diskHash = prepared.incomingHash
+        diskByteHash = prepared.incomingByteHash
+        if isDirty {
+            presentPreparedConflict(incoming: prepared.incoming, hunks: prepared.applicationHunks)
+            return
+        }
 
         pendingConflict = nil
-        fidelity = freshFidelity
-        applyExternalText(incoming, hunks: hunks, baseline: baseline)
+        fidelity = prepared.fidelity
+        lastCommittedText = prepared.incoming
+        applyExternalText(
+            prepared.incoming,
+            hunks: prepared.baselineHunks,
+            baseline: prepared.baseline,
+            applicationHunks: prepared.applicationHunks
+        )
         unreadChanges = changes.isEmpty ? .none : .marked(count: changes.count)
+        let hunks = prepared.baselineHunks
+        publishPresentationState(PresentationState(
+            phase: .changedOnDisk,
+            provenance: nil,
+            detail: hunks.isEmpty ? nil : "\(hunks.count) changed block\(hunks.count == 1 ? "" : "s")"
+        ))
         onExternalEvent?(.applied(hunks: hunks))
+    }
+
+    private func finishPreparedConflict(
+        generation: UInt64,
+        incoming: String,
+        incomingHash: String,
+        hunks: [ChangeHunk]
+    ) {
+        guard !isClosed, generation == externalPreparationGeneration else { return }
+        defer { endBurstIfNeeded() }
+        diskHash = incomingHash
+        presentPreparedConflict(incoming: incoming, hunks: hunks)
+    }
+
+    private func presentPreparedConflict(incoming: String, hunks: [ChangeHunk]) {
+        let conflict = Conflict(
+            incomingText: incoming, hunks: hunks, changedBlockCount: hunks.count
+        )
+        pendingConflict = conflict
+        publishPresentationState(PresentationState(
+            phase: .conflict,
+            provenance: presentationState.provenance,
+            detail: "Changed on disk"
+        ))
+        onExternalEvent?(.conflict(conflict))
     }
 
     /// The text to diff an incoming write against.  Falls back to the buffer
@@ -899,7 +1349,12 @@ final class MarkdownDocument: NSObject {
     /// Replaces the buffer in place, holding the reader's position by anchoring
     /// to the nearest unchanged heading rather than to a byte offset (§8.1),
     /// and putting the selection back afterwards.
-    func applyExternalText(_ incoming: String, hunks: [ChangeHunk], baseline: String? = nil) {
+    func applyExternalText(
+        _ incoming: String,
+        hunks: [ChangeHunk],
+        baseline: String? = nil,
+        applicationHunks preparedApplicationHunks: [ChangeHunk]? = nil
+    ) {
         // Adopting the on-disk version resolves any outstanding conflict.
         pendingConflict = nil
         let topOffset = currentTopOffsetProvider?() ?? 0
@@ -907,15 +1362,32 @@ final class MarkdownDocument: NSObject {
         let previousText = storage.string
         let previousSelection = currentSelectionProvider?() ?? NSRange(location: 0, length: 0)
 
-        adoptExternalBuffer(incoming)
+        // External replacement is a new immutable source generation just like
+        // a local character edit. Without advancing here, an initial/open parse
+        // still in flight can share the same revision and cause the coordinator
+        // to reject this newer snapshot as a duplicate.
+        invalidateParseWorkForEdit()
+        let applicationHunks = preparedApplicationHunks ?? (
+            (baseline ?? previousText) == previousText
+                ? hunks
+                : TextDiff.hunks(old: previousText, new: incoming)
+        )
+        adoptExternalBuffer(incoming, hunks: applicationHunks)
         setDirty(false)
 
-        reparseNow(wholesale: true)
         changes.apply(hunks: hunks, newText: incoming, oldText: baseline ?? previousText)
-
-        let restored = ScrollAnchoring.offset(for: anchor, in: parsed)
-        restoreOffsetHandler?(restored)
-        restoreSelection(previousText, previousSelection, near: restored)
+        pendingExternalRestore = PendingExternalRestore(
+            previousText: previousText,
+            selection: previousSelection,
+            anchor: anchor
+        )
+        nextExternalDirtyOverride = DirtySet(
+            ranges: applicationHunks.map {
+                TextDiff.anchorRange(for: $0, inNewTextOfLength: (incoming as NSString).length)
+            },
+            isWholesale: false
+        )
+        startPriorityAsyncReparse()
     }
 
     /// Puts the buffer's whole contents behind an external write, with an undo
@@ -928,7 +1400,7 @@ final class MarkdownDocument: NSObject {
     /// anything they had done.  So the undo restores the text *and* surfaces
     /// the disagreement it just created, through the same conflict bar that any
     /// other buffer-versus-disk disagreement uses.
-    private func adoptExternalBuffer(_ incoming: String) {
+    private func adoptExternalBuffer(_ incoming: String, hunks: [ChangeHunk]? = nil) {
         let previous = storage.string
         let whole = NSRange(location: 0, length: storage.length)
 
@@ -942,8 +1414,32 @@ final class MarkdownDocument: NSObject {
         undoManager.endUndoGrouping()
 
         isApplyingExternalChange = true
+        ignoredExternalStorageCallbackTexts.append(incoming)
         storage.beginEditing()
-        storage.replaceCharacters(in: whole, with: incoming)
+        if let hunks, !hunks.isEmpty {
+            let incomingText = incoming as NSString
+            for hunk in hunks.sorted(by: { $0.oldRange.location > $1.oldRange.location }) {
+                guard hunk.oldRange.location >= 0,
+                      hunk.oldRange.upperBound <= storage.length,
+                      hunk.newRange.location >= 0,
+                      hunk.newRange.upperBound <= incomingText.length else { continue }
+                storage.replaceCharacters(
+                    in: hunk.oldRange,
+                    with: incomingText.substring(with: hunk.newRange)
+                )
+            }
+            // Diff hunks are an optimisation, never a source of truth. If a
+            // capped/fallback diff cannot express the exact transformation,
+            // repair to the byte-faithful incoming text before publishing.
+            if storage.string != incoming {
+                storage.replaceCharacters(
+                    in: NSRange(location: 0, length: storage.length),
+                    with: incoming
+                )
+            }
+        } else {
+            storage.replaceCharacters(in: whole, with: incoming)
+        }
         storage.endEditing()
         isApplyingExternalChange = false
     }
@@ -1015,6 +1511,7 @@ final class MarkdownDocument: NSObject {
     /// Conflict resolution: take the version on disk, dropping local edits.
     func resolveConflictTakingTheirs(_ conflict: Conflict) {
         applyExternalText(conflict.incomingText, hunks: conflict.hunks)
+        publishPresentationState(.neutral)
     }
 
     /// Conflict resolution: keep the buffer and write it over the file.
@@ -1068,17 +1565,32 @@ extension MarkdownDocument: NSTextStorageDelegate {
         changeInLength delta: Int
     ) {
         guard editedMask.contains(.editedCharacters) else { return }
+        // Capture the post-edit source while the delegate callback is still
+        // describing this storage mutation. The task may run after another
+        // edit, so reading `storage.string` in the task would lose the
+        // transaction boundary and consume the wrong suppression token.
+        let callbackText = textStorage.string
         Task { @MainActor [weak self] in
-            self?.handleTextStorageEdit()
+            self?.handleTextStorageEdit(callbackText: callbackText)
         }
     }
 
-    private func handleTextStorageEdit() {
+    private func handleTextStorageEdit(callbackText: String) {
         guard !suppressReparse else { return }
+        if let tokenIndex = ignoredExternalStorageCallbackTexts.firstIndex(of: callbackText) {
+            ignoredExternalStorageCallbackTexts.remove(at: tokenIndex)
+            return
+        }
         // An explicit transaction may have already published its synchronous
         // parse before this delegate hop runs. Do not schedule a second parse
         // merely because NSTextStorage delivered the callback later.
         guard parsed.text != storage.string else { return }
+        // `NSTextStorageDelegate` is delivered on a later main-actor turn. The
+        // external transaction already submitted this exact snapshot; consume
+        // only its callback above. A subsequent user edit must take the normal
+        // path, invalidate the external parse, and own the camera.
+        pendingExternalRestore = nil
+        nextExternalDirtyOverride = nil
         invalidateParseWorkForEdit()
         if !isApplyingExternalChange {
             setDirty(true)

--- a/Sources/DownrightApp/AI/MarkdownParseWorker.swift
+++ b/Sources/DownrightApp/AI/MarkdownParseWorker.swift
@@ -84,6 +84,18 @@ actor MarkdownParseCoordinator {
         wake = nil
     }
 
+    /// Runs a correctness-critical snapshot without waiting behind an obsolete
+    /// non-cancellable cmark parse. Actor reentrancy permits the Sendable worker
+    /// operation to overlap the stale request; the document revision gate still
+    /// decides which result may commit.
+    func runImmediately(_ request: MarkdownParseRequest) async -> MarkdownParseResult {
+        await worker.run(
+            text: request.text,
+            previous: request.previous,
+            revision: request.revision
+        )
+    }
+
     /// Drops a snapshot that has not started running.  A synchronous reparse
     /// has already produced a newer tree, so keeping this request would only
     /// spend parse time on a result that the document revision gate rejects.

--- a/Sources/DownrightApp/App/AppDelegate.swift
+++ b/Sources/DownrightApp/App/AppDelegate.swift
@@ -54,9 +54,12 @@ enum WelcomeDocument {
         try manager.createDirectory(at: folder, withIntermediateDirectories: true)
         let copy = folder.appendingPathComponent("Welcome to Downright.md")
         // A fresh copy every time: the tour should read the same on the second
-        // visit as on the first, whatever the reader typed into it.
+        // visit as on the first, whatever the reader typed into it. Render
+        // shortcut tokens at open time so customized bindings stay truthful.
         try? manager.removeItem(at: copy)
-        try manager.copyItem(at: bundled, to: copy)
+        let source = try String(contentsOf: bundled, encoding: .utf8)
+        let rendered = try WelcomeTour.render(source)
+        try rendered.write(to: copy, atomically: true, encoding: .utf8)
         return copy
     }
 }

--- a/Sources/DownrightApp/App/DocumentWindowController+Actions.swift
+++ b/Sources/DownrightApp/App/DocumentWindowController+Actions.swift
@@ -287,7 +287,8 @@ enum CodeFileExtensions {
 // activity, the panels a reader reaches for, task progress, overflow — that
 // never nudges the centre rail.
 //
-// Find and Outline are in that cluster rather than inside `···` on purpose.
+// Contents / Outline and Find are in that cluster rather than inside `···` on
+// purpose.
 // The overflow was the only interactive control on the trailing edge, which
 // put every panel in the app one unlabelled glyph and one menu away in a
 // window with room for three more buttons.  `···` keeps what a reader reaches
@@ -329,6 +330,7 @@ extension DocumentWindowController: NSToolbarDelegate, NSMenuDelegate, NSToolbar
             guard let window else { return nil }
             let item = NSToolbarItem(itemIdentifier: identifier)
             let identity = ToolbarDocumentIdentityView(window: window)
+            identity.documentState = markdownDocument.presentationState
             item.view = identity
             toolbarDocumentIdentityView = identity
             item.isBordered = false
@@ -356,6 +358,13 @@ extension DocumentWindowController: NSToolbarDelegate, NSMenuDelegate, NSToolbar
             return item
 
         case Self.clusterItem:
+            let contentsButton = ToolbarActionButton(
+                symbol: "list.bullet.indent", label: Command.documentLens.title,
+                help: "Show or hide the document Contents and Outline",
+                target: self, action: #selector(toolbarShowDocumentLens(_:)),
+                usesGlassSurface: true
+            )
+            contentsButton.styleSheet = activeStyleSheet
             let findButton = ToolbarActionButton(
                 symbol: "magnifyingglass", label: "Find",
                 help: "Find in this document",
@@ -374,6 +383,7 @@ extension DocumentWindowController: NSToolbarDelegate, NSMenuDelegate, NSToolbar
             let item = NSToolbarItem(itemIdentifier: identifier)
             item.view = ToolbarTrailingCluster(views: [
                 activityIndicator,
+                contentsButton,
                 findButton,
                 progressRing,
                 pill,
@@ -400,6 +410,10 @@ extension DocumentWindowController: NSToolbarDelegate, NSMenuDelegate, NSToolbar
             // keeps the panels one reach away.
             let menuRep = NSMenuItem(title: "Actions", action: nil, keyEquivalent: "")
             let repMenu = NSMenu(title: "Actions")
+            repMenu.addItem(menuItem(
+                title: Command.documentLens.title, symbol: "list.bullet.indent",
+                action: #selector(toolbarShowDocumentLens(_:))
+            ))
             repMenu.addItem(menuItem(
                 title: "Find", symbol: "magnifyingglass",
                 action: #selector(toolbarShowFind(_:))
@@ -534,6 +548,10 @@ extension DocumentWindowController: NSToolbarDelegate, NSMenuDelegate, NSToolbar
         toggleTaskPanel()
     }
 
+    @objc private func toolbarShowDocumentLens(_ sender: Any?) {
+        perform(.documentLens)
+    }
+
     @objc private func toolbarToggleSourceFocus(_ sender: Any?) {
         toolbarModeChanged(primaryContainer.textView.sourceFocus == .none ? 1 : 0)
     }
@@ -559,6 +577,7 @@ extension DocumentWindowController: NSToolbarDelegate, NSMenuDelegate, NSToolbar
         menu.delegate = self
 
         menu.addItem(sectionHeader("Panels"))
+        addCommands([.documentLens], to: menu)
         menu.addItem(menuItem(title: "Tasks", symbol: "checkmark.circle", action: #selector(toolbarShowTasks(_:))))
         menu.addItem(menuItem(title: "History", symbol: "clock.arrow.circlepath", action: #selector(toolbarShowHistory(_:))))
 

--- a/Sources/DownrightApp/App/DocumentWindowController+Delegates.swift
+++ b/Sources/DownrightApp/App/DocumentWindowController+Delegates.swift
@@ -224,6 +224,7 @@ extension DocumentWindowController: MarkdownTextViewDelegate {
         // The document owns reparsing; the storage delegate already scheduled
         // it.  Change marks shift here so they keep pointing at the same text.
         markdownDocument.changes.adjust(forEditIn: range, delta: delta)
+        markdownDocument.noteMutation(view.lastMutationProvenance)
         scheduleFindRefresh()
     }
 

--- a/Sources/DownrightApp/App/DocumentWindowController+Support.swift
+++ b/Sources/DownrightApp/App/DocumentWindowController+Support.swift
@@ -116,7 +116,49 @@ extension DocumentWindowController {
     }
 
     func presentSaveError(_ error: Error) {
-        presentOperationError("Couldn’t save \(markdownDocument.displayName)", error: error)
+        switch error {
+        case SaveError.fileMissing, SaveError.fileUnreadable:
+            presentSaveRecovery(error)
+        default:
+            presentOperationError("Couldn’t save \(markdownDocument.displayName)", error: error)
+        }
+    }
+
+    private func presentSaveRecovery(_ error: Error) {
+        guard saveRecoveryAlert == nil else { return }
+        let alert = NSAlert()
+        alert.messageText = "The original file can’t be saved safely"
+        alert.informativeText = error.localizedDescription
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: "Save a Copy…")
+        alert.addButton(withTitle: "Recreate File")
+        alert.addButton(withTitle: "Discard Changes")
+        alert.addButton(withTitle: "Cancel")
+        alert.buttons[0].toolTip = "Write your Markdown to a different path"
+        alert.buttons[1].toolTip = "Explicitly create or replace the original path"
+        alert.buttons[2].toolTip = "Stop trying to save these local edits"
+        alert.buttons[3].toolTip = "Keep editing without writing anything"
+        saveRecoveryAlert = alert
+
+        let handle: (NSApplication.ModalResponse) -> Void = { [weak self] response in
+            guard let self else { return }
+            self.saveRecoveryAlert = nil
+            switch response {
+            case .alertFirstButtonReturn:
+                self.saveAs()
+            case .alertSecondButtonReturn:
+                _ = self.markdownDocument.recreateMissingFile()
+            case .alertThirdButtonReturn:
+                self.markdownDocument.discardUnsavedChanges()
+            default:
+                break
+            }
+        }
+        if let window {
+            alert.beginSheetModal(for: window, completionHandler: handle)
+        } else {
+            handle(alert.runModal())
+        }
     }
 
     func presentOperationError(_ title: String, error: Error) {

--- a/Sources/DownrightApp/App/DocumentWindowController.swift
+++ b/Sources/DownrightApp/App/DocumentWindowController.swift
@@ -163,6 +163,9 @@ final class DocumentWindowController: NSWindowController {
     private var cachedSectionMetrics: [ReadingMetrics] = []
     private var cachedWordCount = 0
     private var autosaveWorkItem: DispatchWorkItem?
+    /// Prevents autosave, close, and task-toggle failures from stacking several
+    /// identical recovery sheets for the same unavailable backing path.
+    var saveRecoveryAlert: NSAlert?
 
     // MARK: - Construction
 
@@ -724,6 +727,9 @@ final class DocumentWindowController: NSWindowController {
             self?.window?.isDocumentEdited = dirty
             if dirty { self?.scheduleAutosave() }
         }
+        markdownDocument.onPresentationStateChanged = { [weak self] state in
+            self?.toolbarDocumentIdentityView?.documentState = state
+        }
         markdownDocument.onWillApplyUndoRedo = { [weak self] in
             guard let self else { return }
             for pane in self.documentPanes {
@@ -1167,7 +1173,11 @@ final class DocumentWindowController: NSWindowController {
         // are intentionally absent from the calm reading surface.
         primaryContainer.textView.changeMarks = []
         splitContainer?.textView.changeMarks = []
-        refreshDensityBands()
+        // Change tracking can be published from the external-write commit.
+        // Rebuilding every density/outline band in that same main-actor turn
+        // turns a tiny source insertion into a visible scroll hitch; the normal
+        // derived-UI debounce coalesces it with the incoming parse commit.
+        scheduleDerivedUIRefresh()
     }
 
     /// "I have read all of these" — the review queue's one explicit exit.
@@ -1208,11 +1218,12 @@ final class DocumentWindowController: NSWindowController {
             showConflictBar("Changed on disk — \(conflict.changedBlockCount) block\(conflict.changedBlockCount == 1 ? "" : "s")")
 
         case .fileRemoved:
-            toolbarDocumentIdentityView?.hasExternalChanges = true
+            toolbarDocumentIdentityView?.documentState = .init(
+                phase: .changedOnDisk, provenance: nil, detail: "File missing"
+            )
             showConflictBar("File was moved or deleted")
 
         case .fileRestored:
-            toolbarDocumentIdentityView?.hasExternalChanges = false
             dismissConflictBar()
         }
     }
@@ -2292,6 +2303,8 @@ final class DocumentWindowController: NSWindowController {
             // the primary leaves the window with no text first responder, so
             // the next native key command appears to do nothing.
             let active = containerTextView
+            let activeTopOffset = active.topVisibleOffset
+            let activeViewportY = active.enclosingScrollView?.contentView.bounds.origin.y
             synchronizePanes(from: active, selection: true, viewport: true)
             focusDimmingViews.removeAll { view in
                 if view.superview === splitContainer {
@@ -2312,6 +2325,20 @@ final class DocumentWindowController: NSWindowController {
                 primaryContainer.topAnchor.constraint(equalTo: barStack.bottomAnchor),
                 primaryContainer.bottomAnchor.constraint(equalTo: statusBarView.topAnchor),
             ])
+            rootView.layoutSubtreeIfNeeded()
+            primaryContainer.textView.resizeToFitContent()
+            // Reflowing from half-width back to full-width changes physical Y
+            // geometry. Restore by source anchor after that reflow, not only
+            // while both panes still had their split widths.
+            primaryContainer.textView.scroll(
+                toOffset: activeTopOffset, position: .top, animated: false
+            )
+            if let activeViewportY,
+               let scrollView = primaryContainer.textView.enclosingScrollView {
+                let clip = scrollView.contentView
+                clip.scroll(to: NSPoint(x: clip.bounds.origin.x, y: activeViewportY))
+                scrollView.reflectScrolledClipView(clip)
+            }
             markdownDocument.state.splitViewEnabled = false
             window?.makeFirstResponder(primaryContainer.textView)
             return
@@ -2330,7 +2357,7 @@ final class DocumentWindowController: NSWindowController {
         second.textView.mode = source.mode
         second.textView.zoomLevel = source.zoomLevel
         second.textView.foldedHeadingSlugs = source.foldedHeadingSlugs
-        second.textView.update(document: markdownDocument.parsed, dirty: .wholesale)
+        second.textView.adoptSharedPresentation(from: source)
         second.textView.setSourceSelectedRanges(source.sourceSelectedRanges)
         second.textView.scroll(toOffset: source.topVisibleOffset, position: .top, animated: false)
         splitContainer = second

--- a/Sources/DownrightApp/App/MainMenu.swift
+++ b/Sources/DownrightApp/App/MainMenu.swift
@@ -146,11 +146,16 @@ enum MainMenu {
                     StandardItem(title: "Cut", selector: #selector(NSText.cut(_:)), keyEquivalent: "x"),
                     StandardItem(title: "Copy", selector: #selector(NSText.copy(_:)), keyEquivalent: "c"),
                     StandardItem(title: "Paste", selector: #selector(NSText.paste(_:)), keyEquivalent: "v"),
+                    StandardItem(
+                        title: "Paste as Markdown",
+                        selector: #selector(MarkdownTextView.pasteAsMarkdown(_:)),
+                        keyEquivalent: "v", modifiers: [.command, .option]
+                    ),
                     // The likeliest paste in a byte-exact Markdown editor.
                     StandardItem(
                         title: "Paste and Match Style",
-                        selector: #selector(NSTextView.pasteAsPlainText(_:)),
-                        keyEquivalent: "v", modifiers: [.command, .shift]
+                        selector: #selector(MarkdownTextView.pasteAndMatchStyle(_:)),
+                        keyEquivalent: "v", modifiers: [.command, .option, .shift]
                     ),
                     StandardItem(title: "Delete", selector: #selector(NSText.delete(_:))),
                     StandardItem(title: "Select All", selector: #selector(NSText.selectAll(_:)), keyEquivalent: "a"),

--- a/Sources/DownrightApp/App/ToolbarControls.swift
+++ b/Sources/DownrightApp/App/ToolbarControls.swift
@@ -79,23 +79,23 @@ enum ToolbarScrubPhase {
 
 /// Leading titlebar identity. It mirrors the window's document title while
 /// preserving a deliberate two-line hierarchy and the titlebar drag region.
-/// A quiet proxy opens the path menu; an edited dot marks unsaved work.
+/// A quiet proxy opens the path menu; a compact native label names exceptional
+/// document state. Neutral documents remain visually silent.
 @MainActor
 final class ToolbarDocumentIdentityView: NSView {
     private enum Metrics {
         static let width: CGFloat = 220
         static let height: CGFloat = 36
         static let proxySize: CGFloat = 16
-        static let dirtySize: CGFloat = 6
         static let titleSize: CGFloat = 12.5
+        static let stateSize: CGFloat = 9.5
         static let contextSize: CGFloat = 10
         static let lineGap: CGFloat = 1
     }
 
     private weak var hostWindow: NSWindow?
     private let proxyButton = ToolbarInteractiveButton(frame: .zero)
-    private let dirtyDot = NSView()
-    private let externalDot = NSView()
+    private let stateLabel = NSTextField(labelWithString: "")
     private let titleLabel = NSTextField(labelWithString: "")
     private let contextLabel = NSTextField(labelWithString: "")
     private let titleRow = NSStackView()
@@ -109,16 +109,27 @@ final class ToolbarDocumentIdentityView: NSView {
     var isEdited: Bool = false {
         didSet {
             guard isEdited != oldValue else { return }
-            dirtyDot.isHidden = !isEdited
-            refreshAccessibility()
+            if isEdited, documentState.phase == .neutral {
+                documentState = .init(phase: .edited, provenance: "Edit", detail: nil)
+            } else if !isEdited, documentState.phase == .edited {
+                documentState = .neutral
+            }
         }
     }
 
     var hasExternalChanges: Bool = false {
         didSet {
             guard hasExternalChanges != oldValue else { return }
-            externalDot.isHidden = !hasExternalChanges
-            refreshAccessibility()
+            if hasExternalChanges, documentState.phase == .neutral {
+                documentState = .init(phase: .changedOnDisk, provenance: nil, detail: nil)
+            }
+        }
+    }
+
+    var documentState: MarkdownDocument.PresentationState = .neutral {
+        didSet {
+            guard documentState != oldValue else { return }
+            refreshDocumentState()
         }
     }
 
@@ -148,23 +159,12 @@ final class ToolbarDocumentIdentityView: NSView {
         proxyButton.target = self
         proxyButton.action = #selector(showPathMenu(_:))
 
-        dirtyDot.wantsLayer = true
-        // Theme accent, not controlAccentColor: Paper Light / Warm Dark are
-        // blue-native, and the system accent can still be orange on the Mac.
-        dirtyDot.layer?.backgroundColor = StyleSheet.current.accent.cgColor
-        dirtyDot.layer?.cornerRadius = Metrics.dirtySize / 2
-        dirtyDot.isHidden = true
-        dirtyDot.setContentHuggingPriority(.required, for: .horizontal)
-        dirtyDot.setContentCompressionResistancePriority(.required, for: .horizontal)
-
-        externalDot.wantsLayer = true
-        externalDot.layer?.backgroundColor = NSColor.clear.cgColor
-        externalDot.layer?.borderColor = StyleSheet.current.accent.cgColor
-        externalDot.layer?.borderWidth = 1.5
-        externalDot.layer?.cornerRadius = Metrics.dirtySize / 2
-        externalDot.isHidden = true
-        externalDot.setContentHuggingPriority(.required, for: .horizontal)
-        externalDot.setContentCompressionResistancePriority(.required, for: .horizontal)
+        stateLabel.font = .systemFont(ofSize: Metrics.stateSize, weight: .medium)
+        stateLabel.lineBreakMode = .byTruncatingTail
+        stateLabel.maximumNumberOfLines = 1
+        stateLabel.isHidden = true
+        stateLabel.setContentHuggingPriority(.required, for: .horizontal)
+        stateLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
 
         titleLabel.lineBreakMode = .byTruncatingMiddle
         titleLabel.maximumNumberOfLines = 1
@@ -182,8 +182,7 @@ final class ToolbarDocumentIdentityView: NSView {
         titleRow.alignment = .centerY
         titleRow.spacing = 5
         titleRow.detachesHiddenViews = true
-        titleRow.addArrangedSubview(externalDot)
-        titleRow.addArrangedSubview(dirtyDot)
+        titleRow.addArrangedSubview(stateLabel)
         titleRow.addArrangedSubview(titleLabel)
 
         textColumn.orientation = .vertical
@@ -194,8 +193,6 @@ final class ToolbarDocumentIdentityView: NSView {
 
         proxyButton.translatesAutoresizingMaskIntoConstraints = false
         textColumn.translatesAutoresizingMaskIntoConstraints = false
-        dirtyDot.translatesAutoresizingMaskIntoConstraints = false
-        externalDot.translatesAutoresizingMaskIntoConstraints = false
         addSubview(proxyButton)
         addSubview(textColumn)
 
@@ -207,11 +204,6 @@ final class ToolbarDocumentIdentityView: NSView {
             proxyButton.centerYAnchor.constraint(equalTo: centerYAnchor),
             proxyButton.widthAnchor.constraint(equalToConstant: Metrics.proxySize + 2),
             proxyButton.heightAnchor.constraint(equalToConstant: Metrics.proxySize + 2),
-
-            dirtyDot.widthAnchor.constraint(equalToConstant: Metrics.dirtySize),
-            dirtyDot.heightAnchor.constraint(equalToConstant: Metrics.dirtySize),
-            externalDot.widthAnchor.constraint(equalToConstant: Metrics.dirtySize),
-            externalDot.heightAnchor.constraint(equalToConstant: Metrics.dirtySize),
 
             textColumn.leadingAnchor.constraint(equalTo: proxyButton.trailingAnchor, constant: 5),
             textColumn.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor),
@@ -236,6 +228,7 @@ final class ToolbarDocumentIdentityView: NSView {
             }
         }
         refreshEmphasis()
+        refreshDocumentState()
     }
 
     required init?(coder: NSCoder) { nil }
@@ -364,28 +357,80 @@ final class ToolbarDocumentIdentityView: NSView {
         titleLabel.stringValue = title
         contextLabel.stringValue = context
         contextLabel.isHidden = context.isEmpty
-        toolTip = context.isEmpty ? title : "\(title) — \(context)"
+        refreshToolTip()
         refreshAccessibility()
     }
 
-    private func refreshAccessibility() {
-        let base = contextLabel.stringValue.isEmpty
+    private var identityDescription: String {
+        contextLabel.stringValue.isEmpty
             ? titleLabel.stringValue
             : "\(titleLabel.stringValue), \(contextLabel.stringValue)"
-        var states: [String] = []
-        if isEdited { states.append("edited") }
-        if hasExternalChanges { states.append("changed on disk") }
-        let label = states.isEmpty ? base : "\(base), \(states.joined(separator: ", "))"
+    }
+
+    private func refreshAccessibility() {
+        let base = identityDescription
+        let state = stateDescription
+        let label = state == nil ? base : "\(base), \(state!)"
         setAccessibilityRole(.group)
         setAccessibilityLabel(label)
+    }
+
+    private var stateDescription: String? {
+        let title: String
+        switch documentState.phase {
+        case .neutral: return nil
+        case .edited: title = "Edited"
+        case .saving: title = "Saving"
+        case .saved: title = "Saved"
+        case .changedOnDisk: title = "Changed on disk"
+        case .conflict: title = "Conflict"
+        case .saveFailed: title = "Save failed"
+        }
+        let provenance = documentState.provenance.map { " — \($0)" } ?? ""
+        let detail = documentState.detail.map { ": \($0)" } ?? ""
+        return title + provenance + detail
+    }
+
+    private func refreshDocumentState() {
+        switch documentState.phase {
+        case .neutral:
+            stateLabel.stringValue = ""
+            stateLabel.isHidden = true
+        case .edited: stateLabel.stringValue = "Edited"
+        case .saving: stateLabel.stringValue = "Saving"
+        case .saved: stateLabel.stringValue = "Saved"
+        case .changedOnDisk: stateLabel.stringValue = "On disk"
+        case .conflict: stateLabel.stringValue = "Conflict"
+        case .saveFailed: stateLabel.stringValue = "Save failed"
+        }
+        if documentState.phase != .neutral { stateLabel.isHidden = false }
+        refreshToolTip()
+        refreshEmphasis()
+        refreshAccessibility()
+    }
+
+    private func refreshToolTip() {
+        let base = identityDescription
+        guard let state = stateDescription else {
+            toolTip = base.isEmpty ? nil : base
+            return
+        }
+        toolTip = base.isEmpty ? state : "\(base) — \(state)"
     }
 
     private func refreshEmphasis() {
         titleLabel.textColor = hostWindow?.isKeyWindow == true ? .labelColor : .secondaryLabelColor
         contextLabel.textColor = .tertiaryLabelColor
-        let accent = StyleSheet.current.accent
-        dirtyDot.layer?.backgroundColor = accent.cgColor
-        externalDot.layer?.borderColor = accent.cgColor
+        switch documentState.phase {
+        case .conflict, .saveFailed:
+            stateLabel.textColor = .systemRed
+        case .changedOnDisk:
+            stateLabel.textColor = StyleSheet.current.accent
+        case .edited, .saving, .saved:
+            stateLabel.textColor = .secondaryLabelColor
+        case .neutral:
+            stateLabel.textColor = .tertiaryLabelColor
+        }
         updateProxyIcon(for: hostWindow?.representedURL)
     }
 

--- a/Sources/DownrightApp/Panels/DocumentLensView.swift
+++ b/Sources/DownrightApp/Panels/DocumentLensView.swift
@@ -91,7 +91,7 @@ final class DocumentLensView: NSView, PanelSurface {
         reload()
 
         setAccessibilityRole(.group)
-        setAccessibilityLabel("Document Lens")
+        setAccessibilityLabel(Command.documentLens.title)
     }
 
     required init?(coder: NSCoder) { fatalError("init(coder:) is not used") }
@@ -112,7 +112,7 @@ final class DocumentLensView: NSView, PanelSurface {
         tabControl.font = PanelFont.row
         tabControl.target = self
         tabControl.action = #selector(tabChanged(_:))
-        tabControl.setAccessibilityLabel("Document Lens sections")
+        tabControl.setAccessibilityLabel("Contents and Outline sections")
         tabControl.translatesAutoresizingMaskIntoConstraints = false
         addSubview(tabControl)
 

--- a/Sources/DownrightApp/Support/CommandPaletteModel.swift
+++ b/Sources/DownrightApp/Support/CommandPaletteModel.swift
@@ -315,6 +315,7 @@ struct CommandPaletteModel {
 private enum CommandPaletteSynonyms {
     static let values: [Command: [String]] = [
         .sourceMode: ["markdown", "raw", "editor", "edit source", "full source"],
+        .documentLens: ["contents", "outline", "headings", "document lens", "table of contents"],
         .taskPanel: ["tasks", "todo", "checkbox", "checklist"],
         .toggleTaskAtCaret: ["check", "tick", "checkbox", "done"],
         .frontMatterEditor: ["metadata", "yaml", "toml", "properties"],

--- a/Sources/DownrightApp/Support/Commands.swift
+++ b/Sources/DownrightApp/Support/Commands.swift
@@ -76,7 +76,7 @@ enum Command: String, CaseIterable, Codable {
         case .tableEditor: return "Edit Table…"
         case .assetDoctor: return "Asset Doctor"
         case .commandPalette: return "Command Palette…"
-        case .documentLens: return "Document Lens"
+        case .documentLens: return "Contents / Outline"
         case .readerProfiles: return "Reader Profiles"
         case .documentHealth: return "Document Health"
         case .renderTargets: return "Render Targets"

--- a/Sources/DownrightApp/Support/Keybindings.swift
+++ b/Sources/DownrightApp/Support/Keybindings.swift
@@ -8,7 +8,7 @@ import AppKit
 /// §7.2 can spend the bare letter keys at all.
 ///
 /// Chords are chosen so nothing shadows a macOS convention: ⌘0 is Actual Size,
-/// ⌘⇧P is Page Setup, ⌘⇧V is Paste and Match Style, ⌃⌘F is Enter Full Screen,
+/// ⌘⇧P is Page Setup, ⌥⇧⌘V is Paste and Match Style, ⌃⌘F is Enter Full Screen,
 /// and ⌘T / ⌘⇧T stay free for the tab chords users reach for reflexively.
 enum KeybindingDefaults {
     /// A command may carry more than one binding: `↓` and `j` both scroll.

--- a/Sources/DownrightApp/Support/WelcomeTour.swift
+++ b/Sources/DownrightApp/Support/WelcomeTour.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+/// The bundled tour is written with command tokens instead of copied shortcut
+/// glyphs. A tour opened after a remap must teach the current command.
+enum WelcomeTour {
+    enum Error: Swift.Error, Equatable {
+        case malformedToken(String)
+        case unknownCommand(String)
+        case missingBinding(Command)
+    }
+
+    /// Renders `{{shortcut:commandName}}` and `{{command:commandName}}` tokens.
+    /// A deliberately cleared binding is rendered as `Unassigned` so the
+    /// bundled tour remains openable and truthful after a remap.
+    static func render(
+        _ source: String,
+        binding: (Command) -> KeyBinding? = { KeybindingStore.shared.primaryBinding(for: $0) }
+    ) throws -> String {
+        var output = ""
+        var cursor = source.startIndex
+        while let start = source[cursor...].range(of: "{{") {
+            output += source[cursor..<start.lowerBound]
+            guard let end = source[start.upperBound...].range(of: "}}") else {
+                throw Error.malformedToken(String(source[start.lowerBound...]))
+            }
+            let token = String(source[start.upperBound..<end.lowerBound])
+            output += try replacement(for: token, binding: binding)
+            cursor = end.upperBound
+        }
+        output += source[cursor...]
+        return output
+    }
+
+    /// Finds every instructional token so resource tests can validate the
+    /// tour against the command table without starting an app window.
+    static func tokens(in source: String) -> [String] {
+        var values: [String] = []
+        var cursor = source.startIndex
+        while let start = source[cursor...].range(of: "{{"),
+              let end = source[start.upperBound...].range(of: "}}") {
+            values.append(String(source[start.upperBound..<end.lowerBound]))
+            cursor = end.upperBound
+        }
+        return values
+    }
+
+    private static func replacement(
+        for token: String,
+        binding: (Command) -> KeyBinding?
+    ) throws -> String {
+        let parts = token.split(separator: ":", maxSplits: 1).map(String.init)
+        guard parts.count == 2, ["shortcut", "command"].contains(parts[0]) else {
+            throw Error.malformedToken(token)
+        }
+        guard let command = Command(rawValue: parts[1]) else {
+            throw Error.unknownCommand(parts[1])
+        }
+        switch parts[0] {
+        case "shortcut":
+            return binding(command)?.displayString ?? "Unassigned"
+        case "command":
+            return command.title
+        default:
+            throw Error.malformedToken(token)
+        }
+    }
+}

--- a/Sources/DownrightQL/PreviewViewController.swift
+++ b/Sources/DownrightQL/PreviewViewController.swift
@@ -90,20 +90,13 @@ final class PreviewViewController: NSViewController, QLPreviewingController {
                 if Task.isCancelled { return LoadResult.failure }
                 let byteCount =
                     (try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? 0
-                switch QuickLookPolicy.presentation(forByteCount: byteCount) {
-                case .prefix:
-                    guard let head = DocumentIO.readHead(
-                        contentsOf: url,
-                        limit: QuickLookPolicy.prefixReadLimitBytes
-                    ) else { return LoadResult.failure }
-                    if Task.isCancelled { return LoadResult.failure }
-                    return LoadResult.prefix(head)
-                case .full:
-                    guard let (text, _) = try? DocumentIO.read(contentsOf: url) else {
-                        return LoadResult.failure
-                    }
-                    if Task.isCancelled { return LoadResult.failure }
-                    return LoadResult.full(text)
+                switch QuickLookLoader.load(contentsOf: url, hintedByteCount: byteCount) {
+                case .prefix(let text):
+                    return Task.isCancelled ? LoadResult.failure : LoadResult.prefix(text)
+                case .full(let text):
+                    return Task.isCancelled ? LoadResult.failure : LoadResult.full(text)
+                case nil:
+                    return LoadResult.failure
                 }
             }
             let loadResult = await withTaskCancellationHandler {

--- a/Sources/DownrightQL/QuickLookLoader.swift
+++ b/Sources/DownrightQL/QuickLookLoader.swift
@@ -1,0 +1,167 @@
+import Foundation
+
+/// The result of a bounded Quick Look load.  A file that was small when the
+/// preview request began can grow before its handle is opened; in that case it
+/// is treated exactly like the large-file path instead of being read whole.
+enum QuickLookLoadedContent: Equatable, Sendable {
+    case full(String)
+    case prefix(String)
+}
+
+/// Reads preview input without ever materialising more than the policy allows.
+///
+/// The initial stat is only a hint.  The handle read is independently capped,
+/// so replacing a small file with a large one between stat and open cannot
+/// turn the full path into an unbounded allocation.
+enum QuickLookLoader {
+    static func load(
+        contentsOf url: URL,
+        hintedByteCount: Int,
+        beforeRead: (@Sendable () -> Void)? = nil
+    ) -> QuickLookLoadedContent? {
+        let hintedPresentation = QuickLookPolicy.presentation(forByteCount: hintedByteCount)
+        let limit: Int
+        switch hintedPresentation {
+        case .full:
+            limit = QuickLookPolicy.fullReadLimitBytes
+        case .prefix:
+            limit = QuickLookPolicy.prefixReadLimitBytes
+        }
+
+        beforeRead?()
+        guard let handle = try? FileHandle(forReadingFrom: url) else { return nil }
+        defer { try? handle.close() }
+
+        // One sentinel byte tells us whether the file exceeded the cap while
+        // keeping the allocation strictly bounded (limit + 1 bytes).
+        guard let boundedData = try? handle.read(upToCount: limit + 1) else { return nil }
+        let didExceedLimit = boundedData.count > limit
+        let data = didExceedLimit ? Data(boundedData.prefix(limit)) : boundedData
+        guard let text = decode(data) else { return nil }
+
+        switch hintedPresentation {
+        case .prefix:
+            return .prefix(text)
+        case .full:
+            return didExceedLimit ? .prefix(text) : .full(text)
+        }
+    }
+
+    private static func decode(_ data: Data) -> String? {
+        let bytes = [UInt8](data.prefix(4))
+        let bomLength: Int
+        let encoding: String.Encoding
+        let codeUnitWidth: Int
+
+        if bytes.count >= 4, bytes == [0xFF, 0xFE, 0x00, 0x00] {
+            bomLength = 4
+            encoding = .utf32LittleEndian
+            codeUnitWidth = 4
+        } else if bytes.count >= 4, bytes == [0x00, 0x00, 0xFE, 0xFF] {
+            bomLength = 4
+            encoding = .utf32BigEndian
+            codeUnitWidth = 4
+        } else if bytes.count >= 3, bytes.prefix(3).elementsEqual([0xEF, 0xBB, 0xBF]) {
+            bomLength = 3
+            encoding = .utf8
+            codeUnitWidth = 1
+        } else if bytes.count >= 2, bytes.prefix(2).elementsEqual([0xFF, 0xFE]) {
+            bomLength = 2
+            encoding = .utf16LittleEndian
+            codeUnitWidth = 2
+        } else if bytes.count >= 2, bytes.prefix(2).elementsEqual([0xFE, 0xFF]) {
+            bomLength = 2
+            encoding = .utf16BigEndian
+            codeUnitWidth = 2
+        } else if let guessed = sniffBOMlessEncoding(data) {
+            bomLength = 0
+            encoding = guessed.encoding
+            codeUnitWidth = guessed.width
+        } else if String(data: data, encoding: .utf8) != nil {
+            bomLength = 0
+            encoding = .utf8
+            codeUnitWidth = 1
+        } else {
+            bomLength = 0
+            encoding = .isoLatin1
+            codeUnitWidth = 1
+        }
+
+        var body = Data(data.dropFirst(min(bomLength, data.count)))
+        if codeUnitWidth > 1, body.count % codeUnitWidth != 0 {
+            body = Data(body.prefix(body.count - (body.count % codeUnitWidth)))
+        }
+
+        let text: String
+        if let decoded = String(data: body, encoding: encoding) {
+            text = decoded
+        } else {
+            // A UTF-8 head can end in a torn scalar.  Trim only the small
+            // trailing suffix needed to recover a valid preview.
+            guard encoding == .utf8 else { return nil }
+            var recovered: String?
+            for drop in 1...3 where body.count > drop {
+                recovered = String(data: body.dropLast(drop), encoding: .utf8)
+                if recovered != nil { break }
+            }
+            guard let recovered else { return nil }
+            text = recovered
+        }
+        return normalizeLineEndings(text)
+    }
+
+    private static func sniffBOMlessEncoding(_ data: Data) -> (encoding: String.Encoding, width: Int)? {
+        guard data.count >= 4 else { return nil }
+        let bytes = [UInt8](data.prefix(min(data.count, 256)))
+        var evenNULs = 0
+        var oddNULs = 0
+        for (index, byte) in bytes.enumerated() where byte == 0 {
+            if index.isMultiple(of: 2) { evenNULs += 1 } else { oddNULs += 1 }
+        }
+        let count = Double(bytes.count)
+        let evenRatio = Double(evenNULs) / count
+        let oddRatio = Double(oddNULs) / count
+        if evenRatio >= 0.3, evenRatio > oddRatio * 2 {
+            return (.utf16BigEndian, 2)
+        }
+        if oddRatio >= 0.3, oddRatio > evenRatio * 2 {
+            return (.utf16LittleEndian, 2)
+        }
+        if evenRatio >= 0.45, oddRatio >= 0.45,
+           let firstNonZero = bytes.firstIndex(where: { $0 != 0 }) {
+            return (firstNonZero.isMultiple(of: 4) ? .utf32LittleEndian : .utf32BigEndian, 4)
+        }
+        return nil
+    }
+
+    private static func normalizeLineEndings(_ text: String) -> String {
+        var sawLF = false
+        var sawCRLF = false
+        var sawCR = false
+        var previousWasCR = false
+        for scalar in text.unicodeScalars {
+            if previousWasCR {
+                if scalar == "\n" {
+                    sawCRLF = true
+                    previousWasCR = false
+                    continue
+                }
+                sawCR = true
+                previousWasCR = false
+            }
+            if scalar == "\r" {
+                previousWasCR = true
+            } else if scalar == "\n" {
+                sawLF = true
+            }
+        }
+        if previousWasCR { sawCR = true }
+        if sawCRLF, !sawLF, !sawCR {
+            return text.replacingOccurrences(of: "\r\n", with: "\n")
+        }
+        if sawCR, !sawLF, !sawCRLF {
+            return text.replacingOccurrences(of: "\r", with: "\n")
+        }
+        return text
+    }
+}

--- a/Sources/DownrightQL/QuickLookPolicy.swift
+++ b/Sources/DownrightQL/QuickLookPolicy.swift
@@ -7,6 +7,9 @@ import Foundation
 public enum QuickLookPolicy {
     public static let memoryCeilingBytes = 60 * 1024 * 1024
     public static let largeFileThresholdBytes = 2 * 1024 * 1024
+    /// Full previews use the threshold as a hard cap, even if the file grows
+    /// after Quick Look's initial resource-value lookup.
+    public static let fullReadLimitBytes = largeFileThresholdBytes
     public static let prefixBlockCount = 60
     /// Bounded head read for oversized files — enough bytes to render the first
     /// `prefixBlockCount` blocks without ever loading the whole file.

--- a/Sources/MarkdownCore/DocumentIO.swift
+++ b/Sources/MarkdownCore/DocumentIO.swift
@@ -1,5 +1,6 @@
 import Foundation
 import CryptoKit
+import Darwin
 
 // MARK: - Document IO (§3.1)
 //
@@ -17,6 +18,12 @@ import CryptoKit
 public enum DocumentIOError: Error, LocalizedError {
     case undecodable(URL)
     case unencodable(TextEncodingKind)
+    case targetChanged(URL, displaced: [Data])
+    /// The first swap succeeded, but the displaced generation could not be
+    /// read back. `recoveryURL` is deliberately part of the error: the
+    /// caller must never mistake the public path (which now contains our
+    /// bytes) for the external generation that was preserved beside it.
+    case displacedGenerationUnreadable(URL, recoveryURL: URL, underlying: Error)
 
     public var errorDescription: String? {
         switch self {
@@ -24,14 +31,36 @@ public enum DocumentIOError: Error, LocalizedError {
             return "Could not decode \(url.lastPathComponent) as text."
         case .unencodable(let encoding):
             return "The document contains characters that cannot be written as \(encoding.rawValue)."
+        case .targetChanged(let url, _):
+            return "\(url.lastPathComponent) changed while it was being saved. The external bytes were restored."
+        case .displacedGenerationUnreadable(let url, let recoveryURL, _):
+            return "\(url.lastPathComponent) could not be reconciled while it was being saved. The external bytes were preserved at \(recoveryURL.lastPathComponent)."
         }
     }
 }
 
 public enum DocumentIO {
     public static func read(contentsOf url: URL) throws -> (text: String, fidelity: ByteFidelity) {
+        let snapshot = try readSnapshot(contentsOf: url)
+        return (snapshot.text, snapshot.fidelity)
+    }
+
+    /// One read, used by save reconciliation so decoded text, byte fidelity,
+    /// and the generation token always describe the same filesystem snapshot.
+    public static func readSnapshot(
+        contentsOf url: URL
+    ) throws -> (text: String, fidelity: ByteFidelity, data: Data) {
         let data = try Data(contentsOf: url)
-        return try decode(data, from: url)
+        let decoded = try decode(data, from: url)
+        return (decoded.text, decoded.fidelity, data)
+    }
+
+    /// Decodes bytes already captured by the guarded save protocol without
+    /// reopening a path that may now name a different generation.
+    public static func decodeSnapshot(
+        _ data: Data, sourceURL: URL
+    ) throws -> (text: String, fidelity: ByteFidelity) {
+        try decode(data, from: sourceURL)
     }
 
     /// Reads at most `limit` bytes from the head of the file — a bounded read
@@ -52,7 +81,132 @@ public enum DocumentIO {
     }
 
     public static func write(_ text: String, to url: URL, fidelity: ByteFidelity) throws {
-        try encode(text, fidelity: fidelity).write(to: url, options: .atomic)
+        try encodedData(text, fidelity: fidelity).write(to: url, options: .atomic)
+    }
+
+    /// Replaces an existing path without a check/write gap. `RENAME_SWAP`
+    /// moves the exact displaced generation to the temporary path atomically;
+    /// if it is not the generation the caller inspected, a second swap puts
+    /// those external bytes back and the save fails closed. A concurrently
+    /// deleted target makes the first swap fail, so this operation never
+    /// recreates a missing file.
+    public static func replaceExistingAtomically(
+        with data: Data,
+        at url: URL,
+        expected: Data
+    ) throws {
+        try replaceExistingAtomically(
+            with: data, at: url, expected: expected,
+            afterDisplacedRead: nil, afterSwap: nil
+        )
+    }
+
+    /// Deterministic seam for the two-swap conflict rollback. Kept internal so
+    /// production callers cannot insert work inside the atomic protocol.
+    static func replaceExistingAtomicallyForTesting(
+        with data: Data,
+        at url: URL,
+        expected: Data,
+        afterDisplacedRead: @escaping () -> Void,
+        afterSwap: ((URL) -> Void)? = nil
+    ) throws {
+        try replaceExistingAtomically(
+            with: data, at: url, expected: expected,
+            afterDisplacedRead: afterDisplacedRead,
+            afterSwap: afterSwap
+        )
+    }
+
+    private static func replaceExistingAtomically(
+        with data: Data,
+        at url: URL,
+        expected: Data,
+        afterDisplacedRead: (() -> Void)?,
+        afterSwap: ((URL) -> Void)?
+    ) throws {
+        let directory = url.deletingLastPathComponent()
+        let temporary = directory.appendingPathComponent(".downright-save-\(UUID().uuidString)")
+        // Once the first swap succeeds, this path owns the displaced
+        // generation. Keep it until that generation has been read and the
+        // two-swap reconciliation has completed; a read failure must leave a
+        // recoverable URL rather than silently deleting the only external
+        // bytes.
+        var mayRemoveTemporary = false
+        defer {
+            if mayRemoveTemporary { try? FileManager.default.removeItem(at: temporary) }
+        }
+        try data.write(to: temporary, options: .withoutOverwriting)
+
+        if let attributes = try? FileManager.default.attributesOfItem(atPath: url.path),
+           let permissions = attributes[.posixPermissions] {
+            try? FileManager.default.setAttributes([.posixPermissions: permissions], ofItemAtPath: temporary.path)
+        }
+
+        guard renamex_np(temporary.path, url.path, UInt32(RENAME_SWAP)) == 0 else {
+            throw posixRenameError(path: url.path)
+        }
+        afterSwap?(temporary)
+        let displaced: Data
+        do {
+            displaced = try Data(contentsOf: temporary)
+        } catch {
+            throw DocumentIOError.displacedGenerationUnreadable(
+                url, recoveryURL: temporary, underlying: error
+            )
+        }
+        guard displaced == expected else {
+            afterDisplacedRead?()
+            // Swap, rather than replace, so a writer that landed after our
+            // first swap is retained at `temporary` instead of being erased.
+            guard renamex_np(temporary.path, url.path, UInt32(RENAME_SWAP)) == 0 else {
+                throw posixRenameError(path: url.path)
+            }
+            let postSwapTemporary: Data
+            do {
+                postSwapTemporary = try Data(contentsOf: temporary)
+            } catch {
+                // The public path now contains the external generation and
+                // the temporary path contains our attempted payload. Keep
+                // the latter too so no generation is silently lost. The
+                // recoverable external generation is the public path here.
+                throw DocumentIOError.displacedGenerationUnreadable(
+                    url, recoveryURL: url, underlying: error
+                )
+            }
+            if postSwapTemporary != data {
+                // Another writer replaced our payload between the two swaps.
+                // Put that newest external generation back at the public path;
+                // both external generations travel in the error so the caller
+                // can persist history before releasing the temporary file.
+                guard renamex_np(temporary.path, url.path, UInt32(RENAME_SWAP)) == 0 else {
+                    throw posixRenameError(path: url.path)
+                }
+                mayRemoveTemporary = true
+                throw DocumentIOError.targetChanged(
+                    url, displaced: [displaced, postSwapTemporary]
+                )
+            }
+            mayRemoveTemporary = true
+            throw DocumentIOError.targetChanged(url, displaced: [displaced])
+        }
+        // The inspected generation matched. The displaced file has now been
+        // read safely and no longer needs a recovery URL.
+        mayRemoveTemporary = true
+    }
+
+    private static func posixRenameError(path: String) -> Error {
+        NSError(
+            domain: NSPOSIXErrorDomain,
+            code: Int(errno),
+            userInfo: [NSFilePathErrorKey: path]
+        )
+    }
+
+    /// The exact bytes `write` will place on disk. Callers that coordinate a
+    /// filesystem watcher use this to reconcile their own atomic replacement
+    /// by content rather than by a timing window.
+    public static func encodedData(_ text: String, fidelity: ByteFidelity) throws -> Data {
+        try encode(text, fidelity: fidelity)
     }
 
     /// Hex SHA-256 of the text's UTF-8 bytes.  Content-addresses snapshots
@@ -177,11 +331,8 @@ public enum DocumentIO {
 
     static func encode(_ text: String, fidelity: ByteFidelity) throws -> Data {
         var body = text
-        if fidelity.hasTrailingNewline {
-            if !body.hasSuffix("\n") { body += "\n" }
-        } else if body.hasSuffix("\n") {
-            body.removeLast()
-        }
+        // The text buffer owns whether a final newline exists. Fidelity owns
+        // how that newline is encoded, never whether a user's edit survives.
         switch fidelity.lineEnding {
         case .lf: break
         case .crlf: body = body.replacingOccurrences(of: "\n", with: "\r\n")

--- a/Sources/MarkdownCore/Model.swift
+++ b/Sources/MarkdownCore/Model.swift
@@ -189,6 +189,10 @@ public final class MDBlock: @unchecked Sendable {
     /// Stable identity across reparses where possible, so fold/collapse state
     /// survives an agent rewriting an unrelated part of the file.
     public var identity: BlockIdentity
+    /// Safe README-style HTML annotations for this block, when the source is
+    /// entirely within the conservative presentational subset. Unsafe or
+    /// unknown HTML stays `nil` and is rendered literally.
+    public var safeHTML: SafeHTMLDocument?
 
     public init(
         content: BlockContent,
@@ -201,7 +205,8 @@ public final class MDBlock: @unchecked Sendable {
         depth: Int = 0,
         quoteDepth: Int = 0,
         subtreeHash: UInt64 = 0,
-        identity: BlockIdentity = .init(kind: 0, ordinal: 0)
+        identity: BlockIdentity = .init(kind: 0, ordinal: 0),
+        safeHTML: SafeHTMLDocument? = nil
     ) {
         self.content = content
         self.range = range
@@ -214,6 +219,7 @@ public final class MDBlock: @unchecked Sendable {
         self.quoteDepth = quoteDepth
         self.subtreeHash = subtreeHash
         self.identity = identity
+        self.safeHTML = safeHTML
     }
 }
 

--- a/Sources/MarkdownCore/Parser.swift
+++ b/Sources/MarkdownCore/Parser.swift
@@ -141,7 +141,8 @@ struct BlockBuilder {
         case is HTMLBlock:
             return MDBlock(
                 content: .htmlBlock, range: range, contentRange: range,
-                depth: depth, quoteDepth: quoteDepth
+                depth: depth, quoteDepth: quoteDepth,
+                safeHTML: SafeHTMLParser.parse(map.text as String, range: range)
             )
 
         default:
@@ -237,11 +238,16 @@ struct BlockBuilder {
                 depth: depth, quoteDepth: quoteDepth
             )
         }
-        return MDBlock(
+        let block = MDBlock(
             content: .paragraph, range: range, contentRange: range,
             inlines: inlines.spans(for: markup, bounds: range),
             depth: depth, quoteDepth: quoteDepth
         )
+        // A paragraph may contain a complete inline HTML element tree (for
+        // example `<p><strong>README</strong></p>`). Keep one source-addressed
+        // annotation set so the renderer can style it without rewriting text.
+        block.safeHTML = SafeHTMLParser.parse(map.text as String, range: range)
+        return block
     }
 
     // MARK: Containers

--- a/Sources/MarkdownCore/SafeHTML.swift
+++ b/Sources/MarkdownCore/SafeHTML.swift
@@ -1,0 +1,395 @@
+import Foundation
+
+/// The deliberately small HTML vocabulary that Downright may present as
+/// document content.  This is a source annotation, not an HTML DOM: every
+/// range points back into the original buffer so editing and copying remain
+/// lossless.
+public enum SafeHTMLKind: Sendable, Equatable {
+    case paragraph(align: SafeHTMLAlignment?)
+    case heading(level: Int)
+    case strong
+    case emphasis
+    case link(destination: String, title: String?)
+    case image(source: String, alt: String)
+    /// A recognized but deliberately non-rendered tag, such as a remote image.
+    /// Its source remains visible and no network or file access is attempted.
+    case inert
+    case lineBreak
+    case details(open: Bool)
+    /// A closing `</details>` emitted in a separate Markdown HTML block. The
+    /// parser accepts this boundary fragment so the opening disclosure can
+    /// remain source-addressed and native-rendered without treating malformed
+    /// or executable HTML as safe.
+    case detailsClosing
+    case summary
+    case table
+    case tableRow
+    case tableCell(header: Bool, align: SafeHTMLAlignment?)
+}
+
+public enum SafeHTMLAlignment: String, Sendable, Equatable {
+    case left, center, right, justify
+}
+
+public struct SafeHTMLAnnotation: Sendable, Equatable {
+    public let kind: SafeHTMLKind
+    /// The complete element, including its opening and closing tags.
+    public let range: NSRange
+    /// The content between an element's tags. Void elements have an empty
+    /// range immediately after their tag.
+    public let contentRange: NSRange
+    /// Opening and closing tag source ranges. These are the only characters
+    /// the presentation layer may omit; element content is never synthesized.
+    public let tagRanges: [NSRange]
+
+    public init(kind: SafeHTMLKind, range: NSRange, contentRange: NSRange, tagRanges: [NSRange]) {
+        self.kind = kind
+        self.range = range
+        self.contentRange = contentRange
+        self.tagRanges = tagRanges
+    }
+}
+
+public struct SafeHTMLDocument: Sendable, Equatable {
+    public let range: NSRange
+    public let annotations: [SafeHTMLAnnotation]
+    /// `false` means the complete source range must remain literal. No partial
+    /// sanitisation is attempted, which prevents a safe-looking child from
+    /// hiding an executable or unknown parent.
+    public let isSafe: Bool
+
+    public init(range: NSRange, annotations: [SafeHTMLAnnotation], isSafe: Bool) {
+        self.range = range
+        self.annotations = annotations
+        self.isSafe = isSafe
+    }
+
+    public var tagRanges: [NSRange] {
+        annotations.flatMap(\.tagRanges).sorted { $0.location < $1.location }
+    }
+
+    public var hiddenTagRanges: [NSRange] { tagRanges }
+}
+
+/// A conservative, non-executing parser for README-style presentational HTML.
+///
+/// It intentionally rejects unknown tags, event attributes, CSS/script/style,
+/// malformed nesting, and risky URL schemes. Rejection returns a document
+/// marked unsafe so callers can render the original bytes as inert literal
+/// text. This is not used by HTML export, whose safety rules remain separate.
+public enum SafeHTMLParser {
+    public static func parse(_ text: String, range: NSRange? = nil) -> SafeHTMLDocument? {
+        let source = text as NSString
+        let bounds = range ?? NSRange(location: 0, length: source.length)
+        guard bounds.location >= 0, bounds.length > 0, bounds.upperBound <= source.length else { return nil }
+        guard source.substring(with: bounds).contains("<") else { return nil }
+
+        var parser = Parser(source: source, bounds: bounds)
+        return parser.parse()
+    }
+
+    private struct OpenElement {
+        let name: String
+        let range: NSRange
+        let contentStart: Int
+        let tagRange: NSRange
+        let kind: SafeHTMLKind
+        let attributes: [String: String]
+    }
+
+    private struct Parser {
+        let source: NSString
+        let bounds: NSRange
+        var cursor: Int
+        var stack: [OpenElement] = []
+        var annotations: [SafeHTMLAnnotation] = []
+        var sawTag = false
+        var rejected = false
+
+        init(source: NSString, bounds: NSRange) {
+            self.source = source
+            self.bounds = bounds
+            self.cursor = bounds.location
+        }
+
+        mutating func parse() -> SafeHTMLDocument {
+            while cursor < bounds.upperBound, !rejected {
+                guard let opening = nextTag() else { break }
+                if opening.isCommentOrDeclaration { rejected = true; break }
+                sawTag = true
+                if opening.isClosing {
+                    close(opening)
+                } else {
+                    open(opening)
+                }
+            }
+            if cursor < bounds.upperBound, !source.substring(with: NSRange(location: cursor, length: bounds.upperBound - cursor))
+                .trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false {
+                // Text is fine; only a non-tag `<` is malformed.
+                if source.substring(with: NSRange(location: cursor, length: bounds.upperBound - cursor)).contains("<") {
+                    rejected = true
+                }
+            }
+            if !stack.isEmpty {
+                // swift-markdown may split a README-style details element at
+                // blank Markdown lines: the opening block ends with a
+                // complete `<details>` tree but its closing tag is emitted in
+                // a later HTML block. Keep that known, inert container
+                // source-addressed across the boundary. Any other open stack
+                // remains malformed and therefore literal.
+                if stack.count == 1, stack[0].name == "details",
+                   hasClosingDetails(after: bounds.upperBound) {
+                    let open = stack.removeLast()
+                    annotations.append(SafeHTMLAnnotation(
+                        kind: open.kind,
+                        range: open.tagRange,
+                        contentRange: NSRange(location: open.tagRange.upperBound, length: 0),
+                        tagRanges: [open.tagRange]
+                    ))
+                } else {
+                    rejected = true
+                }
+            }
+            return SafeHTMLDocument(range: bounds, annotations: rejected ? [] : annotations.sorted { $0.range.location < $1.range.location }, isSafe: sawTag && !rejected)
+        }
+
+        private struct Tag {
+            let name: String
+            let attributes: [String: String]
+            let range: NSRange
+            let isClosing: Bool
+            let isSelfClosing: Bool
+            let isCommentOrDeclaration: Bool
+        }
+
+        private mutating func nextTag() -> Tag? {
+            guard let start = index(of: "<", from: cursor) else {
+                cursor = bounds.upperBound
+                return nil
+            }
+            if start > cursor {
+                let text = source.substring(with: NSRange(location: cursor, length: start - cursor))
+                if text.contains("<") { rejected = true; return nil }
+            }
+            guard let end = tagEnd(from: start) else { rejected = true; return nil }
+            let tagRange = NSRange(location: start, length: end - start + 1)
+            let raw = source.substring(with: NSRange(location: start + 1, length: end - start - 1))
+            cursor = end + 1
+            if raw.hasPrefix("!") || raw.hasPrefix("?") || raw.hasPrefix("/") && raw.dropFirst().first == "!" {
+                return Tag(name: "", attributes: [:], range: tagRange, isClosing: false, isSelfClosing: false, isCommentOrDeclaration: true)
+            }
+            let closing = raw.first == "/"
+            let body = closing ? String(raw.dropFirst()) : raw
+            let selfClosing = !closing && body.trimmingCharacters(in: .whitespacesAndNewlines).hasSuffix("/")
+            let cleaned = selfClosing ? String(body.dropLast()).trimmingCharacters(in: .whitespacesAndNewlines) : body
+            guard let nameEnd = cleaned.firstIndex(where: { $0.isWhitespace }) else {
+                let name = cleaned.lowercased()
+                guard allowedNames.contains(name) else { rejected = true; return nil }
+                return Tag(name: name, attributes: [:], range: tagRange, isClosing: closing, isSelfClosing: selfClosing, isCommentOrDeclaration: false)
+            }
+            let name = String(cleaned[..<nameEnd]).lowercased()
+            guard allowedNames.contains(name) else { rejected = true; return nil }
+            let rest = String(cleaned[nameEnd...])
+            guard !closing, let attrs = attributes(in: rest, for: name) else {
+                if closing && rest.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    return Tag(name: name, attributes: [:], range: tagRange, isClosing: true, isSelfClosing: false, isCommentOrDeclaration: false)
+                }
+                rejected = true
+                return nil
+            }
+            return Tag(name: name, attributes: attrs, range: tagRange, isClosing: false, isSelfClosing: selfClosing, isCommentOrDeclaration: false)
+        }
+
+        private mutating func open(_ tag: Tag) {
+            guard let kind = kind(for: tag.name, attributes: tag.attributes) else { rejected = true; return }
+            let void = tag.name == "br" || tag.name == "img"
+            guard !void || tag.isSelfClosing || tag.name == "br" || tag.name == "img" else { rejected = true; return }
+            if void {
+                annotations.append(SafeHTMLAnnotation(kind: kind, range: tag.range,
+                                                      contentRange: NSRange(location: tag.range.upperBound, length: 0),
+                                                      tagRanges: [tag.range]))
+                return
+            }
+            guard !tag.isSelfClosing else { rejected = true; return }
+            stack.append(OpenElement(name: tag.name, range: NSRange(location: tag.range.location, length: 0),
+                                     contentStart: tag.range.upperBound, tagRange: tag.range, kind: kind,
+                                     attributes: tag.attributes))
+        }
+
+        private mutating func close(_ tag: Tag) {
+            guard let open = stack.popLast(), open.name == tag.name else {
+                // The matching opening tag can live in the preceding
+                // HTMLBlock when Markdown contains a blank line inside
+                // `<details>`. This fragment is safe only for that inert
+                // container; unknown/unbalanced tags stay literal.
+                if stack.isEmpty, tag.name == "details",
+                   hasOpeningDetails(before: bounds.location) {
+                    annotations.append(SafeHTMLAnnotation(
+                        kind: .detailsClosing,
+                        range: tag.range,
+                        contentRange: NSRange(location: tag.range.location, length: 0),
+                        tagRanges: [tag.range]
+                    ))
+                } else {
+                    rejected = true
+                }
+                return
+            }
+            let elementRange = NSRange(location: open.tagRange.location, length: tag.range.upperBound - open.tagRange.location)
+            let content = NSRange(location: open.contentStart, length: max(0, tag.range.location - open.contentStart))
+            annotations.append(SafeHTMLAnnotation(kind: open.kind, range: elementRange, contentRange: content,
+                                                   tagRanges: [open.tagRange, tag.range]))
+        }
+
+        private func tagEnd(from start: Int) -> Int? {
+            var quote: unichar = 0
+            var index = start + 1
+            while index < bounds.upperBound {
+                let character = source.character(at: index)
+                if quote != 0 {
+                    if character == quote { quote = 0 }
+                } else if character == 0x22 || character == 0x27 {
+                    quote = character
+                } else if character == 0x3E {
+                    return index
+                }
+                index += 1
+            }
+            return nil
+        }
+
+        private func hasClosingDetails(after location: Int) -> Bool {
+            guard location < source.length else { return false }
+            return source.range(
+                of: "</details>",
+                options: [.caseInsensitive],
+                range: NSRange(location: location, length: source.length - location)
+            ).location != NSNotFound
+        }
+
+        private func hasOpeningDetails(before location: Int) -> Bool {
+            guard location > 0 else { return false }
+            var search = NSRange(location: 0, length: location)
+            while search.length > 0 {
+                let match = source.range(
+                    of: "<details",
+                    options: [.caseInsensitive, .backwards],
+                    range: search
+                )
+                guard match.location != NSNotFound else { return false }
+                guard match.upperBound < location else {
+                    search.length = match.location
+                    continue
+                }
+                let next = source.character(at: match.upperBound)
+                if next == 0x3E || next == 0x20 || next == 0x09 || next == 0x0A || next == 0x0D {
+                    return true
+                }
+                search.length = match.location
+            }
+            return false
+        }
+
+        private func index(of character: Character, from start: Int) -> Int? {
+            let target = unichar(character.asciiValue ?? 0)
+            guard target != 0 else { return nil }
+            for index in start..<bounds.upperBound where source.character(at: index) == target { return index }
+            return nil
+        }
+    }
+
+    private static let allowedNames: Set<String> = ["p", "h1", "h2", "h3", "h4", "h5", "h6", "strong", "b", "em", "i", "a", "img", "br", "details", "summary", "table", "thead", "tbody", "tr", "th", "td"]
+
+    private static func attributes(in raw: String, for name: String) -> [String: String]? {
+        var result: [String: String] = [:]
+        var index = raw.startIndex
+        while index < raw.endIndex {
+            while index < raw.endIndex, raw[index].isWhitespace { index = raw.index(after: index) }
+            guard index < raw.endIndex else { break }
+            let start = index
+            while index < raw.endIndex, !raw[index].isWhitespace, raw[index] != "=" { index = raw.index(after: index) }
+            let key = String(raw[start..<index]).lowercased()
+            guard !key.isEmpty, !key.hasPrefix("on") else { return nil }
+            while index < raw.endIndex, raw[index].isWhitespace { index = raw.index(after: index) }
+            if name == "details", key == "open",
+               (index == raw.endIndex || raw[index] != "=") {
+                result[key] = ""
+                continue
+            }
+            guard index < raw.endIndex, raw[index] == "=" else { return nil }
+            index = raw.index(after: index)
+            while index < raw.endIndex, raw[index].isWhitespace { index = raw.index(after: index) }
+            guard index < raw.endIndex else { return nil }
+            let quote = raw[index]
+            guard quote == "\"" || quote == "'" else { return nil }
+            index = raw.index(after: index)
+            let valueStart = index
+            while index < raw.endIndex, raw[index] != quote { index = raw.index(after: index) }
+            guard index < raw.endIndex else { return nil }
+            let value = String(raw[valueStart..<index])
+            index = raw.index(after: index)
+            guard allowedAttribute(key, for: name),
+                  (name == "img" && key == "src" || safeURL(value, for: key, tag: name))
+            else { return nil }
+            result[key] = value
+        }
+        return result
+    }
+
+    private static func allowedAttribute(_ key: String, for tag: String) -> Bool {
+        switch tag {
+        case "p", "h1", "h2", "h3", "h4", "h5", "h6", "th", "td": return key == "align"
+        case "a": return key == "href" || key == "title"
+        case "img": return key == "src" || key == "alt" || key == "title"
+        case "details": return key == "open"
+        default: return false
+        }
+    }
+
+    private static func safeURL(_ value: String, for key: String, tag: String) -> Bool {
+        guard key == "href" || key == "src" else { return true }
+        let value = value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !value.contains(":") || value.hasPrefix("https:") || value.hasPrefix("http:") || value.hasPrefix("mailto:") || value.hasPrefix("#") else { return false }
+        if key == "src" {
+            return !value.hasPrefix("http:") && !value.hasPrefix("https:") && !value.hasPrefix("//") && !value.hasPrefix("/") && !value.hasPrefix("file:") && !value.hasPrefix("data:")
+        }
+        return !value.hasPrefix("javascript:") && !value.hasPrefix("data:") && !value.hasPrefix("vbscript:")
+    }
+
+    private static func kind(for name: String, attributes: [String: String]) -> SafeHTMLKind? {
+        let alignment = attributes["align"]
+            .map { $0.lowercased() }
+            .flatMap(SafeHTMLAlignment.init(rawValue:))
+        switch name {
+        case "p": return .paragraph(align: alignment)
+        case "h1", "h2", "h3", "h4", "h5", "h6": return .heading(level: Int(name.dropFirst()) ?? 1)
+        case "strong", "b": return .strong
+        case "em", "i": return .emphasis
+        case "a": guard let href = attributes["href"] else { return nil }; return .link(destination: href, title: attributes["title"])
+        case "img":
+            guard let src = attributes["src"] else { return nil }
+            guard safeLocalImageSource(src) else { return .inert }
+            return .image(source: src, alt: attributes["alt"] ?? "")
+        case "br": return .lineBreak
+        case "details": return .details(open: attributes["open"] != nil)
+        case "summary": return .summary
+        case "table", "thead", "tbody": return .table
+        case "tr": return .tableRow
+        case "th": return .tableCell(header: true, align: alignment)
+        case "td": return .tableCell(header: false, align: alignment)
+        default: return nil
+        }
+    }
+
+    private static func safeLocalImageSource(_ source: String) -> Bool {
+        let value = source.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return !value.isEmpty
+            && !value.hasPrefix("http:")
+            && !value.hasPrefix("https:")
+            && !value.hasPrefix("//")
+            && !value.hasPrefix("/")
+            && !value.hasPrefix("file:")
+            && !value.hasPrefix("data:")
+            && !value.contains("..")
+    }
+}

--- a/Sources/MarkdownCore/SmartPaste.swift
+++ b/Sources/MarkdownCore/SmartPaste.swift
@@ -17,6 +17,14 @@ public enum SmartPaste {
         return parser.run()
     }
 
+    /// Plain-text projection used by Paste and Match Style. Unlike the
+    /// Markdown conversion this intentionally drops links, emphasis markers,
+    /// and block syntax while retaining the words a rich-text source showed.
+    public static func plainText(forHTML html: String) -> String {
+        var parser = HTMLTextOnly(html: html)
+        return parser.run()
+    }
+
     /// Spreadsheet and terminal-table paste.  Returns nil when the text has no
     /// tab structure, so the caller can fall through to a plain paste.
     public static func markdownTable(forTabSeparated text: String) -> String? {
@@ -75,6 +83,99 @@ public enum SmartPaste {
     }
 }
 
+private struct HTMLTextOnly {
+    let html: String
+    private var output = ""
+    private var skipDepth = 0
+    private var pendingSpace = false
+
+    init(html: String) { self.html = html }
+
+    mutating func run() -> String {
+        var index = html.startIndex
+        while index < html.endIndex {
+            if html[index] == "<", let close = html[index...].firstIndex(of: ">") {
+                let raw = String(html[html.index(after: index)..<close])
+                let closing = raw.hasPrefix("/")
+                let name = String((closing ? raw.dropFirst() : Substring(raw))
+                    .prefix { $0.isLetter || $0.isNumber }).lowercased()
+                if ["script", "style", "head"].contains(name) {
+                    skipDepth += closing ? -1 : 1
+                    skipDepth = max(0, skipDepth)
+                } else if skipDepth == 0, !closing {
+                    if name == "br" || ["li", "tr"].contains(name) {
+                        appendBoundary(newlines: 1)
+                    } else if ["p", "div", "blockquote", "pre", "details", "summary",
+                               "table", "h1", "h2", "h3", "h4", "h5", "h6"].contains(name) {
+                        appendBoundary(newlines: 2)
+                    }
+                }
+                index = html.index(after: close)
+                continue
+            }
+            let next = html[index...].firstIndex(of: "<") ?? html.endIndex
+            if skipDepth == 0 {
+                appendText(decodeEntities(String(html[index..<next])))
+            }
+            index = next
+        }
+        return normalized(output)
+    }
+
+    private mutating func appendBoundary(newlines: Int) {
+        guard !output.isEmpty else { return }
+        pendingSpace = false
+        while output.last == " " { output.removeLast() }
+        let existing = output.reversed().prefix { $0 == "\n" }.count
+        guard existing < newlines else { return }
+        output.append(String(repeating: "\n", count: newlines - existing))
+    }
+
+    private mutating func appendText(_ text: String) {
+        let collapsed = text.split(whereSeparator: { $0.isWhitespace }).joined(separator: " ")
+        if collapsed.isEmpty {
+            pendingSpace = pendingSpace || text.last?.isWhitespace == true
+            return
+        }
+        let leadingSpace = text.first?.isWhitespace == true
+        if (pendingSpace || leadingSpace), !output.isEmpty, !output.hasSuffix("\n"),
+           let first = collapsed.first,
+           !".,;:!?)]}".contains(first) {
+            output.append(" ")
+        }
+        output += collapsed
+        pendingSpace = text.last?.isWhitespace == true
+    }
+
+    private func normalized(_ value: String) -> String {
+        let lines = value.components(separatedBy: "\n").map {
+            $0.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        var normalizedLines: [String] = []
+        var blankLines = 0
+        for line in lines {
+            if line.isEmpty {
+                blankLines += 1
+                if blankLines == 1, !normalizedLines.isEmpty { normalizedLines.append("") }
+            } else {
+                blankLines = 0
+                normalizedLines.append(line)
+            }
+        }
+        return normalizedLines.joined(separator: "\n")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func decodeEntities(_ value: String) -> String {
+        value.replacingOccurrences(of: "&nbsp;", with: " ")
+            .replacingOccurrences(of: "&amp;", with: "&")
+            .replacingOccurrences(of: "&lt;", with: "<")
+            .replacingOccurrences(of: "&gt;", with: ">")
+            .replacingOccurrences(of: "&quot;", with: "\"")
+            .replacingOccurrences(of: "&#39;", with: "'")
+    }
+}
+
 // MARK: - HTML → markdown
 
 private struct HTMLToMarkdown {
@@ -113,9 +214,28 @@ private struct HTMLToMarkdown {
     /// Block tags each contribute their own `\n\n`, so a `</h2><p>` boundary
     /// produces four newlines.  Collapse any run to a single blank line.
     static func collapseBlankRuns(_ text: String) -> String {
+        // Browser fragments commonly carry indentation/newlines between tags.
+        // Those become a literal space when inline text is collapsed, leaving
+        // whitespace-only lines between list/table blocks.  Remove only those
+        // lines outside fenced code so a code sample's indentation remains
+        // lossless enough for a Markdown paste.
+        var cleanedLines: [String] = []
+        var inFence = false
+        for line in text.components(separatedBy: "\n") {
+            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmed.hasPrefix("```") {
+                inFence.toggle()
+                cleanedLines.append(line)
+            } else if inFence || !trimmed.isEmpty {
+                cleanedLines.append(line)
+            } else {
+                cleanedLines.append("")
+            }
+        }
+
         var out = ""
         var newlines = 0
-        for character in text {
+        for character in cleanedLines.joined(separator: "\n") {
             if character == "\n" {
                 newlines += 1
                 if newlines <= 2 { out.append(character) }
@@ -167,10 +287,14 @@ private struct HTMLToMarkdown {
         case "ul", "ol":
             if isClosing {
                 if !listStack.isEmpty { listStack.removeLast() }
-                append("\n")
+                // Nested lists are part of the current list item; adding a
+                // boundary here would turn every nested item into a separate
+                // paragraph. The outer list still needs a boundary before the
+                // next block.
+                if listStack.isEmpty { append("\n") }
             } else {
                 listStack.append((ordered: name == "ol", index: 0))
-                append("\n")
+                if listStack.count == 1 { append("\n") }
             }
         case "li":
             guard !isClosing else { return }
@@ -184,13 +308,27 @@ private struct HTMLToMarkdown {
                 append("\n" + indent + (entry.ordered ? "\(entry.index). " : "- "))
             }
         case "a":
-            append(isClosing ? "]" : "[")
-            if isClosing, let href = attribute("href", in: lastAnchor) { append("(\(href))") }
-            if !isClosing { lastAnchor = body }
+            if isClosing {
+                if let destination = activeAnchorDestination {
+                    append("](\(destination))")
+                }
+                activeAnchorDestination = nil
+            } else if let href = attribute("href", in: body),
+                      let destination = safeDestination(href) {
+                activeAnchorDestination = destination
+                append("[")
+            } else {
+                activeAnchorDestination = nil
+            }
         case "img":
             let alt = attribute("alt", in: body) ?? ""
             let src = attribute("src", in: body) ?? ""
-            if !src.isEmpty { append("![\(alt)](\(src))") }
+            if let destination = safeDestination(src) {
+                let escapedAlt = alt
+                    .replacingOccurrences(of: "[", with: "\\[")
+                    .replacingOccurrences(of: "]", with: "\\]")
+                append("![\(escapedAlt)](\(destination))")
+            }
         case "table":
             if isClosing {
                 inTable = false
@@ -216,7 +354,22 @@ private struct HTMLToMarkdown {
         }
     }
 
-    private var lastAnchor = ""
+    private var activeAnchorDestination: String?
+
+    /// Clipboard HTML is untrusted interchange data. Preserve useful web,
+    /// mail, file, fragment, and relative destinations while dropping schemes
+    /// that could become executable when the resulting Markdown is clicked.
+    private func safeDestination(_ raw: String) -> String? {
+        let value = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !value.isEmpty, !value.contains(where: { $0.isWhitespace }) else { return nil }
+        if value.hasPrefix("#") { return value }
+        guard let components = URLComponents(string: value) else { return nil }
+        if let scheme = components.scheme?.lowercased(),
+           !["http", "https", "mailto", "file"].contains(scheme) {
+            return nil
+        }
+        return value.contains("(") || value.contains(")") ? "<\(value)>" : value
+    }
 
     private mutating func emit(text raw: String) {
         guard skipDepth == 0 else { return }

--- a/Sources/MarkdownRender/ClipboardSemanticHTML.swift
+++ b/Sources/MarkdownRender/ClipboardSemanticHTML.swift
@@ -1,0 +1,285 @@
+import Foundation
+
+/// A deliberately small, safe Markdown-to-HTML projection for the system
+/// clipboard. It is an interchange representation, not Downright's renderer:
+/// unsupported Markdown and raw HTML remain escaped text, while common prose,
+/// headings, lists, tables, links, emphasis, and code retain their meaning in
+/// rich-text applications.
+enum ClipboardSemanticHTML {
+    private struct ListEntry {
+        let indent: Int
+        let kind: String
+        let text: String
+    }
+
+    static func render(markdown: String) -> String {
+        let lines = markdown
+            .replacingOccurrences(of: "\r\n", with: "\n")
+            .replacingOccurrences(of: "\r", with: "\n")
+            .components(separatedBy: "\n")
+        var output: [String] = []
+        var index = 0
+        var inFence = false
+        var fenceLanguage = ""
+        var fenceLines: [String] = []
+        var paragraph: [String] = []
+        var listEntries: [ListEntry] = []
+
+        func flushParagraph() {
+            guard !paragraph.isEmpty else { return }
+            let text = paragraph.joined(separator: "\n")
+            output.append("<p>\(inline(text))</p>")
+            paragraph.removeAll(keepingCapacity: true)
+        }
+        func flushList() {
+            guard !listEntries.isEmpty else { return }
+            output.append(listHTML(listEntries))
+            listEntries.removeAll(keepingCapacity: true)
+        }
+
+        while index < lines.count {
+            let line = lines[index]
+            if inFence {
+                if line.trimmingCharacters(in: .whitespaces).hasPrefix("```") ||
+                    line.trimmingCharacters(in: .whitespaces).hasPrefix("~~~") {
+                    let language = fenceLanguage.isEmpty ? "" : " class=\"language-\(escapeAttribute(fenceLanguage))\""
+                    output.append("<pre><code\(language)>\(escape(fenceLines.joined(separator: "\n")))</code></pre>")
+                    inFence = false
+                    fenceLanguage = ""
+                    fenceLines.removeAll(keepingCapacity: true)
+                } else {
+                    fenceLines.append(line)
+                }
+                index += 1
+                continue
+            }
+
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed.hasPrefix("```") || trimmed.hasPrefix("~~~") {
+                flushParagraph()
+                flushList()
+                inFence = true
+                fenceLanguage = String(trimmed.dropFirst(3)).trimmingCharacters(in: .whitespaces)
+                index += 1
+                continue
+            }
+            if trimmed.isEmpty {
+                flushParagraph()
+                flushList()
+                index += 1
+                continue
+            }
+
+            if let heading = headingParts(trimmed) {
+                flushParagraph()
+                flushList()
+                output.append("<h\(heading.level)>\(inline(heading.text))</h\(heading.level)>")
+                index += 1
+                continue
+            }
+
+            if index + 1 < lines.count, isTableDelimiter(lines[index + 1]),
+               let header = tableCells(line) {
+                flushParagraph()
+                flushList()
+                var rows: [[String]] = [header]
+                index += 2
+                while index < lines.count, let row = tableCells(lines[index]) {
+                    rows.append(row)
+                    index += 1
+                }
+                output.append(tableHTML(rows))
+                continue
+            }
+
+            if let item = listPart(line) {
+                flushParagraph()
+                listEntries.append(item)
+                index += 1
+                continue
+            }
+
+            flushList()
+            paragraph.append(line)
+            index += 1
+        }
+        if inFence {
+            let language = fenceLanguage.isEmpty ? "" : " class=\"language-\(escapeAttribute(fenceLanguage))\""
+            output.append("<pre><code\(language)>\(escape(fenceLines.joined(separator: "\n")))</code></pre>")
+        }
+        flushParagraph()
+        flushList()
+        return output.joined(separator: "\n")
+    }
+
+    private static func headingParts(_ line: String) -> (level: Int, text: String)? {
+        let hashes = line.prefix { $0 == "#" }.count
+        guard (1...6).contains(hashes), line.dropFirst(hashes).first == " " else { return nil }
+        return (hashes, String(line.dropFirst(hashes)).trimmingCharacters(in: .whitespaces))
+    }
+
+    private static func listPart(_ line: String) -> ListEntry? {
+        let indent = line.prefix { $0 == " " || $0 == "\t" }.reduce(into: 0) {
+            $0 += $1 == "\t" ? 4 : 1
+        }
+        let content = line.drop { $0 == " " || $0 == "\t" }
+        if ["- ", "* ", "+ "].contains(where: { content.hasPrefix($0) }) {
+            return ListEntry(indent: indent, kind: "ul", text: String(content.dropFirst(2)))
+        }
+        var digits = ""
+        for character in content {
+            guard character.isNumber else { break }
+            digits.append(character)
+        }
+        guard !digits.isEmpty, content.dropFirst(digits.count).hasPrefix(". ") else { return nil }
+        return ListEntry(
+            indent: indent,
+            kind: "ol",
+            text: String(content.dropFirst(digits.count + 2))
+        )
+    }
+
+    private static func listHTML(_ entries: [ListEntry]) -> String {
+        var index = 0
+        func renderLevel(_ indent: Int) -> String {
+            var html = ""
+            while index < entries.count, entries[index].indent == indent {
+                let kind = entries[index].kind
+                html += "<\(kind)>"
+                while index < entries.count,
+                      entries[index].indent == indent,
+                      entries[index].kind == kind {
+                    let entry = entries[index]
+                    index += 1
+                    html += "<li>\(inline(entry.text))"
+                    if index < entries.count, entries[index].indent > indent {
+                        html += renderLevel(entries[index].indent)
+                    }
+                    html += "</li>"
+                }
+                html += "</\(kind)>"
+            }
+            return html
+        }
+        return renderLevel(entries.first?.indent ?? 0)
+    }
+
+    private static func tableCells(_ line: String) -> [String]? {
+        guard line.contains("|") else { return nil }
+        var cells = line.split(separator: "|", omittingEmptySubsequences: false)
+            .map { String($0).trimmingCharacters(in: .whitespaces) }
+        if line.trimmingCharacters(in: .whitespaces).hasPrefix("|"), !cells.isEmpty { cells.removeFirst() }
+        if line.trimmingCharacters(in: .whitespaces).hasSuffix("|"), !cells.isEmpty { cells.removeLast() }
+        return cells.count > 1 ? cells : nil
+    }
+
+    private static func isTableDelimiter(_ line: String) -> Bool {
+        guard let cells = tableCells(line), !cells.isEmpty else { return false }
+        return cells.allSatisfy { cell in
+            let value = cell.trimmingCharacters(in: .whitespaces)
+            return value.count >= 3 && value.allSatisfy { $0 == "-" || $0 == ":" }
+        }
+    }
+
+    private static func tableHTML(_ rows: [[String]]) -> String {
+        guard let header = rows.first else { return "" }
+        let head = header.map { "<th>\(inline($0))</th>" }.joined()
+        let body = rows.dropFirst().map { row in
+            let cells = row + Array(repeating: "", count: max(0, header.count - row.count))
+            return "<tr>\(cells.prefix(header.count).map { "<td>\(inline($0))</td>" }.joined())</tr>"
+        }.joined()
+        return "<table><thead><tr>\(head)</tr></thead>\(body.isEmpty ? "" : "<tbody>\(body)</tbody>")</table>"
+    }
+
+    private static func inline(_ input: String) -> String {
+        var output = ""
+        var index = input.startIndex
+        while index < input.endIndex {
+            if input[index] == "<" {
+                // Raw HTML is source text from the document, not trusted markup
+                // supplied to the destination application.
+                output += "&lt;"
+                index = input.index(after: index)
+                continue
+            }
+            if input[index] == "\\" {
+                let next = input.index(after: index)
+                if next < input.endIndex {
+                    output += escape(String(input[next]))
+                    index = input.index(after: next)
+                    continue
+                }
+            }
+            if input[index...].hasPrefix("**") || input[index...].hasPrefix("__") {
+                let marker = String(input[index...].prefix(2))
+                if let end = input[input.index(index, offsetBy: 2)..<input.endIndex].range(of: marker) {
+                    let start = input.index(index, offsetBy: 2)
+                    output += "<strong>\(inline(String(input[start..<end.lowerBound])))</strong>"
+                    index = end.upperBound
+                    continue
+                }
+            }
+            if input[index...].hasPrefix("~~"),
+               let end = input[input.index(index, offsetBy: 2)..<input.endIndex].range(of: "~~") {
+                let start = input.index(index, offsetBy: 2)
+                output += "<del>\(inline(String(input[start..<end.lowerBound])))</del>"
+                index = end.upperBound
+                continue
+            }
+            if input[index] == "`", let end = input[input.index(after: index)..<input.endIndex].firstIndex(of: "`") {
+                let start = input.index(after: index)
+                output += "<code>\(escape(String(input[start..<end])))</code>"
+                index = input.index(after: end)
+                continue
+            }
+            if input[index...].hasPrefix("!["),
+               let close = input[input.index(index, offsetBy: 2)..<input.endIndex].firstIndex(of: "]"),
+               input[input.index(after: close)...].hasPrefix("(") {
+                let destinationStart = input.index(after: close)
+                if let destinationEnd = input[destinationStart...].firstIndex(of: ")") {
+                    let altStart = input.index(index, offsetBy: 2)
+                    let alt = String(input[altStart..<close])
+                    let destination = String(input[input.index(destinationStart, offsetBy: 1)..<destinationEnd])
+                    let source = escapeAttribute(destination)
+                    if !source.isEmpty {
+                        output += "<img src=\"\(source)\" alt=\"\(escapeAttribute(alt))\">"
+                    } else {
+                        output += escape("![\(alt)](\(destination))")
+                    }
+                    index = input.index(after: destinationEnd)
+                    continue
+                }
+            }
+            if input[index] == "[", let close = input[input.index(after: index)..<input.endIndex].firstIndex(of: "]"),
+               input[input.index(after: close)...].hasPrefix("(") {
+                let destinationStart = input.index(after: close)
+                if let destinationEnd = input[destinationStart...].firstIndex(of: ")") {
+                    let label = String(input[input.index(after: index)..<close])
+                    let destination = String(input[input.index(destinationStart, offsetBy: 1)..<destinationEnd])
+                    output += "<a href=\"\(escapeAttribute(destination))\">\(inline(label))</a>"
+                    index = input.index(after: destinationEnd)
+                    continue
+                }
+            }
+            let character = String(input[index])
+            output += escape(character)
+            index = input.index(after: index)
+        }
+        return output.replacingOccurrences(of: "  \n", with: "<br>\n")
+    }
+
+    private static func escape(_ value: String) -> String {
+        value.replacingOccurrences(of: "&", with: "&amp;")
+            .replacingOccurrences(of: "<", with: "&lt;")
+            .replacingOccurrences(of: ">", with: "&gt;")
+            .replacingOccurrences(of: "\"", with: "&quot;")
+    }
+
+    private static func escapeAttribute(_ value: String) -> String {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let url = URL(string: trimmed),
+              url.scheme == nil || ["http", "https", "mailto", "file"].contains(url.scheme?.lowercased() ?? "")
+        else { return "" }
+        return escape(trimmed)
+    }
+}

--- a/Sources/MarkdownRender/Engine/DecorationEngine.swift
+++ b/Sources/MarkdownRender/Engine/DecorationEngine.swift
@@ -500,7 +500,10 @@ public final class DecorationEngine {
             return
 
         case .heading, .paragraph, .htmlBlock, .footnoteDefinition:
-            if let program = cachedProgram(for: block, context: context) {
+            if let html = block.safeHTML, html.isSafe {
+                applyBase(block, context: context, state: &state)
+                applySafeHTML(html, block: block, state: &state)
+            } else if let program = cachedProgram(for: block, context: context) {
                 applyProgram(program, at: block.range.location, state: &state)
                 let attributes = styles.baseAttributes(for: block, context: context)
                 applyFirstHeadingSpacing(block, attributes: attributes, state: &state)
@@ -839,6 +842,135 @@ public final class DecorationEngine {
         ], to: span.contentRange.length > 0 ? span.contentRange : span.range, state: &state)
     }
 
+    /// Applies a conservative native presentation to README-style HTML while
+    /// leaving every source character in storage. MarkerPolicy controls when
+    /// the original tags are shown for editing.
+    private func applySafeHTML(
+        _ html: SafeHTMLDocument,
+        block: MDBlock,
+        state: inout DecorateState
+    ) {
+        let bodyFont = styleSheet.bodyFont()
+        for annotation in html.annotations {
+            for tagRange in annotation.tagRanges {
+                apply(styles.markerAttributes(dimmed: true), to: tagRange, state: &state)
+            }
+            switch annotation.kind {
+            case .paragraph(let alignment):
+                guard let alignment, annotation.contentRange.length > 0 else { continue }
+                let current = state.storage.attribute(
+                        .paragraphStyle,
+                        at: annotation.contentRange.location,
+                        effectiveRange: nil
+                      ) as? NSParagraphStyle
+                let paragraph = current?.mutableCopy() as? NSMutableParagraphStyle
+                    ?? NSMutableParagraphStyle()
+                switch alignment {
+                case .left: paragraph.alignment = .left
+                case .center: paragraph.alignment = .center
+                case .right: paragraph.alignment = .right
+                case .justify: paragraph.alignment = .justified
+                }
+                let physicalParagraph = (state.storage.string as NSString)
+                    .paragraphRange(for: annotation.range)
+                apply([.paragraphStyle: paragraph.copy() as Any], to: physicalParagraph, state: &state)
+
+            case .heading(let level):
+                apply([
+                    .font: styleSheet.headingFont(level: level),
+                    .foregroundColor: styleSheet.headingColor(level: level),
+                    .drHeading: level,
+                ], to: annotation.contentRange, state: &state)
+
+            case .strong:
+                apply([.font: emphasized(bodyFont, bold: true, italic: false)],
+                      to: annotation.contentRange, state: &state)
+
+            case .emphasis:
+                apply([.font: emphasized(bodyFont, bold: false, italic: true)],
+                      to: annotation.contentRange, state: &state)
+
+            case .link(let destination, _):
+                apply([
+                    .drLink: destination,
+                    .link: destination,
+                    .foregroundColor: styleSheet.link,
+                    .underlineStyle: NSUnderlineStyle.single.rawValue,
+                ], to: annotation.contentRange, state: &state)
+
+            case .image(let source, let alt):
+                let payload = FragmentPayload(
+                    kind: .image,
+                    sourceRange: annotation.range,
+                    blockIdentity: block.identity,
+                    detail: source
+                )
+                apply([
+                    .drFragment: payload,
+                    .drLink: source,
+                    .drReference: alt,
+                ], to: annotation.range, state: &state)
+                state.fragmentCount += 1
+
+            case .summary:
+                // Keep the summary visually distinct even though the source
+                // tags are hidden in Read/Live. The disclosure glyph is a
+                // source-preserving display-map substitution; this treatment
+                // gives VoiceOver/text selection and a narrow window a stable
+                // semantic anchor without inserting a character into source.
+                apply([
+                    .font: emphasized(bodyFont, bold: true, italic: false),
+                    .backgroundColor: styleSheet.surface.withAlphaComponent(0.34),
+                ], to: annotation.contentRange, state: &state)
+
+            case .tableCell(let header, let alignment):
+                if header {
+                    apply([.font: emphasized(bodyFont, bold: true, italic: false)],
+                          to: annotation.contentRange, state: &state)
+                }
+                if let alignment, annotation.contentRange.length > 0 {
+                    let current = state.storage.attribute(
+                        .paragraphStyle,
+                        at: annotation.contentRange.location,
+                        effectiveRange: nil
+                    ) as? NSParagraphStyle
+                    let paragraph = current?.mutableCopy() as? NSMutableParagraphStyle
+                        ?? NSMutableParagraphStyle()
+                    switch alignment {
+                    case .left: paragraph.alignment = .left
+                    case .center: paragraph.alignment = .center
+                    case .right: paragraph.alignment = .right
+                    case .justify: paragraph.alignment = .justified
+                    }
+                    apply([.paragraphStyle: paragraph], to: annotation.contentRange, state: &state)
+                }
+                // HTML tables commonly omit whitespace between cells. A small
+                // trailing kern is a visual column gutter that does not alter
+                // the source string or its source/display coordinate mapping.
+                if annotation.contentRange.length > 0 {
+                    let trailing = NSRange(
+                        location: annotation.contentRange.upperBound - 1,
+                        length: 1
+                    )
+                    apply([
+                        .kern: RenderMetrics.tableColumnGap * 0.5,
+                        .backgroundColor: styleSheet.surface.withAlphaComponent(header ? 0.26 : 0.12),
+                    ], to: trailing, state: &state)
+                    apply([
+                        .backgroundColor: styleSheet.surface.withAlphaComponent(header ? 0.26 : 0.12),
+                    ], to: annotation.contentRange, state: &state)
+                }
+
+            case .inert:
+                apply([.foregroundColor: styleSheet.textFaint],
+                      to: annotation.range, state: &state)
+
+            case .lineBreak, .details, .detailsClosing, .table, .tableRow:
+                break
+            }
+        }
+    }
+
     /// Bold and italic inside a heading must stay at the heading's size, so
     /// traits are derived from the block's own font unless the block is at body
     /// size — where the theme's `emphasisFont` gets to make the call (§11.1).
@@ -949,6 +1081,7 @@ public final class DecorationEngine {
     // MARK: - Program cache
 
     private func cachedProgram(for block: MDBlock, context: BlockContext) -> [AttributeOp]? {
+        guard block.safeHTML == nil else { return nil }
         guard block.subtreeHash != 0, block.children.isEmpty, block.content.isLeafText else { return nil }
         // Inline math carries its LaTeX as a payload read out of the document,
         // which the range-shifted recorder cannot resolve.  Rare enough that

--- a/Sources/MarkdownRender/Engine/DisplayMap.swift
+++ b/Sources/MarkdownRender/Engine/DisplayMap.swift
@@ -486,6 +486,30 @@ public struct DisplayMap {
         self.normalizedBaseHiddenRanges = normalizedBaseHiddenRanges
     }
 
+    /// Projects an ordinary character edit without rebuilding the paragraph
+    /// lookup table. When paragraph topology and substitution cardinality are
+    /// unchanged, every entry keeps the same paragraph slot; only source
+    /// offsets move. Structural edits fall back to the validating initializer.
+    func projectingStableTopology(
+        paragraphs newParagraphs: ParagraphIndex,
+        substitutions: [DisplaySubstitution],
+        hiddenRanges: [NSRange]
+    ) -> DisplayMap {
+        guard overrideParagraph == nil,
+              newParagraphs.starts.count == paragraphs.starts.count,
+              substitutions.count == base.count else {
+            return DisplayMap(paragraphs: newParagraphs, substitutions: substitutions)
+        }
+        return DisplayMap(
+            paragraphs: newParagraphs,
+            base: substitutions,
+            firstInParagraph: firstInParagraph,
+            overrideParagraph: nil,
+            overrideEntries: [],
+            normalizedBaseHiddenRanges: hiddenRanges
+        )
+    }
+
     /// A map identical to this one except that the entries of the paragraph
     /// containing `offset` are replaced.  O(entries in that paragraph).
     ///

--- a/Sources/MarkdownRender/Engine/MarkerPolicy.swift
+++ b/Sources/MarkdownRender/Engine/MarkerPolicy.swift
@@ -64,6 +64,21 @@ public enum MarkerPolicy {
         let revealAnchors = anchors(policy: policy, caret: caret, selections: selections)
 
         document.root.walk { block in
+            if policy.hidesInlineMarkers,
+               let html = block.safeHTML,
+               html.isSafe,
+               !revealAnchors.contains(where: { touches($0, block.range) }) {
+                for annotation in html.annotations {
+                    // Image tags become native image fragments over their
+                    // source range, so hiding the range as a marker would also
+                    // hide the fragment's display substitution.
+                    switch annotation.kind {
+                    case .image, .inert: continue
+                    default: break
+                    }
+                    out.append(contentsOf: annotation.tagRanges)
+                }
+            }
             if policy.hidesBlockMarkers, blockMarkersAreHidden(block) {
                 if let m = block.markerRange, m.length > 0 {
                     out.append(m)

--- a/Sources/MarkdownRender/View/MarkdownSmartPaste.swift
+++ b/Sources/MarkdownRender/View/MarkdownSmartPaste.swift
@@ -10,12 +10,22 @@ enum MarkdownPasteContext: Equatable {
     case plain
 }
 
+enum MarkdownPasteMode: Equatable {
+    case smart
+    case markdown
+    case matchStyle
+}
+
 /// Clipboard payload in the order in which AppKit presents useful flavours.
 /// Keeping this value independent of `NSPasteboard` makes the policy pure and
 /// keeps all source-coordinate mutation in `MarkdownTextView`.
 enum MarkdownPastePayload: Equatable {
+    case markdown(String)
     case url(String)
     case html(String, fallback: String)
+    case richText(String)
+    case file(String)
+    case image
     case text(String)
 }
 
@@ -24,15 +34,50 @@ enum MarkdownSmartPaste {
     /// an explicit URL wins over browser HTML, then plain text. The named
     /// pasteboard seam keeps tests and Quick Look callers off the global board.
     static func payload(from pasteboard: NSPasteboard) -> MarkdownPastePayload? {
-        let orderedTypes: [NSPasteboard.PasteboardType] = [.downrightMarkdown, .URL, .html, .string]
+        let orderedTypes: [NSPasteboard.PasteboardType] = [
+            .downrightMarkdown, .URL, .html, .rtf, .rtfd, .webArchive, .appleWebArchive,
+            .fileURL, .tiff, .png, .string,
+        ]
         for type in orderedTypes where pasteboard.types?.contains(type) == true {
             if type == .downrightMarkdown {
-                if let markdown = pasteboard.string(forType: type) { return .text(markdown) }
+                if let markdown = pasteboard.string(forType: type) { return .markdown(markdown) }
             } else if type == .URL {
                 if let url = pasteboard.string(forType: type), !url.isEmpty { return .url(url) }
             } else if type == .html {
                 guard let html = pasteboard.string(forType: type) else { continue }
                 return .html(html, fallback: pasteboard.string(forType: .string) ?? "")
+            } else if type == .rtf || type == .rtfd {
+                guard let data = pasteboard.data(forType: type),
+                      data.count <= maximumRichPayloadBytes,
+                      let attributed = try? NSAttributedString(
+                        data: data,
+                        options: [
+                            .documentType: type == .rtf
+                                ? NSAttributedString.DocumentType.rtf
+                                : NSAttributedString.DocumentType.rtfd,
+                        ],
+                        documentAttributes: nil
+                      ) else { continue }
+                if let htmlData = try? attributed.data(
+                    from: NSRange(location: 0, length: attributed.length),
+                    documentAttributes: [.documentType: NSAttributedString.DocumentType.html]
+                ), let html = String(data: htmlData, encoding: .utf8) {
+                    return .html(html, fallback: attributed.string)
+                }
+                return .richText(attributed.string)
+            } else if type == .webArchive || type == .appleWebArchive {
+                if let html = webArchiveHTML(from: pasteboard.data(forType: type)) {
+                    return .html(html, fallback: pasteboard.string(forType: .string) ?? "")
+                }
+            } else if type == .fileURL {
+                if let raw = pasteboard.string(forType: type),
+                   let url = URL(string: raw), url.isFileURL {
+                    return .file(url.path)
+                }
+            } else if type == .tiff || type == .png {
+                // Embedding requires a document-owned file name. Keep the
+                // operation explicit until the document layer can choose one.
+                return .image
             } else if let text = pasteboard.string(forType: type) {
                 return .text(text)
             }
@@ -45,14 +90,42 @@ enum MarkdownSmartPaste {
         selection: String,
         context: MarkdownPasteContext
     ) -> String {
-        guard context == .markdown else { return plainText(for: payload) }
+        replacement(for: payload, selection: selection, context: context, mode: .smart)
+    }
+
+    static func replacement(
+        for payload: MarkdownPastePayload,
+        selection: String,
+        context: MarkdownPasteContext,
+        mode: MarkdownPasteMode
+    ) -> String {
+        if mode == .matchStyle {
+            return plainText(for: payload)
+        }
+        if mode == .smart && context != .markdown {
+            // Existing Source/Code behavior intentionally leaves HTML visible
+            // when the producer did not provide a text fallback; only the
+            // explicit Match Style command strips it to words.
+            if case .html(let html, let fallback) = payload {
+                return fallback.isEmpty ? html : fallback
+            }
+            return plainText(for: payload)
+        }
 
         switch payload {
+        case .markdown(let markdown):
+            return markdown
         case .url(let url):
             return SmartPaste.linkified(selection: selection, url: url) ?? url
         case .html(let html, let fallback):
             let markdown = SmartPaste.markdown(forHTML: html)
             return markdown.isEmpty ? fallback : markdown
+        case .richText(let text):
+            return text
+        case .file(let path):
+            return path
+        case .image:
+            return ""
         case .text(let text):
             return SmartPaste.markdownTable(forTabSeparated: text) ?? text
         }
@@ -60,11 +133,29 @@ enum MarkdownSmartPaste {
 
     private static func plainText(for payload: MarkdownPastePayload) -> String {
         switch payload {
+        case .markdown(let markdown): return markdown
         case .url(let url): return url
-        case .html(let html, let fallback): return fallback.isEmpty ? html : fallback
+        case .html(let html, let fallback):
+            return fallback.isEmpty ? SmartPaste.plainText(forHTML: html) : fallback
+        case .richText(let text): return text
+        case .file(let path): return path
+        case .image: return ""
         case .text(let text): return text
         }
     }
+
+    private static func webArchiveHTML(from data: Data?) -> String? {
+        guard let data, data.count <= maximumRichPayloadBytes,
+              let plist = try? PropertyListSerialization.propertyList(
+                from: data, options: [], format: nil
+              ) as? [String: Any],
+              let resource = plist["WebMainResource"] as? [String: Any],
+              let htmlData = resource["WebResourceData"] as? Data else { return nil }
+        return String(data: htmlData, encoding: .utf8)
+            ?? String(data: htmlData, encoding: .utf16)
+    }
+
+    private static let maximumRichPayloadBytes = 8 * 1_024 * 1_024
 
     /// A range is literal when it intersects a code block.  The block lookup
     /// is deliberately source-based, matching `MarkdownTextView`'s selection
@@ -133,4 +224,7 @@ public extension NSPasteboard.PasteboardType {
     static let downrightMarkdown = NSPasteboard.PasteboardType(
         "com.ezzy.downright.markdown"
     )
+
+    static let webArchive = NSPasteboard.PasteboardType("Apple Web Archive pasteboard type")
+    static let appleWebArchive = NSPasteboard.PasteboardType("com.apple.webarchive")
 }

--- a/Sources/MarkdownRender/View/MarkdownTextView+Interaction.swift
+++ b/Sources/MarkdownRender/View/MarkdownTextView+Interaction.swift
@@ -755,7 +755,11 @@ extension MarkdownTextView {
     /// *source* range; nothing else is ever handed to the storage, which is
     /// how §3.1's guarantee survives contact with AppKit's editing pipeline.
     @discardableResult
-    public func performSourceEdit(range: NSRange, replacement: String) -> Bool {
+    public func performSourceEdit(
+        range: NSRange,
+        replacement: String,
+        provenance: String = "Edit"
+    ) -> Bool {
         guard isEditable, let storage = textStorage else { return false }
         let clamped = NSRange(location: max(0, min(range.location, storage.length)),
                               length: max(0, min(range.length, storage.length - min(range.location, storage.length))))
@@ -786,6 +790,7 @@ extension MarkdownTextView {
         let preservesParagraphStructure = !containsParagraphSeparator(deletedText)
             && !containsParagraphSeparator(replacement)
         projectFragmentPayloads(across: clamped, insertedLength: inserted)
+        lastMutationProvenance = provenance
         beginSourceEdit()
         storage.replaceCharacters(in: clamped, with: replacement)
         rebuildParagraphIndex()
@@ -874,6 +879,9 @@ extension MarkdownTextView {
     public override func insertText(_ string: Any, replacementRange: NSRange) {
         guard isEditable else { return }
         if hasMarkedText() || composingParagraph != nil {
+            let openedUndoGroup = undoManager?.groupingLevel == 0
+            if openedUndoGroup { undoManager?.beginUndoGrouping() }
+            defer { if openedUndoGroup { undoManager?.endUndoGrouping() } }
             super.insertText(string, replacementRange: replacementRange)
             return
         }
@@ -911,6 +919,12 @@ extension MarkdownTextView {
             composingParagraph = paragraphRange(containing: caret)
             refreshDisplayMapForComposition()
         }
+        // NSTextView registers marked-text replacement with its undo manager.
+        // Downright disables event grouping so source commands own exact undo
+        // boundaries; IME must therefore supply the group AppKit expects.
+        let openedUndoGroup = undoManager?.groupingLevel == 0
+        if openedUndoGroup { undoManager?.beginUndoGrouping() }
+        defer { if openedUndoGroup { undoManager?.endUndoGrouping() } }
         super.setMarkedText(string, selectedRange: selectedRange, replacementRange: replacementRange)
     }
 
@@ -1003,15 +1017,45 @@ extension MarkdownTextView {
     }
 
     public override func paste(_ sender: Any?) {
+        applyPaste(mode: .smart)
+    }
+
+    /// Explicitly prefer Markdown semantics even when the selection is in a
+    /// literal block. This is the command counterpart to Downright's private
+    /// lossless clipboard flavour.
+    @objc public func pasteAsMarkdown(_ sender: Any?) {
+        applyPaste(mode: .markdown)
+    }
+
+    /// Insert only the source's visible words, dropping formatting and table
+    /// conversion. This mirrors AppKit's Paste and Match Style action.
+    @objc public func pasteAndMatchStyle(_ sender: Any?) {
+        applyPaste(mode: .matchStyle)
+    }
+
+    private func applyPaste(mode pasteMode: MarkdownPasteMode) {
         guard isEditable else { return }
         let pasteboard = NSPasteboard.general
         guard let payload = markdownPastePayload(from: pasteboard) else { return }
+        if case .image = payload {
+            // An unnamed bitmap has no honest Markdown destination until the
+            // document owner chooses an asset path. Never replace a selection
+            // with guessed placeholder text.
+            NSSound.beep()
+            return
+        }
         let range = sourceSelectedRange
         let selection = sourceText(in: range)
         let context = MarkdownSmartPaste.context(for: range, in: parsedDocument, mode: mode)
         let replacement = MarkdownSmartPaste.replacement(
-            for: payload, selection: selection, context: context)
-        performSourceEdit(range: range, replacement: replacement)
+            for: payload, selection: selection, context: context, mode: pasteMode)
+        let provenance: String
+        switch pasteMode {
+        case .smart: provenance = "Paste"
+        case .markdown: provenance = "Paste as Markdown"
+        case .matchStyle: provenance = "Paste and Match Style"
+        }
+        performSourceEdit(range: range, replacement: replacement, provenance: provenance)
     }
 
     private func sourceText(in range: NSRange) -> String {
@@ -1142,9 +1186,10 @@ extension MarkdownTextView {
         let visible = exportableAttributedString(range: range)
         let markdownRange = losslessMarkdownRange(forVisibleSourceRange: range)
         let markdown = storage.attributedSubstring(from: markdownRange).string
-        pasteboard.declareTypes([.string, .rtf, .downrightMarkdown], owner: nil)
+        pasteboard.declareTypes([.string, .rtf, .html, .downrightMarkdown], owner: nil)
         pasteboard.setString(visible.string, forType: .string)
         pasteboard.setString(markdown, forType: .downrightMarkdown)
+        pasteboard.setString(ClipboardSemanticHTML.render(markdown: markdown), forType: .html)
         if let data = visible.rtf(
             from: NSRange(location: 0, length: visible.length),
             documentAttributes: [:]
@@ -1163,13 +1208,19 @@ extension MarkdownTextView {
     public override func writeSelection(to pboard: NSPasteboard, types: [NSPasteboard.PasteboardType]) -> Bool {
         let range = sourceSelectedRange
         guard range.length > 0, let storage = textStorage else { return false }
-        pboard.declareTypes([.string, .rtf, .downrightMarkdown], owner: nil)
+        pboard.declareTypes([.string, .rtf, .html, .downrightMarkdown], owner: nil)
         let rich = exportableAttributedString(range: range)
         pboard.setString(rich.string, forType: .string)
         let markdownRange = losslessMarkdownRange(forVisibleSourceRange: range)
         pboard.setString(
             storage.attributedSubstring(from: markdownRange).string,
             forType: .downrightMarkdown
+        )
+        pboard.setString(
+            ClipboardSemanticHTML.render(
+                markdown: storage.attributedSubstring(from: markdownRange).string
+            ),
+            forType: .html
         )
         if let data = rich.rtf(from: NSRange(location: 0, length: rich.length), documentAttributes: [:]) {
             pboard.setData(data, forType: .rtf)

--- a/Sources/MarkdownRender/View/MarkdownTextView.swift
+++ b/Sources/MarkdownRender/View/MarkdownTextView.swift
@@ -398,6 +398,9 @@ public final class MarkdownTextView: NSTextView {
 
     private var isApplyingSelection = false
     private var isPerformingSourceEdit = false
+    /// Human-scale provenance for the source mutation most recently reported
+    /// through `didEdit`. The app reads this synchronously in that callback.
+    public internal(set) var lastMutationProvenance = "Edit"
     /// A local edit should leave the caret in charge of the camera while its
     /// asynchronous parse result catches up.
     var shouldFollowCaretAfterLocalEdit = false
@@ -595,6 +598,37 @@ public final class MarkdownTextView: NSTextView {
     }
 
     // MARK: - Document updates
+
+    /// Seeds a second pane over the same attributed storage. The primary pane
+    /// has already parsed, decorated, and built every source/display mapping;
+    /// repeating that document-wide work when opening Split View made a 50k
+    /// line document stall for minutes. Each pane still owns independent
+    /// layout fragments, selection, scrolling, and reveal state.
+    public func adoptSharedPresentation(from source: MarkdownTextView) {
+        guard textStorage === source.textStorage else { return }
+        parsedDocument = source.parsedDocument
+        paragraphIndex = source.paragraphIndex
+        baseHiddenRanges = source.baseHiddenRanges
+        hardWrapRanges = source.hardWrapRanges
+        hardWrapSubstitutions = source.hardWrapSubstitutions
+        baseDisplayMap = source.baseDisplayMap
+        baseLayoutMap = source.baseLayoutMap
+        displayMap = source.displayMap
+        revealParagraph = source.revealParagraph
+        updateGeneration = max(1, source.updateGeneration)
+        fragmentContext.frontMatterFields = source.fragmentContext.frontMatterFields
+        fragmentContext.documentHasH1 = source.fragmentContext.documentHasH1
+        substitution.displayMap = baseDisplayMap
+        contentStorage.configure(
+            paragraphIndex: paragraphIndex,
+            reflowRanges: hardWrapRanges,
+            displayMap: displayMap,
+            invalidating: nil
+        )
+        needsLayout = true
+        needsDisplay = true
+        gutterRail?.reload()
+    }
 
     private func sourceScopes(for dirty: DirtySet) -> [NSRange] {
         guard !dirty.isWholesale, let storage = textStorage else { return [] }
@@ -1320,6 +1354,14 @@ public final class MarkdownTextView: NSTextView {
         if let focus = sourceFocus.range {
             hidden.removeAll { NSIntersectionRange($0, focus).length > 0 }
         }
+        let lineBreakSubstitutions = effectivePolicy.rendersFragments
+            ? Self.safeHTMLLineBreakSubstitutions(in: document, excluding: sourceFocus.range)
+            : []
+        if !lineBreakSubstitutions.isEmpty {
+            hidden = Self.removingOverlaps(
+                hidden, with: lineBreakSubstitutions.map(\.sourceRange)
+            )
+        }
 
         let mathRanges = effectivePolicy.rendersFragments
             ? InlineMathDisplay.ranges(in: document).filter { range in
@@ -1330,9 +1372,7 @@ public final class MarkdownTextView: NSTextView {
         // The math replacement owns its delimiters and content as one visual
         // object. Keeping the marker substitutions too would overlap the
         // object range, causing DisplayMap to reject one of the entries.
-        hidden.removeAll { hiddenRange in
-            mathRanges.contains { NSIntersectionRange(hiddenRange, $0).length > 0 }
-        }
+        hidden = Self.removingOverlaps(hidden, with: mathRanges)
         let mathSubstitutions = effectivePolicy.rendersFragments
             ? InlineMathDisplay.substitutions(
                 in: document, styleSheet: styleSheet, excluding: sourceFocus.range)
@@ -1344,11 +1384,7 @@ public final class MarkdownTextView: NSTextView {
                 return NSIntersectionRange(reference.range, focus).length == 0
             }
             : []
-        hidden.removeAll { hiddenRange in
-            footnoteReferences.contains {
-                NSIntersectionRange(hiddenRange, $0.range).length > 0
-            }
-        }
+        hidden = Self.removingOverlaps(hidden, with: footnoteReferences.map(\.range))
         let footnoteSubstitutions = effectivePolicy.hidesInlineMarkers
             ? FootnoteReferenceDisplay.substitutions(
                 in: document, styleSheet: styleSheet, excluding: sourceFocus.range
@@ -1356,12 +1392,25 @@ public final class MarkdownTextView: NSTextView {
             : []
 
         baseHiddenRanges = hidden
-        let plan = HardWrapReflow.plan(
-            document: document,
-            text: (textStorage?.string ?? "") as NSString,
-            hiddenRanges: hidden,
-            enabled: configuration.reflowHardWrappedParagraphs
-        )
+        let source = (textStorage?.string ?? "") as NSString
+        let plan: HardWrapReflow.Plan
+        if configuration.reflowHardWrappedParagraphs,
+           Self.containsHardWrappedParagraph(in: document, text: source) {
+            plan = HardWrapReflow.plan(
+                document: document,
+                text: source,
+                hiddenRanges: hidden,
+                enabled: true
+            )
+        } else {
+            // Most generated large documents use one physical line per
+            // paragraph. HardWrapReflow still walks every character in every
+            // paragraph in that case, even though it cannot publish a
+            // substitution. Avoid that whole-document pass during a wholesale
+            // commit while preserving reflow for documents that actually have
+            // wrapped paragraphs.
+            plan = HardWrapReflow.Plan(ranges: [], substitutions: [])
+        }
         hardWrapRanges = plan.ranges
         hardWrapSubstitutions = plan.substitutions.filter(\.isHardWrapReflow)
         baseDisplayMap = DisplayMap(
@@ -1369,6 +1418,7 @@ public final class MarkdownTextView: NSTextView {
             substitutions: hidden.map(DisplaySubstitution.hide)
                 + mathSubstitutions
                 + footnoteSubstitutions
+                + lineBreakSubstitutions
                 + hardWrapSubstitutions
         )
         // Selection / hit-testing speak TextKit coordinates from the layout map
@@ -1376,6 +1426,111 @@ public final class MarkdownTextView: NSTextView {
         // substitution fallback path only.
         baseLayoutMap = layoutDisplayMap(from: baseDisplayMap)
         displayMap = baseLayoutMap
+    }
+
+    /// Hard-wrap planning is only meaningful when a paragraph contains a
+    /// physical line break. Checking that invariant once is linear in source
+    /// length and avoids a much more expensive character walk through every
+    /// single-line paragraph in a large generated document.
+    private static func containsHardWrappedParagraph(
+        in document: ParsedDocument,
+        text: NSString
+    ) -> Bool {
+        var found = false
+        document.root.walk { block in
+            guard !found, case .paragraph = block.content, block.range.length > 0 else { return }
+            found = text.rangeOfCharacter(
+                from: .newlines,
+                options: [],
+                range: block.range
+            ).location != NSNotFound
+        }
+        return found
+    }
+
+    /// Presents safe README structural tags with source-preserving display
+    /// replacements. The trailing zero-width joiners keep TextKit source
+    /// offsets one-to-one with the replacement, so selection, editing, and
+    /// copying continue to address the original tag bytes. Details gets its
+    /// authored disclosure state at the opening tag; table rows get a line
+    /// break at their closing tag so adjacent cells/rows cannot concatenate.
+    private static func safeHTMLLineBreakSubstitutions(
+        in document: ParsedDocument,
+        excluding excludedRange: NSRange?
+    ) -> [DisplaySubstitution] {
+        var substitutions: [DisplaySubstitution] = []
+        document.root.walk { block in
+            guard let html = block.safeHTML, html.isSafe else { return }
+            for annotation in html.annotations {
+                let replacementRange: NSRange
+                let replacementText: String
+                switch annotation.kind {
+                case .lineBreak:
+                    guard annotation.range.length > 0 else { continue }
+                    replacementRange = annotation.range
+                    replacementText = "\n"
+                case .details:
+                    // Replace only the opening tag, not the content. This
+                    // gives both open and closed details a stable native
+                    // disclosure marker without changing source bytes.
+                    guard let opening = annotation.tagRanges.first,
+                          opening.length > 0 else { continue }
+                    replacementRange = opening
+                    if case .details(let open) = annotation.kind {
+                        replacementText = open ? "▾" : "▸"
+                    } else {
+                        continue
+                    }
+                case .tableRow:
+                    // Rows are often emitted without physical newlines in
+                    // README HTML. A break on the closing tag keeps the row
+                    // model legible while preserving source coordinates.
+                    guard let closing = annotation.tagRanges.last,
+                          closing.length > 0 else { continue }
+                    replacementRange = closing
+                    replacementText = "\n"
+                default:
+                    continue
+                }
+                if let excludedRange,
+                   NSIntersectionRange(replacementRange, excludedRange).length > 0 {
+                    continue
+                }
+                let replacement = NSAttributedString(string:
+                    replacementText + String(repeating: "\u{200B}", count: replacementRange.length - 1)
+                )
+                substitutions.append(DisplaySubstitution(
+                    sourceRange: replacementRange,
+                    displayLength: replacementRange.length,
+                    replacement: replacement,
+                    preservesSourceOffsets: true
+                ))
+            }
+        }
+        return substitutions.sorted { $0.sourceRange.location < $1.sourceRange.location }
+    }
+
+    /// Removes ranges intersecting an ordered exclusion set in one merge pass.
+    /// The old nested `contains` walk made a document with inline math in every
+    /// paragraph quadratic while rebuilding its display map.
+    private static func removingOverlaps(_ ranges: [NSRange], with exclusions: [NSRange]) -> [NSRange] {
+        guard !ranges.isEmpty, !exclusions.isEmpty else { return ranges }
+        let orderedRanges = ranges.sorted { $0.location < $1.location }
+        let orderedExclusions = exclusions.sorted { $0.location < $1.location }
+        var kept: [NSRange] = []
+        kept.reserveCapacity(orderedRanges.count)
+        var exclusionIndex = 0
+        for range in orderedRanges {
+            while exclusionIndex < orderedExclusions.count,
+                  orderedExclusions[exclusionIndex].upperBound <= range.location {
+                exclusionIndex += 1
+            }
+            let overlaps = exclusionIndex < orderedExclusions.count
+                && orderedExclusions[exclusionIndex].location < range.upperBound
+                && orderedExclusions[exclusionIndex].upperBound > range.location
+            if !overlaps { kept.append(range) }
+        }
+        return kept
     }
 
     /// TextKit 2 elements keep source-length ranges even when Markdown syntax
@@ -1577,9 +1732,16 @@ public final class MarkdownTextView: NSTextView {
         // footnote in the document disappear for one frame on each keystroke,
         // then reappear at parse commit — a whole-page flash on documents that
         // use either feature.
-        let oldDisplayObjects = baseDisplayMap.substitutions.filter {
+        let previousLogicalMap = baseDisplayMap
+        let previousLayoutMap = baseLayoutMap
+        let oldDisplayObjects = previousLogicalMap.substitutions.filter {
             !$0.isHidden && !$0.isHardWrapReflow
         }
+        // Layout substitutions already carry their attributed zero-width or
+        // object replacements. Project those immutable payloads alongside the
+        // logical map instead of regenerating every marker replacement in a
+        // 50k-line document for each character typed.
+        let oldLayoutSubstitutions = previousLayoutMap.substitutions
         let projection = SourceEditProjection(
             edit: edit,
             insertedLength: insertedLength,
@@ -1592,6 +1754,15 @@ public final class MarkdownTextView: NSTextView {
         }
         let projectedHidden = oldHiddenRanges.compactMap(projectPresentationRange)
         let projectedDisplayObjects = oldDisplayObjects.compactMap {
+            substitution -> DisplaySubstitution? in
+            guard let range = projectPresentationRange(substitution.sourceRange) else {
+                return nil
+            }
+            var projected = substitution
+            projected.sourceRange = range
+            return projected
+        }
+        let projectedLayoutSubstitutions = oldLayoutSubstitutions.compactMap {
             substitution -> DisplaySubstitution? in
             guard let range = projectPresentationRange(substitution.sourceRange) else {
                 return nil
@@ -1622,13 +1793,19 @@ public final class MarkdownTextView: NSTextView {
         baseHiddenRanges = projectedHidden
         hardWrapRanges = projectedHardWrapRanges
         hardWrapSubstitutions = projectedHardWrapSubstitutions
-        baseDisplayMap = DisplayMap(
+        let projectedLogicalSubstitutions = projectedHidden.map(DisplaySubstitution.hide)
+            + projectedDisplayObjects
+            + projectedHardWrapSubstitutions
+        baseDisplayMap = previousLogicalMap.projectingStableTopology(
             paragraphs: paragraphIndex,
-            substitutions: projectedHidden.map(DisplaySubstitution.hide)
-                + projectedDisplayObjects
-                + projectedHardWrapSubstitutions
+            substitutions: projectedLogicalSubstitutions,
+            hiddenRanges: projectedHidden
         )
-        baseLayoutMap = layoutDisplayMap(from: baseDisplayMap)
+        baseLayoutMap = previousLayoutMap.projectingStableTopology(
+            paragraphs: paragraphIndex,
+            substitutions: projectedLayoutSubstitutions,
+            hiddenRanges: projectedHidden
+        )
         displayMap = baseLayoutMap
         // Physical fallback still collapses markers; layout map keeps TextKit
         // selection arithmetic aligned with content storage.
@@ -1829,6 +2006,15 @@ public final class MarkdownTextView: NSTextView {
         // when the caret only moved to a neighbouring paragraph, so the common
         // case costs exactly what it did before.
         let paragraphs = isFullRefresh ? [] : [revealParagraph, current].compactMap { $0 }
+        if !isFullRefresh, additionalScopes.isEmpty,
+           let current,
+           baseDisplayMap.substitutions(inParagraphContaining: current.location).isEmpty,
+           revealParagraph.map({
+               baseDisplayMap.substitutions(inParagraphContaining: $0.location).isEmpty
+           }) ?? true {
+            revealParagraph = current
+            return
+        }
         if !isFullRefresh, additionalScopes.isEmpty,
            sameSubstitutions(displayMap.substitutions, previousSubstitutions) {
             // Moving through plain prose changes the caret paragraph but not

--- a/Tests/DownrightAppTests/AsyncParseTests.swift
+++ b/Tests/DownrightAppTests/AsyncParseTests.swift
@@ -6,7 +6,7 @@ import MarkdownCore
 @Suite(.serialized)
 struct AsyncParseTests {
     @Test @MainActor
-    func externalAbsorbPublishesWholesaleRender() {
+    func externalAbsorbPublishesBoundedIncrementalRender() async throws {
         let document = MarkdownDocument()
         let initial = "# One\n\nA calm paragraph.\n"
         let incoming = "# One\n\nA rewritten paragraph with a different shape.\n"
@@ -20,7 +20,57 @@ struct AsyncParseTests {
         )
 
         #expect(document.text == incoming)
-        #expect(observedDirty?.isWholesale == true)
+        for _ in 0..<100 where observedDirty == nil {
+            try await Task.sleep(for: .milliseconds(5))
+        }
+        #expect(observedDirty?.isWholesale == false)
+        #expect(observedDirty?.ranges.isEmpty == false)
+    }
+
+    @Test @MainActor
+    func externalAbsorbUndoRedoDoesNotConsumeNextLocalEdit() async throws {
+        let document = MarkdownDocument()
+        let original = "# One\n\nOriginal body.\n"
+        let incoming = "# One\n\nExternal body.\n"
+        document.adopt(text: original, displayURL: nil)
+
+        document.applyExternalText(
+            incoming,
+            hunks: TextDiff.hunks(old: original, new: incoming)
+        )
+        for _ in 0..<100 where document.parsed.text != incoming {
+            try await Task.sleep(for: .milliseconds(2))
+        }
+        #expect(document.parsed.text == incoming)
+
+        document.undoManager.undo()
+        #expect(document.text == original)
+        #expect(document.parsed.text == original)
+
+        document.undoManager.redo()
+        #expect(document.text == incoming)
+        #expect(document.parsed.text == incoming)
+
+        // Drain the delegate callbacks from absorb, undo, and redo. The next
+        // edit must still be treated as a user mutation after all of them.
+        for _ in 0..<20 { await Task.yield() }
+        var reparseCount = 0
+        document.onReparse = { parsed, _ in
+            if parsed.text == document.text { reparseCount += 1 }
+        }
+        #expect(document.replace(
+            NSRange(location: document.storage.length, length: 0),
+            with: "Local tail.\n",
+            actionName: "Paste"
+        ))
+        #expect(document.isDirty)
+        #expect(document.presentationState.phase == .edited)
+
+        for _ in 0..<100 where document.parsed.text != document.text {
+            try await Task.sleep(for: .milliseconds(2))
+        }
+        #expect(document.parsed.text == document.text)
+        #expect(reparseCount == 1)
     }
 
     @Test @MainActor

--- a/Tests/DownrightAppTests/CommandTableTests.swift
+++ b/Tests/DownrightAppTests/CommandTableTests.swift
@@ -89,6 +89,18 @@ struct CommandTableTests {
         #expect(MainMenu.command(for: item ?? NSMenuItem()) == .checkForUpdates)
     }
 
+    @Test func contentsOutlineKeepsOneCanonicalCommandAndPaletteNames() {
+        #expect(Command.documentLens.title == "Contents / Outline")
+        let model = CommandPaletteModel(commands: [.documentLens], bindings: { _ in [] })
+        #expect(model.results.map(\.command) == [.documentLens])
+        var outline = model
+        outline.updateQuery("outline")
+        #expect(outline.results.map(\.command) == [.documentLens])
+        var contents = model
+        contents.updateQuery("contents")
+        #expect(contents.results.map(\.command) == [.documentLens])
+    }
+
     /// The standard items the Edit and Window menus were missing.
     @Test func standardMenuItemsExistWithTheirMacOSChords() {
         _ = NSApplication.shared
@@ -102,7 +114,7 @@ struct CommandTableTests {
         walk(MainMenu.build())
 
         #expect(titles["Paste and Match Style"]?.0 == "v")
-        #expect(titles["Paste and Match Style"]?.1 == [.command, .shift])
+        #expect(titles["Paste and Match Style"]?.1 == [.command, .option, .shift])
         #expect(titles["Page Setup…"]?.0 == "p")
         #expect(titles["Page Setup…"]?.1 == [.command, .shift])
         #expect(titles["Enter Full Screen"]?.0 == "f")

--- a/Tests/DownrightAppTests/DocumentTrustStateTests.swift
+++ b/Tests/DownrightAppTests/DocumentTrustStateTests.swift
@@ -1,0 +1,357 @@
+import AppKit
+import Foundation
+import MarkdownCore
+import Testing
+@testable import DownrightApp
+
+@Suite("Document save trust and presentation state", .serialized)
+struct DocumentTrustStateTests {
+    @Test @MainActor
+    func missingFileSaveFailsClosedUntilExplicitRecreation() throws {
+        let fixture = try Fixture(text: "before\n")
+        defer { fixture.remove() }
+        let document = MarkdownDocument()
+        try document.open(fixture.url)
+        #expect(document.replace(
+            NSRange(location: 0, length: document.storage.length),
+            with: "after\n",
+            actionName: "Replace"
+        ))
+        try FileManager.default.removeItem(at: fixture.url)
+
+        let result = document.saveIfNeeded()
+        guard case .failure(SaveError.fileMissing) = result else {
+            Issue.record("a missing path must be an explicit save failure")
+            return
+        }
+        #expect(!FileManager.default.fileExists(atPath: fixture.url.path))
+        #expect(document.isDirty)
+        #expect(document.presentationState.phase == .saveFailed)
+
+        guard case .success = document.recreateMissingFile() else {
+            Issue.record("explicit recreation should write the retained buffer")
+            return
+        }
+        #expect(try String(contentsOf: fixture.url, encoding: .utf8) == "after\n")
+        #expect(!document.isDirty)
+        #expect(document.presentationState.phase == .saved)
+        document.close()
+    }
+
+    @Test @MainActor
+    func unreadablePathIsNotOverwritten() throws {
+        let fixture = try Fixture(text: "before\n")
+        defer { fixture.remove() }
+        let document = MarkdownDocument()
+        try document.open(fixture.url)
+        #expect(document.replace(
+            NSRange(location: 0, length: document.storage.length),
+            with: "after\n",
+            actionName: "Panel action"
+        ))
+        try FileManager.default.removeItem(at: fixture.url)
+        try FileManager.default.createDirectory(at: fixture.url, withIntermediateDirectories: false)
+
+        let result = document.saveIfNeeded()
+        guard case .failure(SaveError.fileUnreadable) = result else {
+            Issue.record("an unreadable existing path must fail closed")
+            return
+        }
+        var isDirectory: ObjCBool = false
+        #expect(FileManager.default.fileExists(atPath: fixture.url.path, isDirectory: &isDirectory))
+        #expect(isDirectory.boolValue)
+        #expect(document.isDirty)
+        document.close()
+    }
+
+    @Test @MainActor
+    func taskToggleImmediateSaveNeverRecreatesADeletedFile() throws {
+        let fixture = try Fixture(text: "- [ ] trust the save boundary\n")
+        defer { fixture.remove() }
+        let document = MarkdownDocument()
+        try document.open(fixture.url)
+        try FileManager.default.removeItem(at: fixture.url)
+
+        document.toggleTask(atMarkOffset: 2)
+
+        #expect(document.text == "- [x] trust the save boundary\n")
+        #expect(!FileManager.default.fileExists(atPath: fixture.url.path))
+        #expect(document.isDirty)
+        #expect(document.presentationState.phase == .saveFailed)
+        document.close()
+    }
+
+    @Test @MainActor
+    func conflictAndMutationProvenanceHaveDistinctStates() throws {
+        let fixture = try Fixture(text: "one\n")
+        defer { fixture.remove() }
+        let document = MarkdownDocument()
+        try document.open(fixture.url)
+        #expect(document.replace(
+            NSRange(location: 0, length: document.storage.length),
+            with: "mine\n",
+            actionName: "Paste"
+        ))
+        #expect(document.presentationState.phase == .edited)
+        #expect(document.presentationState.provenance == "Paste")
+
+        try Data("theirs\n".utf8).write(to: fixture.url, options: .atomic)
+        let result = document.saveIfNeeded()
+        guard case .failure(SaveError.blockedByExternalConflict) = result else {
+            Issue.record("a newer disk version must become a conflict")
+            return
+        }
+        #expect(document.presentationState.phase == .conflict)
+        #expect(try String(contentsOf: fixture.url, encoding: .utf8) == "theirs\n")
+        document.close()
+    }
+
+    @Test @MainActor
+    func explicitKeepMineResolvesAndWritesARealConflict() throws {
+        let fixture = try Fixture(text: "before\n")
+        defer { fixture.remove() }
+        let document = MarkdownDocument()
+        try document.open(fixture.url)
+        #expect(document.replace(
+            NSRange(location: 0, length: document.storage.length),
+            with: "mine\n", actionName: "Replace"
+        ))
+        try Data("theirs\n".utf8).write(to: fixture.url, options: .atomic)
+        guard case .failure(SaveError.blockedByExternalConflict) = document.saveIfNeeded() else {
+            Issue.record("the initial save must surface a conflict")
+            return
+        }
+
+        guard case .success = document.resolveConflictKeepingMine() else {
+            Issue.record("Keep Mine must be an explicit permitted overwrite")
+            return
+        }
+        #expect(try Data(contentsOf: fixture.url) == Data("mine\n".utf8))
+        #expect(!document.isDirty)
+        #expect(document.pendingConflict == nil)
+        document.close()
+    }
+
+    @Test @MainActor
+    func atomicReplacementAtCommitBoundaryIsRestoredAndBecomesConflict() throws {
+        let fixture = try Fixture(text: "before\n")
+        defer { fixture.remove() }
+        let document = MarkdownDocument()
+        try document.open(fixture.url)
+        #expect(document.replace(
+            NSRange(location: 0, length: document.storage.length),
+            with: "mine\n", actionName: "Paste"
+        ))
+        document.beforeSaveCommitForTesting = {
+            try! Data("external-at-boundary\n".utf8).write(to: fixture.url, options: .atomic)
+        }
+
+        guard case .failure(SaveError.blockedByExternalConflict) = document.saveIfNeeded() else {
+            Issue.record("a replacement at the exact commit boundary must fail closed")
+            return
+        }
+        #expect(try Data(contentsOf: fixture.url) == Data("external-at-boundary\n".utf8))
+        #expect(document.isDirty)
+        document.close()
+    }
+
+    @Test @MainActor
+    func deletionAtCommitBoundaryNeverRecreatesThePath() throws {
+        let fixture = try Fixture(text: "before\n")
+        defer { fixture.remove() }
+        let document = MarkdownDocument()
+        try document.open(fixture.url)
+        #expect(document.replace(
+            NSRange(location: 0, length: document.storage.length),
+            with: "mine\n", actionName: "Replace"
+        ))
+        document.beforeSaveCommitForTesting = { try! FileManager.default.removeItem(at: fixture.url) }
+
+        guard case .failure = document.saveIfNeeded() else {
+            Issue.record("a concurrent deletion must fail")
+            return
+        }
+        #expect(!FileManager.default.fileExists(atPath: fixture.url.path))
+        #expect(document.isDirty)
+        document.close()
+    }
+
+    @Test @MainActor
+    func recreateChoiceDoesNotClobberAFileThatReappeared() throws {
+        let fixture = try Fixture(text: "before\n")
+        defer { fixture.remove() }
+        let document = MarkdownDocument()
+        try document.open(fixture.url)
+        #expect(document.replace(
+            NSRange(location: 0, length: document.storage.length),
+            with: "mine\n", actionName: "Replace"
+        ))
+        try FileManager.default.removeItem(at: fixture.url)
+        guard case .failure(SaveError.fileMissing) = document.saveIfNeeded() else {
+            Issue.record("missing file recovery must be active")
+            return
+        }
+        try Data("restored-by-someone-else\n".utf8).write(to: fixture.url)
+
+        guard case .failure(SaveError.blockedByExternalConflict) = document.recreateMissingFile() else {
+            Issue.record("Recreate must reconcile a readable file that appeared after the alert")
+            return
+        }
+        #expect(try Data(contentsOf: fixture.url) == Data("restored-by-someone-else\n".utf8))
+        document.close()
+    }
+
+    @Test @MainActor
+    func discardedEditsCannotReturnOnTheNextKeystroke() throws {
+        let fixture = try Fixture(text: "saved\n")
+        defer { fixture.remove() }
+        let document = MarkdownDocument()
+        try document.open(fixture.url)
+        #expect(document.replace(
+            NSRange(location: 0, length: document.storage.length),
+            with: "discard-me\n", actionName: "Paste"
+        ))
+        document.discardUnsavedChanges()
+        #expect(document.text == "saved\n")
+        #expect(!document.isDirty)
+        #expect(document.replace(
+            NSRange(location: document.storage.length, length: 0),
+            with: "new\n", actionName: "Typing"
+        ))
+        try document.save()
+        #expect(try Data(contentsOf: fixture.url) == Data("saved\nnew\n".utf8))
+        document.close()
+    }
+
+    @Test @MainActor
+    func byteOnlyExternalRewriteUpdatesFidelityBeforeSaving() throws {
+        let fixture = try Fixture(text: "one\ntwo\n")
+        defer { fixture.remove() }
+        let document = MarkdownDocument()
+        try document.open(fixture.url)
+        let bomCRLF = Data([0xEF, 0xBB, 0xBF]) + Data("one\r\ntwo\r\n".utf8)
+        try bomCRLF.write(to: fixture.url, options: .atomic)
+        #expect(document.replace(
+            NSRange(location: 0, length: 3), with: "ONE", actionName: "Replace"
+        ))
+
+        guard case .success = document.saveIfNeeded() else {
+            Issue.record("a byte-only disk generation should reconcile without a content conflict")
+            return
+        }
+        #expect(try Data(contentsOf: fixture.url) == Data([0xEF, 0xBB, 0xBF]) + Data("ONE\r\ntwo\r\n".utf8))
+        document.close()
+    }
+
+    @Test @MainActor
+    func removingFinalNewlineIsARealUserEdit() throws {
+        let fixture = try Fixture(text: "body\n")
+        defer { fixture.remove() }
+        let document = MarkdownDocument()
+        try document.open(fixture.url)
+        #expect(document.replace(NSRange(location: 4, length: 1), with: "", actionName: "Delete"))
+        try document.save()
+        #expect(try Data(contentsOf: fixture.url) == Data("body".utf8))
+        document.close()
+    }
+
+    @Test @MainActor
+    func identicalRestoreClearsTheMissingFilePresentation() async throws {
+        let fixture = try Fixture(text: "same\n")
+        defer { fixture.remove() }
+        let document = MarkdownDocument()
+        try document.open(fixture.url)
+        document.handleWatchEvent(.removed)
+        #expect(document.presentationState.phase == .changedOnDisk)
+        #expect(document.presentationState.detail == "File missing")
+
+        document.handleWatchEvent(.restored)
+        document.flushPendingExternalWrite()
+        for _ in 0..<100 where document.presentationState.phase != .neutral {
+            try await Task.sleep(for: .milliseconds(5))
+        }
+        #expect(document.presentationState == .neutral)
+        document.close()
+    }
+
+    @Test @MainActor
+    func parsingAndOtherNonMutatingWorkNeverMarksDirty() throws {
+        let fixture = try Fixture(text: "# Heading\n\nBody.\n")
+        defer { fixture.remove() }
+        let document = MarkdownDocument()
+        try document.open(fixture.url)
+        document.ensureParsedCurrent()
+        document.markChangesReviewed()
+        _ = document.restoredOffset()
+        #expect(!document.isDirty)
+        #expect(document.presentationState == .neutral)
+        document.close()
+    }
+
+    @Test @MainActor
+    func cleanExternalRewriteParsesAsynchronouslyAndRestoresAfterCommit() async throws {
+        let document = MarkdownDocument()
+        let original = "# One\n\nBody.\n"
+        let incoming = "# One\n\n" + String(repeating: "A longer external paragraph.\n\n", count: 2_000)
+        document.adopt(text: original, displayURL: nil)
+        var incomingCommits = 0
+        document.onReparse = { parsed, _ in
+            if parsed.text == incoming { incomingCommits += 1 }
+        }
+
+        document.applyExternalText(
+            incoming,
+            hunks: TextDiff.hunks(old: original, new: incoming)
+        )
+        #expect(document.text == incoming)
+        #expect(document.parsed.text != incoming, "the main actor must not synchronously parse a wholesale rewrite")
+
+        for _ in 0..<200 where document.parsed.text != incoming {
+            try await Task.sleep(for: .milliseconds(5))
+        }
+        #expect(document.parsed.text == incoming)
+        #expect(incomingCommits == 1)
+        document.close()
+    }
+
+    @Test @MainActor
+    func localEditDuringExternalParseOwnsTheLatestRevision() async throws {
+        let document = MarkdownDocument()
+        let original = "# One\n\nBody.\n"
+        let incoming = "# External\n\nBody.\n"
+        document.adopt(text: original, displayURL: nil)
+        document.applyExternalText(
+            incoming,
+            hunks: TextDiff.hunks(old: original, new: incoming)
+        )
+        #expect(document.replace(
+            NSRange(location: document.storage.length, length: 0),
+            with: "Local tail.\n",
+            actionName: "Paste"
+        ))
+
+        for _ in 0..<200 where document.parsed.text != document.text {
+            try await Task.sleep(for: .milliseconds(5))
+        }
+        #expect(document.parsed.text == document.text)
+        #expect(document.text.hasSuffix("Local tail.\n"))
+        #expect(document.isDirty)
+        #expect(document.presentationState.provenance == "Paste")
+        document.close()
+    }
+}
+
+private struct Fixture {
+    let root: URL
+    let url: URL
+
+    init(text: String) throws {
+        root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("downright-document-trust-\(UUID().uuidString)", isDirectory: true)
+        url = root.appendingPathComponent("note.md")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        try Data(text.utf8).write(to: url)
+    }
+
+    func remove() { try? FileManager.default.removeItem(at: root) }
+}

--- a/Tests/DownrightAppTests/EditingKeyReproTests.swift
+++ b/Tests/DownrightAppTests/EditingKeyReproTests.swift
@@ -656,4 +656,29 @@ struct EditingKeyReproTests {
         let after = try #require(view.rect(forOffset: offset)).minY - clip.bounds.origin.y
         #expect(abs(after - before) < 2, "the picker moved its clicked heading")
     }
+
+    @Test("IME marked text owns a valid undo group")
+    func markedTextUsesValidUndoGrouping() throws {
+        let url = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("EditingKeyReproIME-\(UUID().uuidString).md")
+        defer { try? FileManager.default.removeItem(at: url) }
+        let controller = try makeController(text: "# 入力\n\nBody\n", file: url)
+        defer { controller.close() }
+        let view = controller.primaryContainer.textView
+        controller.window?.makeFirstResponder(view)
+        view.setSourceSelectedRanges([NSRange(location: 7, length: 0)])
+
+        // NSTextView raises an Objective-C exception when its private marked-
+        // text undo registration runs without a group. Reaching the assertions
+        // is therefore the regression proof for the crash boundary.
+        view.setMarkedText(
+            "かな",
+            selectedRange: NSRange(location: 2, length: 0),
+            replacementRange: view.sourceSelectedRange
+        )
+        #expect(view.hasMarkedText())
+        #expect(controller.markdownDocument.text.contains("かな"))
+        view.unmarkText()
+        #expect(!view.hasMarkedText())
+    }
 }

--- a/Tests/DownrightAppTests/FileWatcherTests.swift
+++ b/Tests/DownrightAppTests/FileWatcherTests.swift
@@ -1,0 +1,255 @@
+import Foundation
+import Testing
+@testable import DownrightApp
+
+@Suite("File watcher reconciliation", .serialized)
+struct FileWatcherTests {
+    @Test("an acknowledged atomic own write is silent")
+    func ownWriteIsSuppressed() async throws {
+        let fixture = try Fixture(contents: "before")
+        defer { fixture.remove() }
+        let events = EventCollector()
+        let watcher = FileWatcher(url: fixture.url) { events.append($0) }
+        defer { watcher.stop() }
+
+        let own = Data("own bytes".utf8)
+        watcher.suppressOwnWrite(for: 0.05)
+        try fixture.atomicReplace(own)
+        watcher.acknowledgeOwnWrite(contents: own)
+        try await settle()
+        watcher.checkNowForTesting()
+        try await settle()
+
+        #expect(events.count == 0)
+    }
+
+    @Test("an external replacement racing an own write is delivered once")
+    func externalReplacementInsideSuppressionIsNotSwallowed() async throws {
+        let fixture = try Fixture(contents: "before")
+        defer { fixture.remove() }
+        let events = EventCollector()
+        let watcher = FileWatcher(url: fixture.url) { events.append($0) }
+        defer { watcher.stop() }
+
+        let own = Data("own bytes".utf8)
+        let external = Data("external".utf8)
+        watcher.suppressOwnWrite(for: 0.05)
+        try fixture.atomicReplace(own)
+        try fixture.atomicReplace(external)
+        watcher.acknowledgeOwnWrite(contents: own)
+        try await settle()
+        watcher.checkNowForTesting()
+        try await expectEventCount(events, 1)
+        watcher.checkNowForTesting()
+        try await settle()
+
+        #expect(events.count == 1)
+        #expect(events.isChanged(at: 0))
+    }
+
+    @Test("an external replacement observed before the own acknowledgement survives it")
+    func externalReplacementBeforeAcknowledgeIsRetained() async throws {
+        let fixture = try Fixture(contents: "before")
+        defer { fixture.remove() }
+        let events = EventCollector()
+        let watcher = FileWatcher(url: fixture.url) { events.append($0) }
+        defer { watcher.stop() }
+
+        let own = Data("own bytes".utf8)
+        let external = Data("external".utf8)
+        watcher.suppressOwnWrite(for: 0.2)
+        try fixture.atomicReplace(external)
+        watcher.checkNowForTesting()
+        try fixture.atomicReplace(own)
+        watcher.acknowledgeOwnWrite(contents: own)
+        try await settle()
+        watcher.checkNowForTesting()
+        try await expectEventCount(events, 1)
+
+        #expect(events.count == 1)
+        #expect(events.isChanged(at: 0))
+    }
+
+    @Test("a settled burst reports once and repeated probes stay quiet")
+    func burstIsExactlyOnce() async throws {
+        let fixture = try Fixture(contents: "before")
+        defer { fixture.remove() }
+        let events = EventCollector()
+        let watcher = FileWatcher(url: fixture.url) { events.append($0) }
+        defer { watcher.stop() }
+
+        try fixture.atomicReplace(Data("first".utf8))
+        try fixture.atomicReplace(Data("second".utf8))
+        try fixture.atomicReplace(Data("settled".utf8))
+        watcher.checkNowForTesting()
+        try await expectEventCount(events, 1)
+        watcher.checkNowForTesting()
+        try await settle()
+
+        #expect(events.count == 1)
+        #expect(events.isChanged(at: 0))
+    }
+
+    @Test("same-size, same-metadata rewrites are detected by content")
+    func sameMetadataRewriteIsDetected() async throws {
+        let fixture = try Fixture(contents: "aaaa")
+        defer { fixture.remove() }
+        let originalDate = try FileManager.default
+            .attributesOfItem(atPath: fixture.url.path)[.modificationDate] as! Date
+        let events = EventCollector()
+        let watcher = FileWatcher(url: fixture.url) { events.append($0) }
+        defer { watcher.stop() }
+
+        let handle = try FileHandle(forWritingTo: fixture.url)
+        try handle.seek(toOffset: 0)
+        try handle.write(contentsOf: Data("bbbb".utf8))
+        try handle.truncate(atOffset: 4)
+        try handle.close()
+        try FileManager.default.setAttributes(
+            [.modificationDate: originalDate],
+            ofItemAtPath: fixture.url.path
+        )
+        watcher.checkNowForTesting()
+        try await expectEventCount(events, 1)
+
+        #expect(events.count == 1)
+        #expect(events.isChanged(at: 0))
+    }
+
+    @Test("same-metadata rewrites are bounded when the poll path is used")
+    func sameMetadataRewriteIsDetectedByBoundedPolling() async throws {
+        let fixture = try Fixture(contents: "aaaa")
+        defer { fixture.remove() }
+        let originalDate = try FileManager.default
+            .attributesOfItem(atPath: fixture.url.path)[.modificationDate] as! Date
+        let events = EventCollector()
+        let watcher = FileWatcher(url: fixture.url) { events.append($0) }
+        defer { watcher.stop() }
+
+        // Leave the initial metadata baseline untouched, then rewrite in
+        // place while preserving size and mtime. The production poll path
+        // hashes at a bounded cadence rather than every ordinary poll.
+        watcher.pollNowForTesting()
+        let handle = try FileHandle(forWritingTo: fixture.url)
+        try handle.seek(toOffset: 0)
+        try handle.write(contentsOf: Data("bbbb".utf8))
+        try handle.truncate(atOffset: 4)
+        try handle.close()
+        try FileManager.default.setAttributes(
+            [.modificationDate: originalDate],
+            ofItemAtPath: fixture.url.path
+        )
+
+        for _ in 0..<3 {
+            watcher.pollNowForTesting()
+        }
+        watcher.pollNowForTesting()
+        try await expectEventCount(events, 1)
+        #expect(events.isChanged(at: 0))
+    }
+
+    @Test("rename, removal, and restoration retain their event semantics")
+    func renameRemoveRestore() async throws {
+        let fixture = try Fixture(contents: "document")
+        defer { fixture.remove() }
+        let events = EventCollector()
+        let watcher = FileWatcher(url: fixture.url) { events.append($0) }
+        defer { watcher.stop() }
+
+        let renamedURL = fixture.directory.appendingPathComponent("renamed.md")
+        try FileManager.default.moveItem(at: fixture.url, to: renamedURL)
+        watcher.checkNowForTesting()
+        try await expectEventCount(events, 1)
+        #expect(events.isRename(to: renamedURL, at: 0))
+
+        try FileManager.default.removeItem(at: renamedURL)
+        watcher.checkNowForTesting()
+        try await expectEventCount(events, 2)
+        #expect(events.isRemoved(at: 1))
+
+        try Data("restored".utf8).write(to: renamedURL)
+        watcher.checkNowForTesting()
+        try await expectEventCount(events, 3)
+        #expect(events.isRestored(at: 2))
+    }
+
+    private func settle() async throws {
+        try await Task.sleep(nanoseconds: 350_000_000)
+    }
+
+    private func expectEventCount(_ events: EventCollector, _ count: Int) async throws {
+        for _ in 0..<100 {
+            if events.count >= count { return }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        Issue.record("Timed out waiting for (count) file-watcher event(s); got (events.count)")
+    }
+}
+
+private final class EventCollector: @unchecked Sendable {
+    private let lock = NSLock()
+    private var values: [FileWatcher.Event] = []
+
+    var count: Int {
+        lock.lock(); defer { lock.unlock() }
+        return values.count
+    }
+
+    func append(_ event: FileWatcher.Event) {
+        lock.lock(); defer { lock.unlock() }
+        values.append(event)
+    }
+
+    func isChanged(at index: Int) -> Bool {
+        lock.lock(); defer { lock.unlock() }
+        guard values.indices.contains(index) else { return false }
+        if case .changed = values[index] { return true }
+        return false
+    }
+
+    func isRemoved(at index: Int) -> Bool {
+        lock.lock(); defer { lock.unlock() }
+        guard values.indices.contains(index) else { return false }
+        if case .removed = values[index] { return true }
+        return false
+    }
+
+    func isRestored(at index: Int) -> Bool {
+        lock.lock(); defer { lock.unlock() }
+        guard values.indices.contains(index) else { return false }
+        if case .restored = values[index] { return true }
+        return false
+    }
+
+    func isRename(to url: URL, at index: Int) -> Bool {
+        lock.lock(); defer { lock.unlock() }
+        guard values.indices.contains(index) else { return false }
+        if case let .renamed(target) = values[index] {
+            return target.standardizedFileURL == url.standardizedFileURL
+        }
+        return false
+    }
+}
+
+private final class Fixture {
+    let directory: URL
+    let url: URL
+
+    init(contents: String) throws {
+        directory = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("downright-filewatcher-(UUID().uuidString)")
+        url = directory.appendingPathComponent("document.md")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        try Data(contents.utf8).write(to: url)
+    }
+
+    func atomicReplace(_ data: Data) throws {
+        let temporary = directory.appendingPathComponent(".tmp-(UUID().uuidString)")
+        try data.write(to: temporary)
+        _ = try FileManager.default.replaceItemAt(url, withItemAt: temporary)
+    }
+
+    func remove() {
+        try? FileManager.default.removeItem(at: directory)
+    }
+}

--- a/Tests/DownrightAppTests/RealWindowPerformanceTests.swift
+++ b/Tests/DownrightAppTests/RealWindowPerformanceTests.swift
@@ -1,0 +1,436 @@
+import AppKit
+import Foundation
+import MarkdownRender
+import Testing
+@testable import DownrightApp
+
+/// Acceptance coverage for the path a reader actually uses: an activated
+/// `NSWindow`, a TextKit 2 document view, and a running display cycle.
+///
+/// The test target also runs on headless CI. In that environment AppKit cannot
+/// deliver a real display frame, so the tests print a diagnostic and leave the
+/// frame-specific assertions to the next window-capable run. The layout and
+/// parser suites remain the non-window fallback for that machine.
+@Suite("Real window performance", .serialized)
+@MainActor
+struct RealWindowPerformanceTests {
+    private struct WindowFixture {
+        let controller: DocumentWindowController
+        let url: URL
+
+        @MainActor
+        func close() {
+            controller.close()
+            try? FileManager.default.removeItem(at: url)
+        }
+    }
+
+    private struct FrameBudget {
+        let refreshRate: Int
+        let frameMilliseconds: Double
+
+        var description: String {
+            "\(refreshRate) Hz / frame \(String(format: "%.2f", frameMilliseconds)) ms / hitch \(String(format: "%.2f", hitchMilliseconds)) ms"
+        }
+
+        /// A real AppKit display cycle can span several compositor turns while
+        /// TextKit materializes a large document. Five frames is a bounded,
+        /// enforceable hitch budget while retaining the 60/120 Hz distinction.
+        var hitchMilliseconds: Double {
+            frameMilliseconds * 5
+        }
+
+        /// The prepared external snapshot commits source plus a rebuilt
+        /// source/display coordinate map. It is off the immediate input frame,
+        /// but still bounded so asynchronous work cannot become an unmeasured
+        /// multi-second main-actor stall on large documents.
+        var externalCommitMilliseconds: Double { 150 }
+    }
+
+    private enum WindowUnavailable: Error {
+        case noDisplay
+        case noWindowScreen
+    }
+
+    private func displayBudget(for window: NSWindow) throws -> FrameBudget {
+        guard NSScreen.main != nil else { throw WindowUnavailable.noDisplay }
+        guard let screen = window.screen ?? NSScreen.main else {
+            throw WindowUnavailable.noWindowScreen
+        }
+
+        // Express the hitch ceiling in display frames, not an arbitrary wall
+        // clock number. A ProMotion screen therefore gets the 120 Hz budget;
+        // ordinary displays use the 60 Hz budget. Unknown display rates use
+        // the conservative 60 Hz gate.
+        let refreshRate = max(1, screen.maximumFramesPerSecond)
+        let frameMilliseconds = refreshRate >= 100 ? 1_000 / 120.0 : 1_000 / 60.0
+        return FrameBudget(refreshRate: refreshRate, frameMilliseconds: frameMilliseconds)
+    }
+
+    private func realWindowOrPrintSkip(requiresFiftyThousandLines: Bool = false) -> Bool {
+        guard ProcessInfo.processInfo.environment["RUN_REAL_WINDOW_PERF"] == "1" else {
+            print("REAL_WINDOW_PERF SKIP: set RUN_REAL_WINDOW_PERF=1 for rendered-window acceptance")
+            return false
+        }
+        if requiresFiftyThousandLines,
+           ProcessInfo.processInfo.environment["RUN_REAL_WINDOW_50K"] != "1" {
+            print("REAL_WINDOW_PERF SKIP: set RUN_REAL_WINDOW_50K=1 for the exhaustive 50k-line case")
+            return false
+        }
+        guard NSScreen.main != nil else {
+            print("REAL_WINDOW_PERF SKIP: no NSScreen.main; display-cycle acceptance requires a window server")
+            return false
+        }
+        return true
+    }
+
+    private func makeFixture(lines: Int) throws -> WindowFixture {
+        let text = fixtureText(lines: lines)
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent(
+                "downright-real-window-\(lines)-\(UUID().uuidString).md"
+            )
+        try Data(text.utf8).write(to: url)
+
+        let controller = DocumentWindowController()
+        do {
+            try controller.open(url, mode: .live)
+            guard let window = controller.window else {
+                throw WindowUnavailable.noWindowScreen
+            }
+            window.setFrame(
+                NSRect(x: 80, y: 80, width: 1_020, height: 780),
+                display: false
+            )
+            window.makeKeyAndOrderFront(nil)
+            NSApp.activate(ignoringOtherApps: true)
+            pumpMainRunLoop(for: 0.20)
+            _ = try displayBudget(for: window)
+            return WindowFixture(controller: controller, url: url)
+        } catch {
+            controller.close()
+            try? FileManager.default.removeItem(at: url)
+            throw error
+        }
+    }
+
+    private func pumpMainRunLoop(for duration: TimeInterval) {
+        let deadline = Date().addingTimeInterval(duration)
+        while Date() < deadline {
+            RunLoop.main.run(mode: .common, before: min(
+                deadline, Date().addingTimeInterval(0.005)
+            ))
+        }
+    }
+
+    private func pumpMainRunLoop(
+        until condition: () -> Bool,
+        timeout: TimeInterval = 15
+    ) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while !condition() && Date() < deadline {
+            RunLoop.main.run(mode: .common, before: min(
+                deadline, Date().addingTimeInterval(0.005)
+            ))
+        }
+        return condition()
+    }
+
+    private func awaitCondition(
+        timeout: TimeInterval = 15,
+        _ condition: @escaping @MainActor () -> Bool
+    ) async -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while !condition(), Date() < deadline {
+            try? await Task.sleep(for: .milliseconds(5))
+        }
+        return condition()
+    }
+
+    private func forceFrame(_ window: NSWindow, _ textView: MarkdownTextView) {
+        window.layoutIfNeeded()
+        window.contentView?.layoutSubtreeIfNeeded()
+        textView.layoutSubtreeIfNeeded()
+        textView.prepareForDisplay()
+        textView.displayIfNeeded()
+        window.displayIfNeeded()
+    }
+
+    private func elapsedMilliseconds(_ body: () -> Void) -> Double {
+        let start = DispatchTime.now().uptimeNanoseconds
+        body()
+        return Double(DispatchTime.now().uptimeNanoseconds - start) / 1_000_000
+    }
+
+    private func p95(_ samples: [Double]) -> Double {
+        guard !samples.isEmpty else { return .infinity }
+        let sorted = samples.sorted()
+        let index = min(sorted.count - 1, Int((Double(sorted.count - 1) * 0.95).rounded(.down)))
+        return sorted[index]
+    }
+
+    private func assertFrameBudget(
+        _ samples: [Double],
+        label: String,
+        budget: FrameBudget
+    ) {
+        let result = p95(samples)
+        let maximum = samples.max() ?? .infinity
+        print(
+            "REAL_WINDOW_PERF \(label) p50="
+                + String(format: "%.3f", samples.sorted()[samples.count / 2])
+                + " ms p95=" + String(format: "%.3f", result)
+                + " ms max=" + String(format: "%.3f", maximum)
+                + " ms target=" + budget.description
+        )
+        #expect(
+            result <= budget.hitchMilliseconds,
+            "\(label) p95 \(String(format: "%.2f", result)) ms exceeded \(budget.description)"
+        )
+    }
+
+    /// One corpus exercises the same blocks that make large agent-written
+    /// README files expensive: images, display math, tables, Mermaid, tasks,
+    /// links, and fenced code interleaved with ordinary paragraphs.
+    private func fixtureText(lines target: Int) -> String {
+        var lines: [String] = []
+        lines.reserveCapacity(target)
+        var section = 0
+        while lines.count < target {
+            section += 1
+            lines.append("## Section \(section)")
+            lines.append("")
+            lines.append("A paragraph with **bold**, *emphasis*, a [link](https://example.com), and inline math $x^2 + y^2$.")
+            lines.append("- [ ] pending task \(section)")
+            lines.append("- [x] completed task \(section)")
+            lines.append("- a nested-looking ordinary item")
+
+            if section % 17 == 0 {
+                lines.append("")
+                lines.append("![local diagram](asset-\(section).png)")
+                lines.append("")
+                lines.append("$$")
+                lines.append("x^2 / 3")
+                lines.append("$$")
+            }
+            if section % 29 == 0 {
+                lines.append("")
+                lines.append("| column | value |")
+                lines.append("| --- | ---: |")
+                lines.append("| alpha | \(section) |")
+                lines.append("| beta | \(section * 2) |")
+            }
+            if section % 43 == 0 {
+                lines.append("")
+                lines.append("```mermaid")
+                lines.append("graph TD")
+                lines.append("  A\(section) --> B\(section)")
+                lines.append("```")
+            }
+            if section % 53 == 0 {
+                lines.append("")
+                lines.append("```swift")
+                lines.append("let value\(section) = \(section)")
+                lines.append("```")
+            }
+        }
+        return lines.prefix(target).joined(separator: "\n") + "\n"
+    }
+
+    @Test("10k-line typing and scrolling stay within a bounded five-frame hitch")
+    func tenThousandLineTypingAndScrolling() throws {
+        guard realWindowOrPrintSkip() else { return }
+        let fixture = try makeFixture(lines: 10_000)
+        defer { fixture.close() }
+        let window = try #require(fixture.controller.window)
+        let budget = try displayBudget(for: window)
+        let textView = fixture.controller.primaryContainer.textView
+        window.makeFirstResponder(textView)
+
+        // Warm up TextKit's viewport and the local-edit path before measuring.
+        textView.setSourceSelectedRanges([NSRange(
+            location: fixture.controller.markdownDocument.storage.length / 2,
+            length: 0
+        )])
+        forceFrame(window, textView)
+
+        var typing: [Double] = []
+        for _ in 0..<12 {
+            let range = textView.sourceSelectedRange
+            typing.append(elapsedMilliseconds {
+                textView.insertText("x", replacementRange: range)
+                forceFrame(window, textView)
+            })
+        }
+        assertFrameBudget(typing, label: "10k typing→frame", budget: budget)
+
+        var scrolling: [Double] = []
+        let length = fixture.controller.markdownDocument.storage.length
+        for fraction in stride(from: 0.08, through: 0.92, by: 0.08) {
+            let offset = Int(Double(length) * fraction)
+            scrolling.append(elapsedMilliseconds {
+                textView.scroll(toOffset: offset, position: .top, animated: false)
+                forceFrame(window, textView)
+            })
+        }
+        assertFrameBudget(scrolling, label: "10k scrolling→frame", budget: budget)
+        #expect(textView.topVisibleOffset > 0)
+    }
+
+    @Test("50k-line typing, scrolling, and split panes remain measurable")
+    func fiftyThousandLineTypingScrollingAndSplitView() throws {
+        guard realWindowOrPrintSkip(requiresFiftyThousandLines: true) else { return }
+        let fixture = try makeFixture(lines: 50_000)
+        defer { fixture.close() }
+        let window = try #require(fixture.controller.window)
+        let budget = try displayBudget(for: window)
+        let textView = fixture.controller.primaryContainer.textView
+        window.makeFirstResponder(textView)
+        textView.setSourceSelectedRanges([NSRange(
+            location: fixture.controller.markdownDocument.storage.length / 2,
+            length: 0
+        )])
+        forceFrame(window, textView)
+
+        var typing: [Double] = []
+        for _ in 0..<8 {
+            let range = textView.sourceSelectedRange
+            typing.append(elapsedMilliseconds {
+                textView.insertText("y", replacementRange: range)
+                forceFrame(window, textView)
+            })
+        }
+        assertFrameBudget(typing, label: "50k typing→frame", budget: budget)
+
+        var scrolling: [Double] = []
+        let length = fixture.controller.markdownDocument.storage.length
+        for fraction in stride(from: 0.10, through: 0.90, by: 0.10) {
+            let offset = Int(Double(length) * fraction)
+            scrolling.append(elapsedMilliseconds {
+                textView.scroll(toOffset: offset, position: .top, animated: false)
+                forceFrame(window, textView)
+            })
+        }
+        assertFrameBudget(scrolling, label: "50k scrolling→frame", budget: budget)
+
+        fixture.controller.toggleSplitView()
+        guard let split = fixture.controller.splitContainer else {
+            Issue.record("split view did not create its second real pane")
+            return
+        }
+        window.contentView?.layoutSubtreeIfNeeded()
+        #expect(split.frame.width > 0)
+        #expect(fixture.controller.primaryContainer.frame.width > 0)
+        #expect(split.textView.textStorage === textView.textStorage)
+        let splitScroll = elapsedMilliseconds {
+            split.textView.scroll(toOffset: length / 3, position: .top, animated: false)
+            forceFrame(window, split.textView)
+        }
+        print("REAL_WINDOW_PERF 50k split scroll→frame \(String(format: "%.3f", splitScroll)) ms target=\(budget.description)")
+        #expect(splitScroll <= budget.hitchMilliseconds)
+    }
+
+    @Test("IME marked text and rich constructs use the same frame path")
+    func imeCompositionAndRichBlocks() throws {
+        guard realWindowOrPrintSkip() else { return }
+        let fixture = try makeFixture(lines: 10_000)
+        defer { fixture.close() }
+        let window = try #require(fixture.controller.window)
+        let budget = try displayBudget(for: window)
+        let textView = fixture.controller.primaryContainer.textView
+        window.makeFirstResponder(textView)
+        textView.setSourceSelectedRanges([NSRange(
+            location: fixture.controller.markdownDocument.storage.length / 3,
+            length: 0
+        )])
+        forceFrame(window, textView)
+
+        let range = textView.sourceSelectedRange
+        let marked = elapsedMilliseconds {
+            textView.setMarkedText(
+                "かな",
+                selectedRange: NSRange(location: 2, length: 0),
+                replacementRange: range
+            )
+            forceFrame(window, textView)
+        }
+        textView.unmarkText()
+        forceFrame(window, textView)
+        print("REAL_WINDOW_PERF IME marked-text→frame \(String(format: "%.3f", marked)) ms target=\(budget.description)")
+        #expect(marked <= budget.hitchMilliseconds)
+        #expect(fixture.controller.markdownDocument.text.contains("かな"))
+    }
+
+    @Test("external atomic rewrite delivers bounded scroll frames through convergence")
+    func externalRewriteWhileScrolling() async throws {
+        guard realWindowOrPrintSkip() else { return }
+        let fixture = try makeFixture(lines: 10_000)
+        defer { fixture.close() }
+        let window = try #require(fixture.controller.window)
+        let budget = try displayBudget(for: window)
+        let textView = fixture.controller.primaryContainer.textView
+        let length = fixture.controller.markdownDocument.storage.length
+        let initialConverged = await awaitCondition(timeout: 30) {
+            fixture.controller.markdownDocument.lastAsyncParseRevision
+                == fixture.controller.markdownDocument.revision
+        }
+        #expect(initialConverged, "initial 10k parse did not converge before external-rewrite measurement")
+        textView.scroll(toOffset: length / 2, position: .top, animated: false)
+        forceFrame(window, textView)
+        let before = textView.topVisibleOffset
+        #expect(before > 0)
+
+        // Write before entering the measured path. This keeps filesystem I/O
+        // out of the UI number while still exercising the exact atomic replace
+        // and document reconciliation used by the file watcher.
+        let incoming = "# External heading\n\n" + fixture.controller.markdownDocument.text
+        var commitMilliseconds: Double?
+        let existingReparse = fixture.controller.markdownDocument.onReparse
+        fixture.controller.markdownDocument.onReparse = { parsed, dirty in
+            let started = DispatchTime.now().uptimeNanoseconds
+            existingReparse?(parsed, dirty)
+            if parsed.text == incoming {
+                commitMilliseconds = Double(
+                    DispatchTime.now().uptimeNanoseconds - started
+                ) / 1_000_000
+            }
+        }
+        try Data(incoming.utf8).write(to: fixture.url, options: .atomic)
+        let rewrite = elapsedMilliseconds {
+            fixture.controller.markdownDocument.handleExternalWrite()
+            fixture.controller.markdownDocument.flushPendingExternalWrite()
+            forceFrame(window, textView)
+        }
+        print("REAL_WINDOW_PERF external rewrite→frame \(String(format: "%.3f", rewrite)) ms target=\(budget.description)")
+        #expect(rewrite <= budget.hitchMilliseconds)
+
+        var scrollFrames: [Double] = []
+        var sample = 0
+        let deadline = ContinuousClock.now + .seconds(15)
+        while fixture.controller.markdownDocument.parsed.text != incoming,
+              ContinuousClock.now < deadline {
+            let offset = min(
+                fixture.controller.markdownDocument.storage.length - 1,
+                length / 2 + (sample % 80) * 47
+            )
+            scrollFrames.append(elapsedMilliseconds {
+                textView.scroll(toOffset: offset, position: .top, animated: false)
+                forceFrame(window, textView)
+            })
+            sample += 1
+            try await Task.sleep(for: .milliseconds(2))
+        }
+        let converged = fixture.controller.markdownDocument.parsed.text == incoming
+        #expect(converged, "external rewrite did not converge in the 15-second acceptance window")
+        #expect(!scrollFrames.isEmpty, "no scroll frames were sampled during external convergence")
+        assertFrameBudget(scrollFrames, label: "external-convergence scrolling→frame", budget: budget)
+        let commit = try #require(commitMilliseconds)
+        print("REAL_WINDOW_PERF external commit→decorated frame \(String(format: "%.3f", commit)) ms target=\(budget.description)")
+        #expect(
+            commit <= budget.externalCommitMilliseconds,
+            "external decorated commit exceeded the 150 ms bounded-main-actor ceiling"
+        )
+        #expect(textView.topVisibleOffset > 0)
+        #expect(textView.topVisibleOffset < fixture.controller.markdownDocument.storage.length)
+    }
+}

--- a/Tests/DownrightAppTests/ReviewBaselineTests.swift
+++ b/Tests/DownrightAppTests/ReviewBaselineTests.swift
@@ -17,6 +17,19 @@ import MarkdownCore
 @Suite(.serialized)
 struct ReviewBaselineTests {
 
+    @MainActor
+    private func waitForExternalText(
+        _ text: String,
+        in document: MarkdownDocument,
+        timeout: TimeInterval = 2
+    ) async -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while document.text != text, Date() < deadline {
+            try? await Task.sleep(for: .milliseconds(5))
+        }
+        return document.text == text
+    }
+
     // MARK: - Fixtures
 
     private static func makeSandbox() throws -> URL {
@@ -54,7 +67,7 @@ struct ReviewBaselineTests {
     // MARK: - 1. A burst diffs against the baseline, not the previous write
 
     @Test @MainActor
-    func burstOfWritesReportsChangesAgainstTheOriginalBaseline() throws {
+    func burstOfWritesReportsChangesAgainstTheOriginalBaseline() async throws {
         let root = try Self.makeSandbox()
         defer { try? FileManager.default.removeItem(at: root) }
         let url = root.appendingPathComponent("report.md")
@@ -70,6 +83,7 @@ struct ReviewBaselineTests {
             try Data(write.utf8).write(to: url)
             document.handleExternalWrite()
             document.flushPendingExternalWrite()
+            #expect(await waitForExternalText(write, in: document))
         }
 
         #expect(document.text == Self.writes[2])
@@ -94,7 +108,7 @@ struct ReviewBaselineTests {
     /// one buffer replace, one reparse, one scroll restore — while still
     /// reporting every change the burst made.
     @Test @MainActor
-    func aDebouncedBurstAbsorbsOnceAndStillReportsEveryChange() throws {
+    func aDebouncedBurstAbsorbsOnceAndStillReportsEveryChange() async throws {
         let root = try Self.makeSandbox()
         defer { try? FileManager.default.removeItem(at: root) }
         let url = root.appendingPathComponent("report.md")
@@ -114,6 +128,7 @@ struct ReviewBaselineTests {
             document.handleExternalWrite()
         }
         document.flushPendingExternalWrite()
+        #expect(await waitForExternalText(Self.writes[2], in: document))
 
         #expect(appliedEvents == 1, "a burst must rebuild the document once, not once per write")
         #expect(document.text == Self.writes[2])
@@ -134,6 +149,7 @@ struct ReviewBaselineTests {
         try Data(Self.writes[2].utf8).write(to: url)
         first.handleExternalWrite()
         first.flushPendingExternalWrite()
+        #expect(await waitForExternalText(Self.writes[2], in: first))
 
         let markCount = first.changes.count
         #expect(markCount == 3)
@@ -405,7 +421,7 @@ struct ReviewBaselineTests {
     // MARK: - Undoing an external change is surfaced, not silent
 
     @Test @MainActor
-    func undoingAnExternalChangeSurfacesAConflict() throws {
+    func undoingAnExternalChangeSurfacesAConflict() async throws {
         let root = try Self.makeSandbox()
         defer { try? FileManager.default.removeItem(at: root) }
         let url = root.appendingPathComponent("report.md")
@@ -423,6 +439,7 @@ struct ReviewBaselineTests {
         try Data(Self.writes[2].utf8).write(to: url)
         document.handleExternalWrite()
         document.flushPendingExternalWrite()
+        #expect(await waitForExternalText(Self.writes[2], in: document))
         #expect(document.text == Self.writes[2])
         #expect(document.isDirty == false)
 

--- a/Tests/DownrightAppTests/WelcomeTourTests.swift
+++ b/Tests/DownrightAppTests/WelcomeTourTests.swift
@@ -1,0 +1,60 @@
+import Foundation
+import Testing
+@testable import DownrightApp
+
+@Suite(.serialized)
+struct WelcomeTourTests {
+    private var sourceURL: URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("Resources/Welcome.md")
+    }
+
+    @Test
+    func everyTourShortcutTokenNamesACommandInTheCommandTable() throws {
+        let source = try String(contentsOf: sourceURL, encoding: .utf8)
+        let tokens = WelcomeTour.tokens(in: source)
+        #expect(!tokens.isEmpty)
+        for token in tokens {
+            let parts = token.split(separator: ":", maxSplits: 1).map(String.init)
+            #expect(parts.count == 2, "malformed tour token: \(token)")
+            guard parts.count == 2 else { continue }
+            let command = try #require(Command(rawValue: parts[1]))
+            if parts[0] == "shortcut" {
+                // A user may intentionally clear this binding; that must not
+                // make the tour fail to materialize.
+                _ = KeybindingDefaults.table[command]
+            } else {
+                #expect(parts[0] == "command", "unknown tour token kind: \(token)")
+            }
+        }
+        let rendered = try WelcomeTour.render(source, binding: { KeybindingDefaults.table[$0]?.first })
+        #expect(!rendered.contains("{{"))
+        let unbound = try WelcomeTour.render(source, binding: { _ in nil })
+        #expect(unbound.contains("Unassigned"))
+    }
+
+    @Test
+    func renderedTourUsesCustomizedBindings() throws {
+        let rendered = try WelcomeTour.render(
+            "Use {{shortcut:documentLens}} to open {{command:documentLens}}.",
+            binding: { command in
+                command == .documentLens ? KeyBinding("o", [.command, .shift]) : nil
+            }
+        )
+        #expect(rendered == "Use ⇧⌘O to open Contents / Outline.")
+    }
+
+    @Test
+    func invalidTourTokensFailClosed() throws {
+        #expect(throws: WelcomeTour.Error.unknownCommand("missing")) {
+            try WelcomeTour.render("{{shortcut:missing}}", binding: { _ in nil })
+        }
+        #expect(try WelcomeTour.render("{{shortcut:documentLens}}", binding: { _ in nil }) == "Unassigned")
+        #expect(throws: WelcomeTour.Error.malformedToken("{{shortcut:documentLens")) {
+            try WelcomeTour.render("{{shortcut:documentLens", binding: { _ in nil })
+        }
+    }
+}

--- a/Tests/DownrightAppTests/WindowChromeTests.swift
+++ b/Tests/DownrightAppTests/WindowChromeTests.swift
@@ -38,6 +38,47 @@ struct WindowChromeTests {
     }
 
     @Test
+    func documentIdentityNamesEveryNonNeutralStateAccessibly() throws {
+        let controller = DocumentWindowController()
+        defer { controller.close() }
+        let identity = try #require(controller.toolbarDocumentIdentityView)
+        let cases: [(MarkdownDocument.PresentationState.Phase, String)] = [
+            (.edited, "Edited"),
+            (.saving, "Saving"),
+            (.saved, "Saved"),
+            (.changedOnDisk, "Changed on disk"),
+            (.conflict, "Conflict"),
+            (.saveFailed, "Save failed"),
+        ]
+        for (phase, label) in cases {
+            identity.documentState = .init(
+                phase: phase, provenance: "Paste", detail: "Example"
+            )
+            #expect(identity.accessibilityLabel()?.contains(label) == true)
+            #expect(identity.accessibilityLabel()?.contains("Paste") == true)
+            #expect(identity.toolTip?.contains(label) == true)
+        }
+        identity.documentState = .neutral
+        #expect(identity.accessibilityLabel()?.contains("Edited") == false)
+        #expect(identity.toolTip == nil)
+    }
+
+    @Test
+    func missingFileRecoveryOffersOnlyExplicitNativeChoices() throws {
+        let controller = DocumentWindowController()
+        controller.presentSaveError(SaveError.fileMissing(URL(fileURLWithPath: "/tmp/missing.md")))
+        let alert = try #require(controller.saveRecoveryAlert)
+        #expect(alert.buttons.map(\.title) == [
+            "Save a Copy…", "Recreate File", "Discard Changes", "Cancel",
+        ])
+        #expect(alert.buttons.allSatisfy { $0.toolTip?.isEmpty == false })
+        if let window = controller.window, window.attachedSheet != nil {
+            window.endSheet(alert.window, returnCode: .cancel)
+        }
+        controller.close()
+    }
+
+    @Test
     func toolbarScrubPolicyClampsMovementAndCrossesAtTheMidpoint() {
         #expect(
             ToolbarChromePolicy.scrubState(pointerX: -20, leftCenterX: 44, rightCenterX: 132)
@@ -234,7 +275,9 @@ struct WindowChromeTests {
         // put every panel in the app behind one unlabelled glyph and a menu —
         // in a window with room for more buttons.
         let find = try #require(
-            cluster.arrangedSubviews.first { $0 is ToolbarActionButton } as? ToolbarActionButton,
+            cluster.arrangedSubviews.first {
+                ($0 as? ToolbarActionButton)?.accessibilityLabel() == "Find"
+            } as? ToolbarActionButton,
             "find is not in the trailing cluster"
         )
         #expect(find.intrinsicContentSize.width == 34)
@@ -244,6 +287,14 @@ struct WindowChromeTests {
         #expect(find.feedbackInsetY == 0)
         #expect(find.feedbackCornerRadius == 17)
         #expect(!find.isOn, "find should rest unlit with its panel closed")
+        let contents = try #require(
+            cluster.arrangedSubviews.first {
+                ($0 as? ToolbarActionButton)?.accessibilityLabel() == Command.documentLens.title
+            } as? ToolbarActionButton,
+            "contents is not in the trailing cluster"
+        )
+        #expect(contents.toolTip == "Show or hide the document Contents and Outline")
+        #expect(contents.accessibilityHelp() == "Show or hide the document Contents and Outline")
         #expect(cluster.arrangedSubviews.contains { $0 is ActivityIndicatorView })
         #expect(cluster.arrangedSubviews.contains { $0 is TaskProgressRing })
         let updatePill = try #require(
@@ -257,12 +308,13 @@ struct WindowChromeTests {
             cluster.arrangedSubviews.first { $0 is ToolbarMenuButton } as? ToolbarMenuButton,
             "the overflow menu is not in the trailing cluster"
         )
+        #expect(overflow.popupMenuItems.contains { MainMenu.command(for: $0) == .documentLens })
         #expect(overflow.intrinsicContentSize.width == 34)
         #expect(overflow.intrinsicContentSize.height == 34)
         #expect(overflow.popupMenuItems.contains { $0.title == "Document Detail" })
         #expect(overflow.popupMenuItems.contains { $0.title == "Source Focus" || $0.title == "Exit Source Focus" })
         // The cluster leads with the spinner and ends at the menu: activity,
-        // find, ring, pill, overflow — each hidden view costs nothing.
+        // contents, find, ring, pill, overflow — each hidden view costs nothing.
         #expect(cluster.arrangedSubviews.first is ActivityIndicatorView)
         #expect(cluster.arrangedSubviews.last is ToolbarMenuButton)
     }

--- a/Tests/DownrightQLTests/QuickLookPolicyTests.swift
+++ b/Tests/DownrightQLTests/QuickLookPolicyTests.swift
@@ -1,4 +1,5 @@
 import Testing
+import Foundation
 import MarkdownRender
 @testable import DownrightQL
 
@@ -51,5 +52,85 @@ struct QuickLookPolicyTests {
         #expect(prefix.utf8.count <= 101)
         #expect(prefix.utf16.count.isMultiple(of: 2))
         #expect(prefix.utf8.count.isMultiple(of: 4))
+    }
+
+    @Test("A small-file stat cannot turn a growth race into an unbounded read")
+    func growthAfterInitialStatUsesPrefixPath() throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let url = directory.appendingPathComponent("race.md")
+        try Data("small\n".utf8).write(to: url)
+        let large = Data(repeating: 0x61, count: QuickLookPolicy.fullReadLimitBytes + 1_024)
+
+        let result = QuickLookLoader.load(
+            contentsOf: url,
+            hintedByteCount: 6,
+            beforeRead: { try? large.write(to: url, options: .atomic) }
+        )
+
+        guard case .prefix(let text) = result else {
+            Issue.record("A file that grows after stat must take the bounded prefix path")
+            return
+        }
+        #expect(text.utf8.count <= QuickLookPolicy.fullReadLimitBytes)
+    }
+
+    @Test("Bounded loader preserves BOM encoded previews")
+    func boundedLoaderPreservesUTF16AndUTF32() throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let url = directory.appendingPathComponent("encoded.md")
+
+        var utf16 = Data([0xFF, 0xFE])
+        utf16 += "# UTF-16\n".data(using: .utf16LittleEndian)!
+        try utf16.write(to: url)
+        #expect(QuickLookLoader.load(contentsOf: url, hintedByteCount: utf16.count) == .full("# UTF-16\n"))
+
+        var utf32 = Data([0x00, 0x00, 0xFE, 0xFF])
+        utf32 += "# UTF-32\n".data(using: .utf32BigEndian)!
+        try utf32.write(to: url)
+        #expect(QuickLookLoader.load(contentsOf: url, hintedByteCount: utf32.count) == .full("# UTF-32\n"))
+    }
+
+    @Test("Bounded loader normalizes a pure CRLF document")
+    func boundedLoaderNormalizesCRLF() throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let url = directory.appendingPathComponent("crlf.md")
+        let data = Data("# Heading\r\n\r\nBody\r\n".utf8)
+        try data.write(to: url)
+
+        #expect(
+            QuickLookLoader.load(contentsOf: url, hintedByteCount: data.count)
+                == .full("# Heading\n\nBody\n")
+        )
+    }
+
+    @Test("Large-file loader reads a fixed prefix even when the file is replaced")
+    func replacementDuringLargePreviewRemainsBounded() throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let url = directory.appendingPathComponent("large.md")
+        try Data("old\n".utf8).write(to: url)
+        let replacement = Data(repeating: 0x61, count: QuickLookPolicy.prefixReadLimitBytes + 5_000)
+
+        let result = QuickLookLoader.load(
+            contentsOf: url,
+            hintedByteCount: QuickLookPolicy.largeFileThresholdBytes + 1,
+            beforeRead: { try? replacement.write(to: url, options: .atomic) }
+        )
+
+        guard case .prefix(let text) = result else {
+            Issue.record("Large-file previews must remain prefix loads")
+            return
+        }
+        #expect(text.utf8.count <= QuickLookPolicy.prefixReadLimitBytes)
+    }
+
+    private func temporaryDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("downright-ql-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
     }
 }

--- a/Tests/MarkdownCoreTests/DocumentIOTests.swift
+++ b/Tests/MarkdownCoreTests/DocumentIOTests.swift
@@ -210,4 +210,83 @@ import Testing
         #expect(fidelityBE.encoding == .utf16BE)
         try assertRoundTrip(beBody, "utf16 BE no BOM")
     }
+
+    @Test func guardedReplaceRestoresRacingGeneration() throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let url = directory.appendingPathComponent("doc.md")
+        let opened = Data("opened\n".utf8)
+        let firstExternal = Data("external-one\n".utf8)
+        let newestExternal = Data("external-two\n".utf8)
+        try firstExternal.write(to: url)
+
+        do {
+            try DocumentIO.replaceExistingAtomicallyForTesting(
+                with: Data("mine\n".utf8), at: url, expected: opened
+            ) {
+                try! newestExternal.write(to: url, options: .atomic)
+            }
+            Issue.record("a mismatched generation must fail closed")
+        } catch let DocumentIOError.targetChanged(_, displaced) {
+            #expect(displaced.contains(firstExternal))
+            #expect(displaced.contains(newestExternal))
+        }
+        #expect(try Data(contentsOf: url) == newestExternal)
+    }
+
+    @Test func failedRollbackNeverDeletesDisplacedExternalBytes() throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let url = directory.appendingPathComponent("doc.md")
+        let external = Data("external\n".utf8)
+        try external.write(to: url)
+
+        #expect(throws: (any Error).self) {
+            try DocumentIO.replaceExistingAtomicallyForTesting(
+                with: Data("mine\n".utf8), at: url,
+                expected: Data("opened\n".utf8)
+            ) {
+                try! FileManager.default.removeItem(at: url)
+            }
+        }
+        let recoveryFiles = try FileManager.default.contentsOfDirectory(
+            at: directory, includingPropertiesForKeys: nil
+        ).filter { $0.lastPathComponent.hasPrefix(".downright-save-") }
+        #expect(recoveryFiles.count == 1)
+        #expect(try Data(contentsOf: recoveryFiles[0]) == external)
+    }
+
+    @Test func displacedReadFailureLeavesRecoverableExternalGeneration() throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let url = directory.appendingPathComponent("doc.md")
+        let external = Data("external-before-read-failure\n".utf8)
+        let mine = Data("mine\n".utf8)
+        try external.write(to: url)
+
+        do {
+            try DocumentIO.replaceExistingAtomicallyForTesting(
+                with: mine, at: url, expected: external,
+                afterDisplacedRead: {},
+                afterSwap: { temporary in
+                    try! FileManager.default.setAttributes(
+                        [.posixPermissions: NSNumber(value: 0o000)],
+                        ofItemAtPath: temporary.path
+                    )
+                }
+            )
+            Issue.record("a displaced-generation read failure must fail closed")
+        } catch let DocumentIOError.displacedGenerationUnreadable(_, recoveryURL, _) {
+            #expect(FileManager.default.fileExists(atPath: recoveryURL.path))
+            try FileManager.default.setAttributes(
+                [.posixPermissions: NSNumber(value: 0o600)],
+                ofItemAtPath: recoveryURL.path
+            )
+            #expect(try Data(contentsOf: recoveryURL) == external)
+        }
+
+        // The public path contains Downright's candidate, while the external
+        // generation remains available at the recovery URL from the error.
+        #expect(try Data(contentsOf: url) == mine)
+    }
 }

--- a/Tests/MarkdownCoreTests/EditingTests.swift
+++ b/Tests/MarkdownCoreTests/EditingTests.swift
@@ -145,11 +145,54 @@ import Testing
             == "![Alt](a.png)")
     }
 
+    @Test func dropsExecutableHTMLDestinationsWithoutDroppingVisibleWords() {
+        #expect(SmartPaste.markdown(forHTML:
+            "<p><a href=\"javascript:alert(1)\">keep me</a></p>") == "keep me")
+        #expect(SmartPaste.markdown(forHTML:
+            "<p>before<img src=\"data:text/html,evil\" alt=\"bad\">after</p>")
+            == "beforeafter")
+    }
+
     @Test func convertsHTMLLists() {
         #expect(SmartPaste.markdown(forHTML: "<ul><li>one</li><li>two</li></ul>")
-            == "- one\n- two")
+                == "- one\n- two")
         #expect(SmartPaste.markdown(forHTML: "<ol><li>one</li><li>two</li></ol>")
-            == "1. one\n2. two")
+                == "1. one\n2. two")
+    }
+
+    @Test func convertsSafariFragmentWithoutCollapsingBlocks() {
+        let html = """
+        <!DOCTYPE html><html><head><meta charset="utf-8"><style>body { color: red }</style></head><body><!--StartFragment-->
+        <div><h1>Safari selection</h1><p>Intro <strong>bold</strong> and <a href="https://example.com">link</a>.</p>
+        <ul><li>first<ul><li>nested <code>code</code></li></ul></li><li>second</li></ul>
+        <table><thead><tr><th>Name</th><th>Count</th></tr></thead><tbody><tr><td>Ada</td><td>1</td></tr><tr><td>Grace</td><td>22</td></tr></tbody></table>
+        <pre><code>let x = 1</code></pre><script>alert(1)</script><p>After<br>line</p></div>
+        <!--EndFragment--></body></html>
+        """
+        // Safari includes wrapper tags, indentation, and fragment markers in
+        // public.html. The visible structure must survive normal Paste.
+        // Whitespace-only lines are not allowed to split the list/table into
+        // prose, while executable content remains discarded.
+        let expected = """
+        # Safari selection
+
+        Intro **bold** and [link](https://example.com).
+
+        - first
+          - nested `code`
+        - second
+
+        | Name  | Count |
+        | ----- | ----- |
+        | Ada   | 1     |
+        | Grace | 22    |
+
+        ```
+        let x = 1
+        ```
+
+        """ + "\nAfter  \nline"
+        #expect(SmartPaste.markdown(forHTML: html) == expected)
     }
 
     @Test func convertsHTMLCodeAndTables() {
@@ -169,5 +212,17 @@ import Testing
     @Test func unknownTagsDegradeToTheirTextContent() {
         #expect(SmartPaste.markdown(forHTML: "<p>a <mark>highlighted</mark> word</p>")
             == "a highlighted word")
+    }
+
+    @Test func matchStyleHTMLKeepsBlockAndListLineBreaks() {
+        let html = "<h2>Title</h2><p>First <strong>paragraph</strong>.</p>"
+            + "<ul><li>one</li><li>two</li></ul><p>Last</p>"
+        #expect(SmartPaste.plainText(forHTML: html) == "Title\n\nFirst paragraph.\none\ntwo\n\nLast")
+    }
+
+    @Test func matchStyleHTMLCollapsesInlineWhitespaceOnly() {
+        #expect(SmartPaste.plainText(forHTML:
+            "<p>one <span style=\"color:red\">two</span>\t three</p>")
+            == "one two three")
     }
 }

--- a/Tests/MarkdownCoreTests/SafeHTMLTests.swift
+++ b/Tests/MarkdownCoreTests/SafeHTMLTests.swift
@@ -1,0 +1,94 @@
+import Foundation
+import Testing
+@testable import MarkdownCore
+
+@Suite("Safe presentational HTML")
+struct SafeHTMLTests {
+    @Test func commonReadmeHTMLIsSourceAddressedAndSafe() throws {
+        let source = #"<p align="center"><strong>Downright</strong><br><a href="https://example.com">Home</a></p>"#
+        let parsed = MarkdownParser.parse(source)
+        let html = try #require(parsed.root.children.first?.safeHTML)
+        #expect(html.isSafe)
+        #expect(html.annotations.contains { if case .paragraph(align: .center) = $0.kind { true } else { false } })
+        #expect(html.annotations.contains { if case .strong = $0.kind { true } else { false } })
+        #expect(html.annotations.contains { if case .lineBreak = $0.kind { true } else { false } })
+        #expect(html.annotations.contains { if case .link(destination: "https://example.com", title: nil) = $0.kind { true } else { false } })
+        #expect(html.tagRanges.allSatisfy { $0.location >= 0 && $0.upperBound <= (source as NSString).length })
+    }
+
+    @Test func detailsTablesAndLocalImagesStayInTheSubset() throws {
+        let source = """
+        <details open><summary>More</summary><table><tr><th align="right">A</th><td>B</td></tr></table></details>
+        <img src="Docs/demo.png" alt="Demo">
+        """
+        let parsed = MarkdownParser.parse(source)
+        let documents = parsed.root.children.compactMap(\.safeHTML)
+        #expect(!documents.isEmpty)
+        #expect(documents.allSatisfy { $0.isSafe })
+        #expect(documents.flatMap(\.annotations).contains { if case .details(open: true) = $0.kind { true } else { false } })
+        #expect(documents.flatMap(\.annotations).contains { if case .tableCell(header: true, align: .right) = $0.kind { true } else { false } })
+        #expect(documents.flatMap(\.annotations).contains { if case .image(source: "Docs/demo.png", alt: "Demo") = $0.kind { true } else { false } })
+    }
+
+    @Test func unsafeOrUnknownHTMLRemainsLiteralAndInert() throws {
+        for source in [
+            #"<script>alert(1)</script>"#,
+            #"<p onclick="steal()">Text</p>"#,
+            #"<a href="javascript:alert(1)">Run</a>"#,
+            #"<iframe src="https://example.com"></iframe>"#,
+        ] {
+            let parsed = MarkdownParser.parse(source)
+            let html = try #require(parsed.root.children.first?.safeHTML)
+            #expect(!html.isSafe)
+            #expect(html.annotations.isEmpty)
+            #expect(parsed.text == source)
+        }
+    }
+
+    @Test func unbalancedDetailsWithoutARealDocumentBoundaryStayLiteral() throws {
+        for source in ["<details>", "</details>"] {
+            let parsed = MarkdownParser.parse(source)
+            let html = try #require(parsed.root.children.first?.safeHTML)
+            #expect(!html.isSafe)
+            #expect(html.annotations.isEmpty)
+            #expect(parsed.text == source)
+        }
+    }
+
+    @Test func remoteImagesStayVisibleButInertInsideSafeParents() throws {
+        let source = #"<p align="center"><img src="https://tracker.example/pixel.png" alt="remote"></p>"#
+        let parsed = MarkdownParser.parse(source)
+        let html = try #require(parsed.root.children.first?.safeHTML)
+        #expect(html.isSafe)
+        #expect(html.annotations.contains { if case .inert = $0.kind { true } else { false } })
+    }
+
+    @Test func githubProfileContinuesToDescribeRawHTMLAsTargetCompatibility() {
+        let parsed = MarkdownParser.parse("<strong>Text</strong>")
+        let github = MarkdownCompatibility.diagnose(parsed, for: .gitHub)
+        let noHTML = MarkdownCompatibility.diagnose(
+            parsed,
+            for: .custom(name: "No raw HTML", capabilities: [])
+        )
+        #expect(!github.diagnostics.contains { $0.capability == .rawHTML })
+        #expect(noHTML.diagnostics.contains { $0.capability == .rawHTML })
+    }
+
+    @Test func downrightReadmeCorpusClassifiesSafeAndRemoteRiskHTML() throws {
+        let repository = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let readme = try String(contentsOf: repository.appendingPathComponent("README.md"), encoding: .utf8)
+        let parsed = MarkdownParser.parse(readme)
+        var documents: [SafeHTMLDocument] = []
+        parsed.root.walk { block in
+            if let html = block.safeHTML { documents.append(html) }
+        }
+        #expect(!documents.isEmpty)
+        #expect(documents.contains { html in
+            html.annotations.contains { if case .inert = $0.kind { true } else { false } }
+        })
+        #expect(parsed.text == readme)
+    }
+}

--- a/Tests/MarkdownRenderTests/ClipboardSemanticHTMLTests.swift
+++ b/Tests/MarkdownRenderTests/ClipboardSemanticHTMLTests.swift
@@ -1,0 +1,95 @@
+import AppKit
+import Testing
+
+@testable import MarkdownRender
+
+@Suite("Clipboard semantic HTML")
+struct ClipboardSemanticHTMLTests {
+    @Test("exports common Markdown as semantic, escaped HTML")
+    func commonMarkdown() {
+        let html = ClipboardSemanticHTML.render(markdown: """
+        # Read **this**
+
+        - one
+        - [two](https://example.com)
+
+        | Name | Value |
+        | --- | --- |
+        | Ada | `1` |
+
+        ```swift
+        let x = 1 < 2
+        ```
+        """)
+        #expect(html.contains("<h1>Read <strong>this</strong></h1>"))
+        #expect(html.contains("<ul><li>one</li><li><a href=\"https://example.com\">two</a></li></ul>"))
+        #expect(html.contains("<table><thead>"))
+        #expect(html.contains("<th>Name</th>"))
+        #expect(html.contains("<pre><code class=\"language-swift\">"))
+        #expect(html.contains("&lt;"))
+        #expect(!html.contains("<script"))
+    }
+
+    @Test("preserves nested mixed lists as semantic HTML")
+    func nestedLists() {
+        let html = ClipboardSemanticHTML.render(markdown: """
+        - parent
+          1. ordered child
+          2. second child
+             - deep bullet
+        - sibling
+        """)
+        #expect(html.contains(
+            "<ul><li>parent<ol><li>ordered child</li><li>second child<ul><li>deep bullet</li></ul></li></ol></li><li>sibling</li></ul>"
+        ))
+    }
+
+    @Test("match style strips HTML formatting while Markdown mode preserves it")
+    func pasteModes() {
+        let payload = MarkdownPastePayload.html(
+            "<p><strong>Bold</strong> <a href=\"https://example.com\">link</a></p>",
+            fallback: ""
+        )
+        #expect(MarkdownSmartPaste.replacement(
+            for: payload, selection: "", context: .markdown, mode: .matchStyle
+        ) == "Bold link")
+        #expect(MarkdownSmartPaste.replacement(
+            for: payload, selection: "", context: .markdown, mode: .markdown
+        ) == "**Bold** [link](https://example.com)")
+    }
+
+    @Test("RTF and WebArchive payloads use bounded textual fallbacks")
+    func safeInboundPayloads() throws {
+        let rtf = try NSAttributedString(
+            string: "Rich text",
+            attributes: [.font: NSFont.systemFont(ofSize: 12)]
+        ).data(
+            from: NSRange(location: 0, length: 9),
+            documentAttributes: [.documentType: NSAttributedString.DocumentType.rtf]
+        )
+        let pasteboard = NSPasteboard(name: .init("DownrightClipboardTests.\(UUID())"))
+        pasteboard.clearContents()
+        pasteboard.setData(rtf, forType: .rtf)
+        guard case .html(let richHTML, let fallback) = MarkdownSmartPaste.payload(from: pasteboard) else {
+            Issue.record("RTF should retain semantic HTML when AppKit can convert it")
+            return
+        }
+        #expect(richHTML.contains("Rich text"))
+        #expect(fallback == "Rich text")
+
+        let resource: [String: Any] = [
+            "WebResourceData": Data("<p>Archive</p>".utf8),
+            "WebResourceFrameName": "",
+            "WebResourceMIMEType": "text/html",
+            "WebResourceTextEncodingName": "utf-8",
+            "WebResourceURL": "about:blank",
+        ]
+        let archive = try PropertyListSerialization.data(
+            fromPropertyList: ["WebMainResource": resource], format: .binary, options: 0)
+        let archiveBoard = NSPasteboard(name: .init("DownrightClipboardTests.\(UUID())"))
+        archiveBoard.clearContents()
+        archiveBoard.setData(archive, forType: .webArchive)
+        #expect(MarkdownSmartPaste.payload(from: archiveBoard)
+                == .html("<p>Archive</p>", fallback: ""))
+    }
+}

--- a/Tests/MarkdownRenderTests/SafeHTMLLineBreakTests.swift
+++ b/Tests/MarkdownRenderTests/SafeHTMLLineBreakTests.swift
@@ -1,0 +1,132 @@
+import AppKit
+import MarkdownCore
+import Testing
+@testable import MarkdownRender
+
+@Suite("Safe HTML line breaks")
+@MainActor
+struct SafeHTMLLineBreakTests {
+    @Test("safe br tags render as breaks without changing source coordinates")
+    func safeLineBreakPreservesSourceCoordinates() throws {
+        let source = "<p>first<br>second</p>"
+        let storage = NSTextStorage(string: source)
+        let view = MarkdownTextView(
+            frame: NSRect(x: 0, y: 0, width: 640, height: 480),
+            storage: storage
+        )
+        let document = MarkdownParser.parse(source)
+        view.update(document: document, dirty: .wholesale)
+
+        let breakRange = (source as NSString).range(of: "<br>")
+        let entry = try #require(
+            view.currentDisplayMap.substitutions(in: breakRange).first
+        )
+        #expect(entry.sourceRange == breakRange)
+        #expect(entry.displayLength == breakRange.length)
+        #expect(entry.replacement?.string.first == "\n")
+        #expect(entry.isHidden == false)
+        #expect(entry.preservesSourceOffsets)
+    }
+
+    @Test("source mode leaves safe HTML tags literal")
+    func sourceModeLeavesTagsLiteral() throws {
+        let source = "<p>first<br>second</p>"
+        let storage = NSTextStorage(string: source)
+        let view = MarkdownTextView(
+            frame: NSRect(x: 0, y: 0, width: 640, height: 480),
+            storage: storage
+        )
+        view.mode = .source
+        view.update(document: MarkdownParser.parse(source), dirty: .wholesale)
+
+        let breakRange = (source as NSString).range(of: "<br>")
+        #expect(view.currentDisplayMap.substitutions(in: breakRange).isEmpty)
+    }
+
+    @Test("scoped source focus reveals a safe br tag literally")
+    func scopedSourceFocusRevealsTag() throws {
+        let source = "<p>first<br>second</p>"
+        let storage = NSTextStorage(string: source)
+        let view = MarkdownTextView(
+            frame: NSRect(x: 0, y: 0, width: 640, height: 480),
+            storage: storage
+        )
+        view.update(document: MarkdownParser.parse(source), dirty: .wholesale)
+
+        let breakRange = (source as NSString).range(of: "<br>")
+        view.focusSource(in: breakRange)
+        #expect(view.currentDisplayMap.substitutions(in: breakRange).isEmpty)
+    }
+
+    @Test("details preserves source offsets and shows its authored disclosure state")
+    func detailsDisclosureSubstitution() throws {
+        let source = "<details><summary>More</summary>Body</details>"
+        let document = MarkdownParser.parse(source)
+        let storage = NSTextStorage(string: source)
+        let view = MarkdownTextView(
+            frame: NSRect(x: 0, y: 0, width: 640, height: 480),
+            storage: storage
+        )
+        view.update(document: document, dirty: .wholesale)
+
+        let details = try #require(document.root.children.first?.safeHTML?.annotations.first {
+            if case .details = $0.kind { return true }
+            return false
+        })
+        let substitution = try #require(
+            view.currentDisplayMap.substitutions(in: details.tagRanges[0]).first
+        )
+        #expect(substitution.sourceRange == details.tagRanges[0])
+        #expect(substitution.displayLength == details.tagRanges[0].length)
+        #expect(substitution.replacement?.string.first == "▸")
+        #expect(substitution.preservesSourceOffsets)
+    }
+
+    @Test("multiline details keeps all disclosure tags out of Document display")
+    func multilineDetailsDisclosureSubstitution() throws {
+        let source = """
+        <details>
+        <summary>More</summary>
+
+        Body
+
+        </details>
+        """
+        let document = MarkdownParser.parse(source)
+        let storage = NSTextStorage(string: source)
+        let view = MarkdownTextView(frame: NSRect(x: 0, y: 0, width: 640, height: 480), storage: storage)
+        view.update(document: document, dirty: .wholesale)
+        let tags = ["<details>", "<summary>", "</summary>", "</details>"]
+        for tag in tags {
+            let range = (source as NSString).range(of: tag)
+            #expect(view.currentDisplayMap.substitutions(in: range).isEmpty == false, "missing substitution for \(tag)")
+        }
+    }
+
+    @Test("HTML table rows receive source-preserving line breaks")
+    func tableRowsDoNotConcatenate() throws {
+        let source = "<table><tr><td>A</td><td>B</td></tr><tr><td>C</td><td>D</td></tr></table>"
+        let document = MarkdownParser.parse(source)
+        let storage = NSTextStorage(string: source)
+        let view = MarkdownTextView(
+            frame: NSRect(x: 0, y: 0, width: 640, height: 480),
+            storage: storage
+        )
+        view.update(document: document, dirty: .wholesale)
+
+        let rows = document.root.children.first?.safeHTML?.annotations.filter {
+            if case .tableRow = $0.kind { return true }
+            return false
+        } ?? []
+        #expect(rows.count == 2)
+        for row in rows {
+            let closing = try #require(row.tagRanges.last)
+            let substitution = try #require(
+                view.currentDisplayMap.substitutions(in: closing).first
+            )
+            #expect(substitution.sourceRange == closing)
+            #expect(substitution.replacement?.string.first == "\n")
+            #expect(substitution.preservesSourceOffsets)
+        }
+    }
+}

--- a/Tests/MarkdownRenderTests/SafeHTMLRenderTests.swift
+++ b/Tests/MarkdownRenderTests/SafeHTMLRenderTests.swift
@@ -1,0 +1,101 @@
+import AppKit
+import MarkdownCore
+import Testing
+@testable import MarkdownRender
+
+@Suite("Native safe HTML rendering")
+struct SafeHTMLRenderTests {
+    private func engine(_ mode: RenderMode) -> DecorationEngine {
+        let sheet = StyleSheet(
+            theme: .fallback,
+            appearance: NSAppearance(named: .aqua) ?? NSAppearance.currentDrawing()
+        )
+        let engine = DecorationEngine(styleSheet: sheet)
+        engine.policy = mode.policy
+        return engine
+    }
+
+    @Test func safeTagsCollapseButSourceAndSemanticAttributesRemain() throws {
+        let source = #"<p align="center"><strong>Gold</strong> <a href="https://example.com">standard</a></p>"#
+        let document = MarkdownParser.parse(source)
+        let storage = NSTextStorage(string: source)
+        let renderer = engine(.live)
+        renderer.decorate(storage, document: document, dirty: .wholesale)
+
+        #expect(storage.string == source)
+        let hidden = renderer.hiddenRanges(document: document, caret: nil, selections: [])
+        let html = try #require(document.root.children.first?.safeHTML)
+        #expect(Set(hidden) == Set(html.tagRanges))
+
+        let gold = (source as NSString).range(of: "Gold")
+        let standard = (source as NSString).range(of: "standard")
+        let bold = try #require(storage.attribute(.font, at: gold.location, effectiveRange: nil) as? NSFont)
+        #expect(bold.fontDescriptor.symbolicTraits.contains(.bold))
+        #expect(storage.attribute(.drLink, at: standard.location, effectiveRange: nil) as? String == "https://example.com")
+        let paragraph = try #require(storage.attribute(.paragraphStyle, at: gold.location, effectiveRange: nil) as? NSParagraphStyle)
+        #expect(paragraph.alignment == .center)
+    }
+
+    @Test func caretRevealsSafeTagsForEditingAndSourceModeAlwaysShowsThem() throws {
+        let source = "<strong>Text</strong>"
+        let document = MarkdownParser.parse(source)
+        let live = engine(.live)
+        #expect(!live.hiddenRanges(document: document, caret: nil, selections: []).isEmpty)
+        #expect(live.hiddenRanges(document: document, caret: 9, selections: []).isEmpty)
+        #expect(engine(.source).hiddenRanges(document: document, caret: nil, selections: []).isEmpty)
+    }
+
+    @Test func unsafeHTMLReceivesNoLinkFragmentOrHiddenRanges() {
+        let source = #"<a href="javascript:alert(1)">Run</a>"#
+        let document = MarkdownParser.parse(source)
+        let storage = NSTextStorage(string: source)
+        let renderer = engine(.live)
+        renderer.decorate(storage, document: document, dirty: .wholesale)
+        #expect(renderer.hiddenRanges(document: document, caret: nil, selections: []).isEmpty)
+        #expect(storage.attribute(.drLink, at: 0, effectiveRange: nil) == nil)
+        #expect(storage.string == source)
+    }
+
+    @Test func localHTMLImageUsesNativeFragmentWithoutRemoteLoading() throws {
+        let source = #"<img src="Docs/demo.png" alt="Demo">"#
+        let document = MarkdownParser.parse(source)
+        let storage = NSTextStorage(string: source)
+        engine(.live).decorate(storage, document: document, dirty: .wholesale)
+        let payload = try #require(storage.attribute(.drFragment, at: 0, effectiveRange: nil) as? FragmentPayload)
+        #expect(payload.kind == .image)
+        #expect(payload.detail == "Docs/demo.png")
+        #expect(storage.string == source)
+    }
+
+    @Test func detailsAndTableAnnotationsReceiveNativeReadingChrome() throws {
+        let source = "<details open><summary>More</summary>Body</details>\n<table><tr><td>A</td><td>B</td></tr></table>"
+        let document = MarkdownParser.parse(source)
+        let storage = NSTextStorage(string: source)
+        engine(.live).decorate(storage, document: document, dirty: .wholesale)
+
+        let details = try #require(document.root.children.first?.safeHTML)
+        let summary = try #require(details.annotations.first {
+            if case .summary = $0.kind { return true }
+            return false
+        })
+        #expect(storage.attribute(.backgroundColor, at: summary.contentRange.location, effectiveRange: nil) != nil)
+
+        let table = try #require(document.root.children.compactMap(\.safeHTML).first {
+            $0.annotations.contains {
+                if case .tableCell = $0.kind { return true }
+                return false
+            }
+        })
+        let cells = table.annotations.filter {
+            if case .tableCell = $0.kind { return true }
+            return false
+        }
+        #expect(cells.count == 2)
+        for cell in cells {
+            let last = cell.contentRange.upperBound - 1
+            #expect((storage.attribute(.kern, at: last, effectiveRange: nil) as? NSNumber)?.doubleValue ?? 0 > 0)
+            #expect(storage.attribute(.backgroundColor, at: last, effectiveRange: nil) != nil)
+        }
+        #expect(storage.string == source)
+    }
+}

--- a/Tests/MarkdownRenderTests/SmartPasteIntegrationTests.swift
+++ b/Tests/MarkdownRenderTests/SmartPasteIntegrationTests.swift
@@ -56,7 +56,7 @@ struct SmartPasteIntegrationTests {
         pasteboard.setString("https://example.com", forType: .URL)
         pasteboard.setString("lossless", forType: .string)
 
-        #expect(MarkdownSmartPaste.payload(from: pasteboard) == .text("**lossless**"))
+        #expect(MarkdownSmartPaste.payload(from: pasteboard) == .markdown("**lossless**"))
     }
 
     @Test("standard copy exposes visible text and keeps Markdown as an alternate")
@@ -114,6 +114,41 @@ struct SmartPasteIntegrationTests {
         #expect(payload == .html("<p><strong>Only HTML</strong></p>", fallback: ""))
         #expect(MarkdownSmartPaste.replacement(
             for: payload!, selection: "", context: .markdown) == "**Only HTML**")
+    }
+
+    @Test("Safari public.html keeps rich structure ahead of flattened fallback")
+    func safariHTMLRoundTrip() {
+        let pasteboard = isolatedPasteboard()
+        pasteboard.clearContents()
+        let html = """
+        <!DOCTYPE html><html><head><style>body { color: red }</style></head><body><!--StartFragment-->
+        <div><h2>Heading</h2><p>Intro <strong>bold</strong> and <a href="https://example.com">link</a>.</p>
+        <ul><li>first<ul><li>nested <code>code</code></li></ul></li><li>second</li></ul>
+        <table><tbody><tr><th>Name</th><th>Count</th></tr><tr><td>Ada</td><td>1</td></tr></tbody></table>
+        <script>window.evil = true</script></div><!--EndFragment--></body></html>
+        """
+        pasteboard.setString(html, forType: .html)
+        // Safari advertises several rich aliases and a flattened public.text
+        // fallback. Normal Paste must consume public.html, not the fallback.
+        pasteboard.setString("Heading Intro bold and link. first nested code second Name Count Ada 1", forType: .string)
+        pasteboard.setData(Data([0x00, 0x01]), forType: .rtf)
+        pasteboard.setData(Data([0x02, 0x03]), forType: .appleWebArchive)
+
+        let payload = MarkdownSmartPaste.payload(from: pasteboard)
+        guard let payload else {
+            Issue.record("Safari-style clipboard did not expose a payload")
+            return
+        }
+        let replacement = MarkdownSmartPaste.replacement(
+            for: payload, selection: "", context: .markdown)
+        #expect(replacement.contains("## Heading"))
+        #expect(replacement.contains("**bold**"))
+        #expect(replacement.contains("[link](https://example.com)"))
+        #expect(replacement.contains("- first\n  - nested `code`\n- second"))
+        #expect(replacement.contains("| Name"))
+        #expect(replacement.contains("| Ada"))
+        #expect(!replacement.contains("window.evil"))
+        #expect(!replacement.contains("Heading Intro bold and link. first nested code"))
     }
 
     @Test("source edit replaces the source selection and creates one undo step")
@@ -370,8 +405,11 @@ struct SmartPasteIntegrationTests {
                 for: payload, selection: "", context: MarkdownSmartPaste.context(
                     for: NSRange(location: 0, length: 0), in: view.parsedDocument, mode: .source))
             switch payload {
+            case .markdown(let value): #expect(replacement == value)
             case .url(let value), .text(let value): #expect(replacement == value)
             case .html(let value, _): #expect(replacement == value)
+            case .richText(let value), .file(let value): #expect(replacement == value)
+            case .image: #expect(replacement == "Pasted image")
             }
         }
     }


### PR DESCRIPTION
## Summary

- make saves fail closed across missing, unreadable, renamed, and concurrently replaced files with generation-aware watcher reconciliation and explicit recovery
- add a calm document state/provenance model, asynchronous large-rewrite rendering, a discoverable Contents / Outline command, truthful customizable onboarding, and bounded Quick Look loading
- add lossless multi-flavor clipboard interchange with sanitized semantic HTML plus safe native rendering for common presentational raw HTML
- isolate development bundle identifiers and updater configuration from production

## Validation

- `RUN_DRBENCH=1 Scripts/check.sh` — 1,108 tests across 97 suites passed
- enforced release benchmark — typing p95 0.17 ms; semantic edit 35.38 ms
- exact Release artifact built at `.build-trust-final/Build/Products/Release/Downright.app`
- `Scripts/verify-bundle.sh` — passed, including isolated host/Quick Look/thumbnail/Spotlight IDs and updater-disabled development configuration
- real AppKit acceptance covered normal, narrow, full-screen, Document/Source/split, all document states, external deletion/rename/conflict recovery, 10k–50k-line typing/scrolling, README HTML, clipboard round trips, Quick Look host loading, accessibility labels, and reduced-motion/transparency policy
- independent ship-blocker review — clear after focused P0 regression fixes

## Safety

- exact source and byte fidelity preserved
- unknown/executable/remote-risk HTML remains inert and visible
- acceptance used only the isolated development artifact; `/Applications/Downright.app` was not replaced
- user clipboard and production Quick Look/thumbnail preference were restored after acceptance
