### PR TITLE
Bound long-lived document state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,50 @@
+# Downright Repository Guide
+
+This file contains Downright-specific context, invariants, and evidence gates. Follow any applicable higher-level instructions as well.
+
+## Project Model and Live State
+
+- Downright is a native macOS 14+ Markdown reader/editor built with AppKit and TextKit 2. It is local-first and source-preserving.
+- The main boundaries are `MarkdownCore` for parsing and source edits, `MarkdownRender` for TextKit presentation, `DownrightApp` for windows/files/actions, `DownrightQL` and `DownrightThumb` for Finder, Spotlight targets for metadata, and `down` for the CLI.
+- This checkout is the native app. `/Volumes/Neural/downright-website` is the Astro site; `/Volumes/Neural/product-downright` is a separate product/media workspace. Do not substitute one for another.
+- Source, SwiftPM bundles, Xcode bundles, `/Applications/Downright.app`, Finder extensions, mounted DMGs, and public releases are distinct surfaces. Name the surface in scope before changing or validating it.
+- Treat this file as durable policy, not a status page. Never rely on hard-coded SHAs, branch divergence, version/build numbers, test counts, benchmark results, release tags, download totals, or installed-app identity.
+- Resolve volatile state at task start from its live authority:
+  - checkout: `git status --short --branch`, `HEAD`, and refreshed upstream state when current upstream truth is required;
+  - local version/build: `Config/version.env`;
+  - current tests and budgets: the relevant scripts’ fresh output;
+  - public release/update state: the live GitHub Release, DMG/checksum, and Sparkle appcast;
+  - running app state: exact bundle path, `Info.plist` version/build, executable identity, and process path.
+- If live verification is unavailable or intentionally skipped, label conclusions snapshot-only. If this or a nested instruction file changes during the task, reread the applicable instructions before continuing.
+- When a change alters an architectural, validation, privacy, or release contract named here, update this file and the relevant project documentation in the same change. Do not append dated status snapshots.
+- Consult the relevant contract before changing behavior: `PRODUCT.md`, `DESIGN.md`, `Docs/ARCHITECTURE.md`, `Docs/QUICKLOOK.md`, `Docs/PERFORMANCE.md`, or `Docs/RELEASE.md`. `project.yml` is the XcodeGen source; `Config/version.env` is the canonical version/build source. Report conflicting guidance rather than silently choosing one.
+
+## Product Invariants
+
+- Raw Markdown bytes on disk are authoritative. Rendering, hidden syntax, reflow, attachments, Quick Look, and presentation state must not rewrite the document.
+- Source UTF-16 positions are canonical. Route source/display conversions through `DisplayMap`; never reuse a TextKit/display offset as a source offset.
+- Preserve selection, undo, revision convergence, and a semantic source/reading anchor for operations expected to preserve position. Explicit navigation may move to its target; verify both the target and post-navigation anchor.
+- Keep the one-TextKit-2-surface architecture unless the task explicitly changes that contract. Incremental typing must not cause a whole-document rebuild; length-changing edits must invalidate all shifted ranges and fragments.
+- Make source mutations and undo boundaries explicit. Storage, autosave, watcher, and external-write changes need focused coverage for the relevant clean/dirty states and, when applicable, atomic replacement, deletion/rename, own-write suppression, conflict/review, failure, and recovery.
+- Never translate an I/O failure into “no change,” recreate a deleted file silently, overwrite source after a rendering failure, or save after the user chose Discard.
+- Downright has no app telemetry and does not upload document contents. Public acquisition means GitHub Release `.dmg` asset requests across stable and versioned DMGs; exclude Sparkle ZIP/delta requests and never describe requests as unique people or completed installs.
+
+## Validation by Surface
+
+- Use focused tests while iterating, then run `Scripts/check.sh` as the authoritative source gate. Do not substitute bare `swift test`; zero executed tests or a masked pipeline failure is a failed gate.
+- Give concurrent checks unique scratch/build locations using the supported variables: `SCRATCH`, `TEST_SCRATCH`, `APP_ACCEPTANCE_SCRATCH`, and `SPOTLIGHT_SCRATCH`. If source, `HEAD`, or relevant outputs change during validation, discard the result and rerun on the intended snapshot.
+- `Scripts/bundle-app.sh` is appropriate for host-only iteration but does not prove Finder extensions. Use `Scripts/bundle-xcode-app.sh` and `Scripts/check-app.sh` for Quick Look, thumbnails, Finder integration, or production-shaped app acceptance. Development/ad-hoc bundles do not prove production Sparkle behavior.
+- When the installed app is the acceptance surface, install the intended artifact explicitly with `APP_SOURCE=... Scripts/install.sh`, stop stale Downright instances when safe, and verify bundle path, version/build, executable identity, signature, embedded components, and running process before exercising the feature.
+- Use a disposable document copy for destructive editing, Replace All, task toggles, metadata, save/discard, or conflict QA. Restore task-created preferences/state afterward.
+- For changed visual or interaction behavior, verify the relevant journey in the exact app: launch, first visible frame, transition, settled state, real pointer/keyboard interaction, dismissal, rapid reopen or interruption, and resize. Check only the relevant light/dark and accessibility states.
+- For glass/material work, verify document sampling, crisp foreground content, no first-frame material swap, and working pointer, keyboard, focus, outside-click, and fallback behavior.
+- When the report concerns clicking, caret placement, hover, drag, scrolling, or a close/checkbox control, use a real native input path. Accessibility actions, `performClick`, screenshots, hashes, and direct method calls are supporting evidence, not substitutes.
+- Quick Look preview and Finder thumbnail are separate acceptance surfaces. Use the packaged installed extensions, verify current registration, test an actual Finder Spacebar preview after startup settles, and generate a fresh thumbnail. Do not infer one from the other or from `qlmanage` generation alone.
+- Report performance by the layer measured: edit/storage response, parse/semantic convergence, TextKit layout, and visible frame/scroll stability are different claims. Pair performance-sensitive editor changes with the repository budgets and a real large-document exercise.
+
+## Plans and Release Evidence
+
+- For a numbered audit or broad implementation plan, expand grouped bullets into concrete acceptance items. Reconcile every original item and later correction as proved, explicitly approved as changed, or blocked before claiming completion.
+- A push or merge to this repository’s `main` is a consequential signed-release action, including documentation-only changes. Obtain explicit authorization immediately before it. Feature-branch pushes and merged PRs are not release proof.
+- For release claims, follow `Docs/RELEASE.md` and keep these states distinct: intended `main` SHA, workflow completion, version/build, GitHub Release, signed/notarized/stapled DMG and checksum, stable download URL, signed Sparkle appcast/enclosure, update availability, and installed `/Applications` bundle.
+- Verify every release stage the request places in scope and label the rest unverified. “Update available” does not mean existing installations have already updated.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ every release; Sparkle orders updates by it.
 
 ### Fixed
 
+- Stopped idle history maintenance from rewriting every unchanged index, made
+  long-session pruning half-hourly, and added mounted-volume-aware collection
+  of stale history and reading-state files.
+- Bounded external-change undo history and moved path-existence rechecks to a
+  background cache warm so long-lived, frequently rewritten documents cannot
+  grow memory indefinitely or stall the main thread on filesystem checks.
+
 - **Made saves fail closed around external file activity.** Downright now
   distinguishes unchanged, changed, missing, and unreadable disk state; an
   implicit save can no longer recreate a deleted file, swallow an atomic

--- a/Docs/ARCHITECTURE.md
+++ b/Docs/ARCHITECTURE.md
@@ -83,8 +83,19 @@ writes replace the inode. On an external write:
 5. If the buffer is clean, apply the new text.
 6. If the buffer is dirty, show Review, Keep Mine, and Take Theirs.
 
-Snapshots deduplicate by content hash and have local retention rules. Snapshot
-restore is a text edit, not a hidden file replacement.
+Snapshots deduplicate by content hash. Retention applies the configured age,
+per-document, and global byte caps without rewriting unchanged indexes; a
+half-hour maintenance interval bounds long-running sessions. History for a
+deleted document becomes eligible after the configured snapshot age; its
+reading-position state uses a fixed 30-day age. Both require two distinct
+observations that the path is absent, and the containing volume must be
+mounted. An unreadable path, an I/O error, an unmounted volume, or a path
+restored between observations is preserved. These checks deliberately fail
+closed around atomic replacements.
+
+Snapshot restore is a text edit, not a hidden file replacement. Persistence
+tests inject temporary support roots, and the repository gate also refuses to
+run them without an isolated Application Support directory.
 
 ## Workspace and path resolution
 

--- a/Docs/PRIVACY.md
+++ b/Docs/PRIVACY.md
@@ -50,9 +50,17 @@ the network.
 
 ## Retention and deletion
 
-Snapshots are local and content-addressed. Users can delete snapshot history
-from the app. Settings and themes can be removed from the Downright support
-folder. The app does not claim ownership of user Markdown files.
+Snapshots are local and content-addressed. The app applies configured age and
+size caps. A missing path's snapshot index becomes eligible at the configured
+snapshot age; its reading-position state becomes eligible after 30 days. Both
+may be collected only after two separate checks confirm that the path is
+absent and its containing volume is mounted. Downright preserves this local
+metadata when the path is unreadable, the filesystem answer is uncertain, the
+volume is unavailable, or the file returns between checks.
+
+Users can delete snapshot history from the app. Settings and themes can be
+removed from the Downright support folder. The app does not claim ownership of
+user Markdown files.
 
 Crash logs and diagnostics are local unless the user chooses to share them.
 Logs must not include document text, prompts, or full file paths when a stable

--- a/Scripts/check.sh
+++ b/Scripts/check.sh
@@ -16,6 +16,25 @@ SCRATCH="${SCRATCH:-.build-main}"
 # path makes SwiftPM rebuild the world on every switch.  Keep them apart.
 TEST_SCRATCH="${TEST_SCRATCH:-.build-test}"
 
+# Model and app-layer tests exercise snapshot/state persistence, including
+# destructive pruning. Never let the authoritative gate inherit the user's
+# real Application Support directory. Callers that provide an explicit
+# isolated directory keep ownership of it; otherwise this script creates and
+# removes a per-run sandbox.
+if [ -z "${DOWNRIGHT_SUPPORT_DIRECTORY:-}" ]; then
+    if ! TEST_SUPPORT_DIRECTORY="$(mktemp -d "${TMPDIR:-/tmp}/downright-check-support.XXXXXX")" \
+        || [ -z "$TEST_SUPPORT_DIRECTORY" ] \
+        || [ ! -d "$TEST_SUPPORT_DIRECTORY" ]; then
+        echo "check: could not create an isolated Application Support directory" >&2
+        exit 1
+    fi
+    export DOWNRIGHT_SUPPORT_DIRECTORY="$TEST_SUPPORT_DIRECTORY"
+    cleanup_test_support() {
+        find "$TEST_SUPPORT_DIRECTORY" -depth -delete
+    }
+    trap cleanup_test_support EXIT
+fi
+
 # Logs are named after the scratch path, not fixed under /tmp.  Two runs with
 # different SCRATCH values are a deliberately supported thing (CI uses its own,
 # and running a second check while one is in flight is normal), but with fixed

--- a/Sources/DownrightApp/AI/DocumentStateStore.swift
+++ b/Sources/DownrightApp/AI/DocumentStateStore.swift
@@ -123,51 +123,139 @@ final class DocumentStateStore {
     private var cacheOrder: [String] = []
     private let maximumCachedStates = 256
     private let lock = NSLock()
+    private let pruneQueue = DispatchQueue(label: "com.ezzy.downright.state-prune", qos: .utility)
 
-    private init() { AppPaths.ensure(AppPaths.stateDirectory) }
+    /// A deleted document keeps its reading position long enough to be
+    /// restored from the Trash, without making the state directory a permanent
+    /// record of every document ever opened.
+    private let abandonedStateMaximumAge: TimeInterval = 30 * 24 * 60 * 60
+    private let abandonedStateConfirmationDelay: TimeInterval
+    private let supportDirectory: URL
+    private let stateDirectory: URL
+    private var abandonedCandidates: [String: String] = [:]
+
+    /// `supportDirectory` is injectable so state-pruning tests cannot touch the
+    /// user's real reading positions or recents.
+    init(
+        supportDirectory: URL = AppPaths.supportDirectory,
+        abandonedStateConfirmationDelay: TimeInterval = 30
+    ) {
+        self.supportDirectory = supportDirectory.standardizedFileURL
+        self.stateDirectory = self.supportDirectory.appendingPathComponent("state", isDirectory: true)
+        self.abandonedStateConfirmationDelay = abandonedStateConfirmationDelay
+        AppPaths.ensure(self.stateDirectory)
+    }
+
+    /// Drops stale reading state for documents that no longer exist. This is a
+    /// launch job: nothing else deletes these files, and doing the directory
+    /// walk off the main thread keeps opening a document responsive.
+    func schedulePruneAbandonedStates() {
+        pruneQueue.async { [self] in
+            pruneAbandonedStates()
+            // A second, meaningfully separated observation confirms absence
+            // without installing a permanent maintenance timer.
+            pruneQueue.asyncAfter(deadline: .now() + abandonedStateConfirmationDelay) { [self] in
+                pruneAbandonedStates()
+            }
+        }
+    }
+
+    @discardableResult
+    func pruneAbandonedStates() -> Int {
+        guard let files = try? fm.contentsOfDirectory(
+            at: stateDirectory,
+            includingPropertiesForKeys: nil
+        ) else { return 0 }
+
+        let cutoff = Date().addingTimeInterval(-abandonedStateMaximumAge)
+        var removed = 0
+        for file in files where file.pathExtension == "json" {
+            let key = file.deletingPathExtension().lastPathComponent
+            guard let data = try? Data(contentsOf: file),
+                  let state = try? JSONDecoder.snapshotDecoder.decode(DocumentState.self, from: data)
+            else {
+                _ = lock.withLock { abandonedCandidates.removeValue(forKey: key) }
+                continue
+            }
+
+            guard state.lastOpened < cutoff else {
+                _ = lock.withLock { abandonedCandidates.removeValue(forKey: key) }
+                continue
+            }
+            let presence = state.path.isEmpty
+                ? SnapshotStore.PathPresence.absent
+                : SnapshotStore.pathPresence(for: state.path)
+            guard presence == .absent,
+                  (state.path.isEmpty || SnapshotStore.volumeIsMounted(for: state.path)) else {
+                _ = lock.withLock { abandonedCandidates.removeValue(forKey: key) }
+                continue
+            }
+            let signature = DocumentIO.contentHash(data)
+            let confirmed = lock.withLock {
+                guard abandonedCandidates[key] == signature else {
+                    abandonedCandidates[key] = signature
+                    return false
+                }
+                return true
+            }
+            guard confirmed else { continue }
+            let didRemove = lock.withLock {
+                // A save can refresh this state while the prune is walking.
+                // Delete only the exact stale generation we inspected.
+                guard (try? Data(contentsOf: file)) == data else { return false }
+                do {
+                    try fm.removeItem(at: file)
+                } catch {
+                    return false
+                }
+                cache.removeValue(forKey: key)
+                cacheOrder.removeAll { $0 == key }
+                abandonedCandidates.removeValue(forKey: key)
+                return true
+            }
+            if didRemove { removed += 1 }
+        }
+        return removed
+    }
 
     // MARK: - Per-document state
 
     func state(for url: URL) -> DocumentState {
         let key = SnapshotStore.documentKey(for: url)
-        lock.lock()
-        if let cached = cache[key] {
-            touchCacheKey(key)
-            lock.unlock()
-            return cached
-        }
-        lock.unlock()
+        return lock.withLock {
+            if let cached = cache[key] {
+                touchCacheKey(key)
+                return cached
+            }
 
-        let fileURL = AppPaths.stateDirectory.appendingPathComponent(key + ".json")
-        var state: DocumentState
-        if let data = try? Data(contentsOf: fileURL),
-           let decoded = try? JSONDecoder.snapshotDecoder.decode(DocumentState.self, from: data) {
-            state = decoded
-        } else {
-            state = DocumentState(path: url.path)
+            let fileURL = stateDirectory.appendingPathComponent(key + ".json")
+            var state: DocumentState
+            if let data = try? Data(contentsOf: fileURL),
+               let decoded = try? JSONDecoder.snapshotDecoder.decode(DocumentState.self, from: data) {
+                state = decoded
+            } else {
+                state = DocumentState(path: url.path)
+            }
+            state.path = url.path
+            storeInCache(state, forKey: key)
+            return state
         }
-        state.path = url.path
-
-        lock.lock()
-        storeInCache(state, forKey: key)
-        lock.unlock()
-        return state
     }
 
     func save(_ state: DocumentState, for url: URL) {
         let key = SnapshotStore.documentKey(for: url)
-        lock.lock()
-        storeInCache(state, forKey: key)
-        lock.unlock()
-
         guard let data = try? JSONEncoder.snapshotEncoder.encode(state) else { return }
-        let fileURL = AppPaths.stateDirectory.appendingPathComponent(key + ".json")
-        try? data.write(to: fileURL, options: .atomic)
+        let fileURL = stateDirectory.appendingPathComponent(key + ".json")
+        lock.withLock {
+            storeInCache(state, forKey: key)
+            try? data.write(to: fileURL, options: .atomic)
+            _ = abandonedCandidates.removeValue(forKey: key)
+        }
     }
 
     // MARK: - Recents
 
-    private var recentsURL: URL { AppPaths.supportDirectory.appendingPathComponent("recents.json") }
+    private var recentsURL: URL { supportDirectory.appendingPathComponent("recents.json") }
 
     func recents(limit: Int = 30) -> [RecentDocument] {
         guard let data = try? Data(contentsOf: recentsURL),

--- a/Sources/DownrightApp/AI/MarkdownDocument.swift
+++ b/Sources/DownrightApp/AI/MarkdownDocument.swift
@@ -253,6 +253,8 @@ final class MarkdownDocument: NSObject {
     private var isApplyingBatch = false
     private var suppressReparse = false
     private let parseCoordinator: MarkdownParseCoordinator
+    private let snapshotStore: SnapshotStore
+    private let documentStateStore: DocumentStateStore
     private var parseTask: Task<Void, Never>?
     private var parseControlTask: Task<Void, Never>?
     private(set) var revision = MarkdownParseRevision.zero
@@ -284,8 +286,14 @@ final class MarkdownDocument: NSObject {
         self.init(parseWorker: MarkdownParseWorker())
     }
 
-    init(parseWorker: MarkdownParseWorker) {
+    init(
+        parseWorker: MarkdownParseWorker,
+        snapshotStore: SnapshotStore = .shared,
+        documentStateStore: DocumentStateStore = .shared
+    ) {
         self.parseCoordinator = MarkdownParseCoordinator(worker: parseWorker)
+        self.snapshotStore = snapshotStore
+        self.documentStateStore = documentStateStore
         self.state = DocumentState(path: "")
         super.init()
         parseCoordinator.onBusyChange = { [weak self] busy in
@@ -293,6 +301,10 @@ final class MarkdownDocument: NSObject {
         }
         storage.delegate = self
         undoManager.groupsByEvent = false
+        // External rewrites can register whole-document undo payloads for as
+        // long as a window remains open. Bound the stack like a conventional
+        // editor so a busy file cannot grow memory without limit.
+        undoManager.levelsOfUndo = 200
         undoManager.onDidApplyUndoRedo = { [weak self] in
             self?.finishUndoRedo()
         }
@@ -353,7 +365,7 @@ final class MarkdownDocument: NSObject {
         changes.reset()
         self.url = canonical
         self.fidelity = fidelity
-        self.state = DocumentStateStore.shared.state(for: canonical)
+        self.state = documentStateStore.state(for: canonical)
 
         suppressReparse = true
         storage.beginEditing()
@@ -374,8 +386,8 @@ final class MarkdownDocument: NSObject {
         let structure = MarkdownParser.parse(text, options: .structureOnly)
         parsed = structure
 
-        SnapshotStore.shared.record(text, for: canonical, kind: .baseline)
-        DocumentStateStore.shared.noteOpened(canonical, document: structure)
+        snapshotStore.record(text, for: canonical, kind: .baseline)
+        documentStateStore.noteOpened(canonical, document: structure)
 
         restoreReviewState(currentText: text)
 
@@ -417,7 +429,7 @@ final class MarkdownDocument: NSObject {
             return
         }
 
-        let stored = SnapshotStore.shared.content(forHash: storedBaseline)
+        let stored = snapshotStore.content(forHash: storedBaseline)
         guard case .text(let previous) = stored else {
             // The file moved and the old text is gone.  Keep the baseline hash
             // so a later write is still measured from the right place, and let
@@ -580,7 +592,7 @@ final class MarkdownDocument: NSObject {
                case .targetChanged(_, let generations) = ioError {
                 for data in generations {
                     if let decoded = try? DocumentIO.decodeSnapshot(data, sourceURL: url) {
-                        SnapshotStore.shared.record(decoded.text, for: url, kind: .external)
+                        snapshotStore.record(decoded.text, for: url, kind: .external)
                     }
                 }
             }
@@ -612,7 +624,7 @@ final class MarkdownDocument: NSObject {
         diskByteHash = DocumentIO.contentHash(encoded)
         lastCommittedText = text
         pendingConflict = nil
-        SnapshotStore.shared.record(text, for: url, kind: .local)
+        snapshotStore.record(text, for: url, kind: .local)
         setDirty(false)
         persistState()
         publishSavedState()
@@ -695,7 +707,7 @@ final class MarkdownDocument: NSObject {
     ) -> SaveError {
         pendingConflict = conflict
         if let incomingHash { diskHash = incomingHash }
-        if let url { SnapshotStore.shared.record(incoming, for: url, kind: .external) }
+        if let url { snapshotStore.record(incoming, for: url, kind: .external) }
         publishPresentationState(PresentationState(
             phase: .conflict,
             provenance: presentationState.provenance,
@@ -790,7 +802,7 @@ final class MarkdownDocument: NSObject {
         }
         state.lastOpened = Date()
         self.state = state
-        DocumentStateStore.shared.save(state, for: url)
+        documentStateStore.save(state, for: url)
     }
 
     /// Restores the reader's place from persisted state (§8.2).
@@ -1141,10 +1153,10 @@ final class MarkdownDocument: NSObject {
         guard canonical != url else { return }
         url = canonical
         state.path = canonical.path
-        DocumentStateStore.shared.save(state, for: canonical)
+        documentStateStore.save(state, for: canonical)
         // Seed the new key's history with what we are holding, so the timeline
         // does not start empty at the new name.
-        SnapshotStore.shared.record(storage.string, for: canonical, kind: .baseline)
+        snapshotStore.record(storage.string, for: canonical, kind: .baseline)
         onFileRenamed?(canonical)
     }
 
@@ -1207,6 +1219,7 @@ final class MarkdownDocument: NSObject {
         let generation = externalPreparationGeneration
         let capturedText = storage.string
         let baseline = effectiveBaselineText(fallback: capturedText)
+        let snapshotStore = snapshotStore
 
         // File I/O, history reservation, and the two Myers diffs are pure or
         // internally synchronized. Keeping them off the main actor is what
@@ -1223,7 +1236,7 @@ final class MarkdownDocument: NSObject {
             let currentHash = SnapshotStore.hash(capturedText)
             if incomingHash != currentHash,
                !Self.finalNewlineDifferenceOnlyValue(capturedText, incoming) {
-                SnapshotStore.shared.record(incoming, for: url, kind: .external)
+                snapshotStore.record(incoming, for: url, kind: .external)
             }
             let baselineHunks = incomingHash == currentHash
                 ? [] : TextDiff.hunks(old: baseline, new: incoming)
@@ -1407,7 +1420,14 @@ final class MarkdownDocument: NSObject {
         undoManager.beginUndoGrouping()
         undoManager.registerUndo(withTarget: self) { document in
             MainActor.assumeIsolated {
-                document.revertExternalBuffer(to: previous, incoming: incoming)
+                // Undo groups unwind last-in-first-out, so after newer local
+                // edits have unwound the buffer contains this generation's
+                // incoming text. Reading it here avoids retaining a second
+                // whole-document copy in every external-change undo group.
+                document.revertExternalBuffer(
+                    to: previous,
+                    incoming: document.storage.string
+                )
             }
         }
         undoManager.setActionName("External Change")
@@ -1529,13 +1549,13 @@ final class MarkdownDocument: NSObject {
 
     func versions() -> [SnapshotStore.VersionRecord] {
         guard let url else { return [] }
-        return SnapshotStore.shared.versions(for: url)
+        return snapshotStore.versions(for: url)
     }
 
     /// Whether a historical version can still be shown, so the timeline can
     /// distinguish "pruned" from "damaged" instead of showing an empty pane.
     func content(of version: SnapshotStore.VersionRecord) -> SnapshotStore.Content {
-        SnapshotStore.shared.content(for: version)
+        snapshotStore.content(for: version)
     }
 
     /// Restores a historical version into the buffer as a normal, undoable edit.
@@ -1543,7 +1563,7 @@ final class MarkdownDocument: NSObject {
     /// the next agent write is measured against what the user just chose.
     @discardableResult
     func restore(version: SnapshotStore.VersionRecord) -> Bool {
-        guard case .text(let text) = SnapshotStore.shared.content(for: version) else { return false }
+        guard case .text(let text) = snapshotStore.content(for: version) else { return false }
         let previous = storage.string
         let hunks = TextDiff.hunks(old: previous, new: text)
         replace(NSRange(location: 0, length: storage.length), with: text, actionName: "Restore Version")

--- a/Sources/DownrightApp/AI/PathResolver.swift
+++ b/Sources/DownrightApp/AI/PathResolver.swift
@@ -27,6 +27,8 @@ final class PathResolver {
     private let gitRoot: URL?
     private var cache: [String: Resolution] = [:]
     private let lock = NSLock()
+    private let warmQueue = DispatchQueue(label: "com.ezzy.downright.path-resolve", qos: .userInitiated)
+    private var generation: UInt64 = 0
 
     init(documentURL: URL?) {
         let directory = documentURL?.deletingLastPathComponent()
@@ -38,7 +40,58 @@ final class PathResolver {
     /// Invalidate after an external write — a file the agent just created
     /// should stop being underlined in red without reopening the document.
     func invalidate() {
-        lock.lock(); cache.removeAll(); lock.unlock()
+        lock.withLock {
+            cache.removeAll()
+            generation &+= 1
+        }
+    }
+
+    /// Returns only an answer already in memory. Decoration uses this API so a
+    /// cache miss can remain visually neutral while background warming stats
+    /// the filesystem; explicit user actions may still call `resolve`.
+    func cachedResolution(for token: PathToken) -> Resolution? {
+        lock.withLock {
+            guard let hit = cache[token.rawPath] else { return nil }
+            return Resolution(
+                url: hit.url,
+                exists: hit.exists,
+                isDirectory: hit.isDirectory,
+                line: token.line
+            )
+        }
+    }
+
+    /// Resolves unique path tokens off the main thread, then returns to the
+    /// main queue so the document can repaint from the warmed cache.
+    func warm(_ tokens: [PathToken], completion: @escaping () -> Void) {
+        guard !tokens.isEmpty else {
+            completion()
+            return
+        }
+        let (requestedGeneration, misses) = lock.withLock {
+            var seen = Set<String>()
+            let misses = tokens.filter {
+                seen.insert($0.rawPath).inserted && cache[$0.rawPath] == nil
+            }
+            return (generation, misses)
+        }
+        guard !misses.isEmpty else {
+            completion()
+            return
+        }
+        warmQueue.async { [self] in
+            var resolutions: [(String, Resolution)] = []
+            for token in misses {
+                resolutions.append((token.rawPath, computeResolution(for: token)))
+            }
+            let accepted = lock.withLock {
+                guard generation == requestedGeneration else { return false }
+                for (path, resolution) in resolutions { cache[path] = resolution }
+                return true
+            }
+            guard accepted else { return }
+            DispatchQueue.main.async(execute: completion)
+        }
     }
 
     func resolve(_ token: PathToken) -> Resolution {

--- a/Sources/DownrightApp/AI/SnapshotStore.swift
+++ b/Sources/DownrightApp/AI/SnapshotStore.swift
@@ -1,5 +1,6 @@
 import Foundation
 import MarkdownCore
+import Darwin
 
 /// Local time-travel (§8.3).
 ///
@@ -14,7 +15,7 @@ import MarkdownCore
 /// history/objects/<ab>/<hash>       zlib-compressed UTF-8 content
 /// history/index/<docKey>.json       ordered version list for one document
 /// ```
-final class SnapshotStore {
+final class SnapshotStore: @unchecked Sendable {
     static let shared = SnapshotStore()
 
     enum SnapshotKind: String, Codable {
@@ -115,15 +116,22 @@ final class SnapshotStore {
     /// reads and acknowledges its own count.
     private var evictedVersionsByDocument: [String: Int] = [:]
     private var lastReport = PruneReport()
+    private let historyDirectory: URL
+    private var abandonedCandidates: [String: String] = [:]
+    private let abandonedConfirmationDelay: TimeInterval = 30
 
-    private init() {
-        AppPaths.ensure(AppPaths.historyDirectory)
+    /// `historyDirectory` is injectable so maintenance tests can exercise real
+    /// filesystem behavior without ever traversing the user's production
+    /// Application Support store.
+    init(historyDirectory: URL = AppPaths.historyDirectory) {
+        self.historyDirectory = historyDirectory.standardizedFileURL
+        AppPaths.ensure(self.historyDirectory)
         AppPaths.ensure(objectsDirectory)
         AppPaths.ensure(indexDirectory)
     }
 
-    private var objectsDirectory: URL { AppPaths.historyDirectory.appendingPathComponent("objects", isDirectory: true) }
-    private var indexDirectory: URL { AppPaths.historyDirectory.appendingPathComponent("index", isDirectory: true) }
+    private var objectsDirectory: URL { historyDirectory.appendingPathComponent("objects", isDirectory: true) }
+    private var indexDirectory: URL { historyDirectory.appendingPathComponent("index", isDirectory: true) }
 
     // MARK: - Recording
 
@@ -223,7 +231,23 @@ final class SnapshotStore {
     /// window between its write and the matching index append.
     func schedulePrune() {
         queue.async { [self] in
+            lastPrune = Date()
             _ = prune()
+            queue.asyncAfter(deadline: .now() + abandonedConfirmationDelay) { [self] in
+                lastPrune = Date()
+                _ = prune()
+            }
+        }
+    }
+
+    /// Executes exactly one prune generation and waits for it. Destructive
+    /// filesystem tests use this instead of production's delayed confirmation.
+    func pruneOneGenerationForTesting() async {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            queue.async { [self] in
+                _ = prune()
+                continuation.resume()
+            }
         }
     }
 
@@ -312,10 +336,61 @@ final class SnapshotStore {
 
     // MARK: - Pruning
 
+    /// Pruning is primarily a launch job. This interval is only a backstop for
+    /// unusually long sessions that can cross the configured size caps.
+    private let pruneInterval: TimeInterval = 30 * 60
+
     private func pruneIfDue() {
-        guard Date().timeIntervalSince(lastPrune) > 300 else { return }
+        guard Date().timeIntervalSince(lastPrune) > pruneInterval else { return }
         lastPrune = Date()
         prune()
+    }
+
+    /// A missing path is abandoned only after its newest version has aged out
+    /// and the containing volume is mounted. This avoids deleting history for
+    /// an atomic replacement in flight or an unplugged external volume.
+    private func isAbandoned(_ index: Index, key: String, cutoff: Date) -> Bool {
+        guard let newest = index.versions.last, newest.date < cutoff else {
+            abandonedCandidates.removeValue(forKey: key)
+            return false
+        }
+        let presence = index.path.isEmpty ? PathPresence.absent : Self.pathPresence(for: index.path)
+        guard presence == .absent,
+              (index.path.isEmpty || Self.volumeIsMounted(for: index.path)) else {
+            abandonedCandidates.removeValue(forKey: key)
+            return false
+        }
+        // ENOENT is also the middle of an atomic replacement. Require the same
+        // old index to be absent in two distinct prune generations.
+        let signature = "\(index.path)\u{0}\(newest.hash)\u{0}\(newest.date.timeIntervalSinceReferenceDate)"
+        guard abandonedCandidates[key] == signature else {
+            abandonedCandidates[key] = signature
+            return false
+        }
+        return true
+    }
+
+    enum PathPresence: Equatable {
+        case present
+        case absent
+        case indeterminate
+    }
+
+    /// Uses `lstat` so permission and I/O failures are not collapsed into the
+    /// same answer as a confirmed missing path.
+    static func pathPresence(for path: String) -> PathPresence {
+        var info = stat()
+        if lstat(path, &info) == 0 { return .present }
+        switch errno {
+        case ENOENT, ENOTDIR: return .absent
+        default: return .indeterminate
+        }
+    }
+
+    static func volumeIsMounted(for path: String) -> Bool {
+        let components = (path as NSString).pathComponents
+        guard components.count > 2, components[1] == "Volumes" else { return true }
+        return pathPresence(for: "/Volumes/" + components[2]) == .present
     }
 
     /// Trims every document against the age cap and its **own** size budget,
@@ -337,12 +412,26 @@ final class SnapshotStore {
         var referenced = Set<String>()
         var newestHashes = Set<String>()
 
-        let indexes = (try? fm.contentsOfDirectory(at: indexDirectory, includingPropertiesForKeys: nil)) ?? []
+        guard let indexes = try? fm.contentsOfDirectory(
+            at: indexDirectory,
+            includingPropertiesForKeys: nil
+        ) else {
+            // No complete index inventory means no safe answer to "unreferenced".
+            // Fail closed and leave every object alone this generation.
+            recordPrune(report)
+            return report
+        }
+        var hasIncompleteReferenceKnowledge = false
+        var liveIndexes: [URL] = []
         for indexFile in indexes where indexFile.pathExtension == "json" {
+            let documentKey = indexFile.deletingPathExtension().lastPathComponent
             guard let data = try? Data(contentsOf: indexFile),
                   var index = try? JSONDecoder.snapshotDecoder.decode(Index.self, from: data)
-            else { continue }
-            let documentKey = indexFile.deletingPathExtension().lastPathComponent
+            else {
+                abandonedCandidates.removeValue(forKey: documentKey)
+                hasIncompleteReferenceKnowledge = true
+                continue
+            }
             let before = index.versions.count
 
             // Always keep the newest version even if it is older than the cap:
@@ -358,16 +447,47 @@ final class SnapshotStore {
                 total -= index.versions.removeFirst().byteCount
             }
 
+            if isAbandoned(index, key: documentKey, cutoff: cutoff) {
+                let removed = pendingLock.withLock {
+                    do {
+                        try fm.removeItem(at: indexFile)
+                    } catch {
+                        return false
+                    }
+                    // Atomic with deletion: a concurrent record must either
+                    // see the old durable index or reload the now-empty one.
+                    stateByDocument.removeValue(forKey: documentKey)
+                    stateOrder.removeAll { $0 == documentKey }
+                    return true
+                }
+                if removed {
+                    if before > 0 {
+                        report.droppedVersions[documentKey, default: 0] += before
+                    }
+                } else {
+                    liveIndexes.append(indexFile)
+                    referenced.formUnion(index.versions.map(\.hash))
+                    if let newest = index.versions.last?.hash { newestHashes.insert(newest) }
+                }
+                continue
+            }
+
             let dropped = before - index.versions.count
             if dropped > 0 { report.droppedVersions[documentKey, default: 0] += dropped }
 
-            if let encoded = try? JSONEncoder.snapshotEncoder.encode(index) {
+            if dropped > 0, let encoded = try? JSONEncoder.snapshotEncoder.encode(index) {
                 try? encoded.write(to: indexFile, options: .atomic)
             }
+            liveIndexes.append(indexFile)
             referenced.formUnion(index.versions.map(\.hash))
             if let newest = index.versions.last?.hash {
                 newestHashes.insert(newest)
             }
+        }
+
+        guard !hasIncompleteReferenceKnowledge else {
+            recordPrune(report)
+            return report
         }
 
         var objects = objectInventory()
@@ -399,7 +519,7 @@ final class SnapshotStore {
             return report
         }
 
-        for indexFile in indexes where indexFile.pathExtension == "json" {
+        for indexFile in liveIndexes {
             guard let data = try? Data(contentsOf: indexFile),
                   var index = try? JSONDecoder.snapshotDecoder.decode(Index.self, from: data)
             else { continue }
@@ -407,7 +527,8 @@ final class SnapshotStore {
             let before = index.versions.count
             index.versions.removeAll { dropped.contains($0.hash) }
             let removed = before - index.versions.count
-            if removed > 0 { report.droppedVersions[documentKey, default: 0] += removed }
+            guard removed > 0 else { continue }
+            report.droppedVersions[documentKey, default: 0] += removed
             if let encoded = try? JSONEncoder.snapshotEncoder.encode(index) {
                 try? encoded.write(to: indexFile, options: .atomic)
             }

--- a/Sources/DownrightApp/App/AppDelegate.swift
+++ b/Sources/DownrightApp/App/AppDelegate.swift
@@ -153,6 +153,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // History pruning at launch rather than on a timer: it touches the disk
         // and there is no reason to do it while the user is reading (§8.3).
         SnapshotStore.shared.schedulePrune()
+        DocumentStateStore.shared.schedulePruneAbandonedStates()
 
         hasFinishedLaunching = true
 

--- a/Sources/DownrightApp/App/DocumentWindowController+Delegates.swift
+++ b/Sources/DownrightApp/App/DocumentWindowController+Delegates.swift
@@ -177,7 +177,9 @@ extension DocumentWindowController: MarkdownTextViewDelegate {
 
     func markdownTextView(_ view: MarkdownTextView, pathExistsFor token: PathToken) -> Bool {
         guard Preferences.shared.values.resolvePathTokens else { return true }
-        return pathResolver?.resolve(token).exists ?? false
+        // Decoration is a main-thread operation. A cold cache is neutral until
+        // the revision-aware background warm completes and refreshes the view.
+        return pathResolver?.cachedResolution(for: token)?.exists ?? true
     }
 
     func markdownTextViewDidChangeSelection(_ view: MarkdownTextView) {

--- a/Sources/DownrightApp/App/DocumentWindowController.swift
+++ b/Sources/DownrightApp/App/DocumentWindowController.swift
@@ -103,6 +103,8 @@ final class DocumentWindowController: NSWindowController {
     // State
     var scanner: SiblingScanner?
     var pathResolver: PathResolver?
+    private var resolvesPathTokens = Preferences.shared.values.resolvePathTokens
+    private var isClearingDisabledPathState = false
     let findSession = FindSession()
     let jumpHistory = JumpHistory()
     var activeStyleSheet = DocumentWindowController.makeStyleSheet(
@@ -716,6 +718,20 @@ final class DocumentWindowController: NSWindowController {
             self.primaryContainer.textView.update(document: parsed, dirty: dirty)
             self.splitContainer?.textView.update(document: parsed, dirty: dirty)
             self.synchronizePanes(from: self.primaryContainer.textView)
+            if Preferences.shared.values.resolvePathTokens {
+                self.pathResolver?.warm(parsed.pathTokens.map(\.token)) { [weak self] in
+                    guard let self else { return }
+                    // Split panes share attributed storage. One bounded refresh
+                    // updates both without duplicating the attribute walk.
+                    for pane in self.documentPanes {
+                        pane.textView.invalidatePathExistenceCache()
+                    }
+                    self.primaryContainer.textView.refreshPathExistence()
+                    self.splitContainer?.textView.needsDisplay = true
+                }
+            } else if self.isClearingDisabledPathState {
+                self.clearDisabledPathState()
+            }
             self.scheduleDerivedUIRefresh()
             self.scheduleFindRefresh()
         }
@@ -799,6 +815,9 @@ final class DocumentWindowController: NSWindowController {
     }
 
     @objc private func preferencesDidChange() {
+        let shouldResolvePathTokens = Preferences.shared.values.resolvePathTokens
+        let pathResolutionChanged = shouldResolvePathTokens != resolvesPathTokens
+        resolvesPathTokens = shouldResolvePathTokens
         window?.applyThemeAppearance(for: ThemeStore.shared.current)
         activeStyleSheet = Self.makeStyleSheet(
             theme: ThemeStore.shared.current,
@@ -808,6 +827,47 @@ final class DocumentWindowController: NSWindowController {
         applyFocusMode(Preferences.shared.values.focusMode, animated: true)
         applyStatusBarPreference()
         rebuildSiblingScannerIfFoldersChanged()
+        if pathResolutionChanged {
+            refreshPathResolutionPreference(enabled: shouldResolvePathTokens)
+        }
+    }
+
+    private func refreshPathResolutionPreference(enabled: Bool) {
+        pathResolver?.invalidate()
+        for pane in documentPanes {
+            pane.textView.invalidatePathExistenceCache()
+        }
+        guard enabled else {
+            // The delegate returns neutral/exists while disabled, so this
+            // bounded pass removes any missing-path underline without I/O.
+            isClearingDisabledPathState = true
+            clearDisabledPathState()
+            return
+        }
+        isClearingDisabledPathState = false
+        pathResolver?.warm(markdownDocument.parsed.pathTokens.map(\.token)) { [weak self] in
+            guard let self, self.resolvesPathTokens else { return }
+            for pane in self.documentPanes {
+                pane.textView.invalidatePathExistenceCache()
+            }
+            self.primaryContainer.textView.refreshPathExistence()
+            self.splitContainer?.textView.needsDisplay = true
+        }
+    }
+
+    private func clearDisabledPathState() {
+        guard !resolvesPathTokens else {
+            isClearingDisabledPathState = false
+            return
+        }
+        for pane in documentPanes {
+            pane.textView.invalidatePathExistenceCache()
+        }
+        primaryContainer.textView.refreshPathExistence { [weak self] in
+            guard let self, !self.resolvesPathTokens else { return }
+            self.isClearingDisabledPathState = false
+            self.splitContainer?.textView.needsDisplay = true
+        }
     }
 
     /// The status bar is opt-in (DESIGN.md's "Avoid" list names a permanent
@@ -1206,6 +1266,8 @@ final class DocumentWindowController: NSWindowController {
         switch event {
         case .applied(let hunks):
             refreshChangeDecorations()
+            // The external parse commits asynchronously. Invalidate now; the
+            // matching onReparse callback warms the new revision's tokens.
             pathResolver?.invalidate()
             scheduleFindRefresh()
             guard !hunks.isEmpty else { return }
@@ -2354,12 +2416,12 @@ final class DocumentWindowController: NSWindowController {
         configureLocalAssetAccess(for: second.textView, documentURL: markdownDocument.url)
         second.textView.configuration = renderConfiguration
         let source = containerTextView
+        let sourceViewportOffset = source.topVisibleOffset
         second.textView.mode = source.mode
         second.textView.zoomLevel = source.zoomLevel
         second.textView.foldedHeadingSlugs = source.foldedHeadingSlugs
         second.textView.adoptSharedPresentation(from: source)
         second.textView.setSourceSelectedRanges(source.sourceSelectedRanges)
-        second.textView.scroll(toOffset: source.topVisibleOffset, position: .top, animated: false)
         splitContainer = second
 
         let split = ThemedSplitView(styleSheet: activeStyleSheet)
@@ -2379,6 +2441,13 @@ final class DocumentWindowController: NSWindowController {
         ])
         rootView.layoutSubtreeIfNeeded()
         split.setPosition(max(1, split.bounds.width / 2), ofDividerAt: 0)
+        // A detached text view has no viewport geometry, so scrolling it before
+        // `addArrangedSubview` silently lands at the document start. Establish
+        // the final pane widths first, then restore the source-space reading
+        // position the user was at when they opened the split.
+        split.layoutSubtreeIfNeeded()
+        second.textView.resizeToFitContent()
+        second.textView.scroll(toOffset: sourceViewportOffset, position: .top, animated: false)
         splitViewContainer = split
         markdownDocument.state.splitViewEnabled = true
         if isFocusModeEnabled { installFocusDimmingView(in: second) }

--- a/Sources/MarkdownRender/View/MarkdownTextView.swift
+++ b/Sources/MarkdownRender/View/MarkdownTextView.swift
@@ -432,6 +432,7 @@ public final class MarkdownTextView: NSTextView {
     private var objectChangeMarks: [ChangeMark] = []
     private var fragmentAccessibilityElements: [NSAccessibilityElement] = []
     private var pathExistence: [PathToken: Bool] = [:]
+    private var pathRefreshGeneration: UInt = 0
     private var codeCollapseOverrides: [Int: Bool] = [:]
     private var invisiblesApplied = false
     private var hoverTracking: NSTrackingArea?
@@ -2421,6 +2422,87 @@ public final class MarkdownTextView: NSTextView {
             let colour = styleSheet.changeColor(mark.kind)
             context.setFillColor(colour.withAlphaComponent(mark.visited ? 0.3 : 0.75).cgColor)
             context.fill(band)
+        }
+    }
+
+    /// Re-runs path-existence styling after the resolver has warmed its cache.
+    public func refreshPathExistence(completion: (() -> Void)? = nil) {
+        invalidatePathExistenceCache()
+        let refreshGeneration = pathRefreshGeneration
+        let documentGeneration = updateGeneration
+        guard !parsedDocument.pathTokens.isEmpty else {
+            completion?()
+            return
+        }
+        refreshPathExistence(
+            parsedDocument.pathTokens,
+            from: 0,
+            documentGeneration: documentGeneration,
+            refreshGeneration: refreshGeneration,
+            completion: completion
+        )
+    }
+
+    /// Split panes share attributed storage but keep independent lookup caches.
+    /// Clear every pane before one owner repairs the shared attributes.
+    public func invalidatePathExistenceCache() {
+        pathRefreshGeneration &+= 1
+        pathExistence.removeAll(keepingCapacity: true)
+    }
+
+    /// Attribute repair is bounded per main-loop turn. Agent-generated reports
+    /// can contain thousands of path tokens; applying all of them in one
+    /// NSTextStorage edit would simply move the external-rewrite hitch from
+    /// filesystem lookup to decoration.
+    private func refreshPathExistence(
+        _ tokens: [ResolvableToken],
+        from start: Int,
+        documentGeneration: Int,
+        refreshGeneration: UInt,
+        completion: (() -> Void)?
+    ) {
+        guard updateGeneration == documentGeneration,
+              pathRefreshGeneration == refreshGeneration,
+              let storage = textStorage,
+              start < tokens.count else { return }
+
+        let end = min(start + 128, tokens.count)
+        storage.beginEditing()
+        for resolvable in tokens[start..<end] {
+            guard let range = clampToStorage(resolvable.range) else { continue }
+            let exists = markdownDelegate?.markdownTextView(
+                self,
+                pathExistsFor: resolvable.token
+            ) ?? true
+            pathExistence[resolvable.token] = exists
+            storage.addAttribute(.drPathExists, value: exists, range: range)
+            if exists {
+                storage.addAttribute(.foregroundColor, value: styleSheet.textSecondary, range: range)
+                storage.removeAttribute(.underlineStyle, range: range)
+                storage.removeAttribute(.underlineColor, range: range)
+            } else {
+                storage.addAttributes([
+                    .foregroundColor: styleSheet.textSecondary,
+                    .underlineStyle: NSUnderlineStyle.patternDot.rawValue | NSUnderlineStyle.single.rawValue,
+                    .underlineColor: styleSheet.textFaint,
+                ], range: range)
+            }
+        }
+        storage.endEditing()
+        needsDisplay = true
+
+        guard end < tokens.count else {
+            completion?()
+            return
+        }
+        DispatchQueue.main.async { [weak self] in
+            self?.refreshPathExistence(
+                tokens,
+                from: end,
+                documentGeneration: documentGeneration,
+                refreshGeneration: refreshGeneration,
+                completion: completion
+            )
         }
     }
 

--- a/Tests/DownrightAppTests/AppLayerTests.swift
+++ b/Tests/DownrightAppTests/AppLayerTests.swift
@@ -125,10 +125,11 @@ struct AppLayerTests {
     // MARK: - Snapshot store (§8.3)
 
     @Test func snapshotStoreDeduplicatesAndRestores() async throws {
-        let store = SnapshotStore.shared
-        let url = URL(fileURLWithPath: NSTemporaryDirectory())
-            .appendingPathComponent("downright-test-\(UUID().uuidString).md")
-        defer { store.forget(url) }
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("downright-store-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = SnapshotStore(historyDirectory: root.appendingPathComponent("history"))
+        let url = root.appendingPathComponent("document.md")
 
         let first = "# One\n\nBody.\n"
         let second = "# One\n\nBody, revised.\n"
@@ -145,6 +146,315 @@ struct AppLayerTests {
         #expect(versions.count == 2)
         #expect(store.text(for: versions[0]) == first)
         #expect(store.text(for: versions[1]) == second)
+    }
+
+    private func snapshotIndexFile(for url: URL, historyDirectory: URL) -> URL {
+        historyDirectory
+            .appendingPathComponent("index", isDirectory: true)
+            .appendingPathComponent(SnapshotStore.documentKey(for: url) + ".json")
+    }
+
+    private func writeSnapshotIndex(path: String, age: TimeInterval, to file: URL) throws {
+        let stamp = ISO8601DateFormatter().string(from: Date().addingTimeInterval(-age))
+        let encodedPath = try #require(String(data: JSONEncoder().encode(path), encoding: .utf8))
+        let json = """
+        {"path":\(encodedPath),"versions":[{"hash":"\(String(repeating: "a", count: 64))",\
+        "date":"\(stamp)","byteCount":12,"kind":"external"}]}
+        """
+        AppPaths.ensure(file.deletingLastPathComponent())
+        try Data(json.utf8).write(to: file, options: .atomic)
+    }
+
+    private func ageSnapshotIndex(_ file: URL, by age: TimeInterval) throws {
+        let data = try Data(contentsOf: file)
+        var json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        var versions = try #require(json["versions"] as? [[String: Any]])
+        versions[versions.count - 1]["date"] = ISO8601DateFormatter().string(
+            from: Date().addingTimeInterval(-age)
+        )
+        json["versions"] = versions
+        try JSONSerialization.data(withJSONObject: json).write(to: file, options: .atomic)
+    }
+
+    private func runSnapshotPrune(_ store: SnapshotStore) async {
+        await store.pruneOneGenerationForTesting()
+    }
+
+    @Test func pruneForgetsOldHistoryForMissingDocument() async throws {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("downright-prune-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let historyDirectory = root.appendingPathComponent("history", isDirectory: true)
+        let store = SnapshotStore(historyDirectory: historyDirectory)
+        let url = root.appendingPathComponent("gone.md")
+        let file = snapshotIndexFile(for: url, historyDirectory: historyDirectory)
+
+        let text = "gone but cached\n"
+        #expect(store.record(text, for: url, kind: .baseline) != nil)
+        await store.waitForPendingWrites()
+        try ageSnapshotIndex(file, by: 90 * 24 * 60 * 60)
+        await runSnapshotPrune(store)
+        #expect(FileManager.default.fileExists(atPath: file.path), "one ENOENT can be an atomic replacement gap")
+        await runSnapshotPrune(store)
+        #expect(!FileManager.default.fileExists(atPath: file.path))
+
+        #expect(
+            store.record(text, for: url, kind: .baseline) != nil,
+            "deleting an abandoned index must atomically invalidate its loaded newest-hash cache"
+        )
+        await store.waitForPendingWrites()
+        #expect(FileManager.default.fileExists(atPath: file.path))
+    }
+
+    @Test func pruneRequiresConsecutiveAbsenceAndForgetsARestoredGap() async throws {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("downright-prune-gap-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let historyDirectory = root.appendingPathComponent("history", isDirectory: true)
+        let store = SnapshotStore(historyDirectory: historyDirectory)
+        let url = root.appendingPathComponent("temporarily-missing.md")
+        let file = snapshotIndexFile(for: url, historyDirectory: historyDirectory)
+        try writeSnapshotIndex(path: url.path, age: 90 * 24 * 60 * 60, to: file)
+
+        await runSnapshotPrune(store)
+        try Data("restored\n".utf8).write(to: url)
+        await runSnapshotPrune(store)
+        try FileManager.default.removeItem(at: url)
+        await runSnapshotPrune(store)
+        #expect(FileManager.default.fileExists(atPath: file.path), "a restored path resets absence confirmation")
+        await runSnapshotPrune(store)
+        #expect(!FileManager.default.fileExists(atPath: file.path))
+    }
+
+    @Test func pruneKeepsHistoryWhenPathLookupIsUnreadable() async throws {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("downright-prune-permission-\(UUID().uuidString)", isDirectory: true)
+        let locked = root.appendingPathComponent("locked", isDirectory: true)
+        try FileManager.default.createDirectory(at: locked, withIntermediateDirectories: true)
+        defer {
+            try? FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: locked.path)
+            try? FileManager.default.removeItem(at: root)
+        }
+        let target = locked.appendingPathComponent("document.md")
+        try Data("private\n".utf8).write(to: target)
+        let historyDirectory = root.appendingPathComponent("history", isDirectory: true)
+        let store = SnapshotStore(historyDirectory: historyDirectory)
+        let file = snapshotIndexFile(for: target, historyDirectory: historyDirectory)
+        try writeSnapshotIndex(path: target.path, age: 90 * 24 * 60 * 60, to: file)
+        try FileManager.default.setAttributes([.posixPermissions: 0], ofItemAtPath: locked.path)
+
+        #expect(SnapshotStore.pathPresence(for: target.path) == .indeterminate)
+        await runSnapshotPrune(store)
+        await runSnapshotPrune(store)
+        #expect(FileManager.default.fileExists(atPath: file.path))
+    }
+
+    @Test func pruneKeepsObjectsWhenIndexDirectoryCannotBeListed() async throws {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("downright-prune-index-directory-\(UUID().uuidString)", isDirectory: true)
+        let historyDirectory = root.appendingPathComponent("history", isDirectory: true)
+        let indexDirectory = historyDirectory.appendingPathComponent("index", isDirectory: true)
+        defer {
+            try? FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: indexDirectory.path)
+            try? FileManager.default.removeItem(at: root)
+        }
+        let store = SnapshotStore(historyDirectory: historyDirectory)
+        let document = root.appendingPathComponent("document.md")
+        let text = "must survive an unreadable index directory\n"
+        let record = try #require(store.record(text, for: document, kind: .baseline))
+        await store.waitForPendingWrites()
+        try FileManager.default.setAttributes([.posixPermissions: 0], ofItemAtPath: indexDirectory.path)
+
+        await runSnapshotPrune(store)
+
+        try FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: indexDirectory.path)
+        #expect(store.content(for: record) == .text(text))
+    }
+
+    @Test func pruneKeepsObjectsWhenAnyIndexIsCorrupt() async throws {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("downright-prune-corrupt-index-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let historyDirectory = root.appendingPathComponent("history", isDirectory: true)
+        let store = SnapshotStore(historyDirectory: historyDirectory)
+        let document = root.appendingPathComponent("document.md")
+        let text = "must survive a corrupt index\n"
+        let record = try #require(store.record(text, for: document, kind: .baseline))
+        await store.waitForPendingWrites()
+        let index = snapshotIndexFile(for: document, historyDirectory: historyDirectory)
+        try Data("not json".utf8).write(to: index, options: .atomic)
+
+        await runSnapshotPrune(store)
+
+        #expect(store.content(for: record) == .text(text))
+    }
+
+    @Test func pruneKeepsObjectsWhenAnyIndexFileIsUnreadable() async throws {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("downright-prune-unreadable-index-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let historyDirectory = root.appendingPathComponent("history", isDirectory: true)
+        let store = SnapshotStore(historyDirectory: historyDirectory)
+        let document = root.appendingPathComponent("document.md")
+        let text = "must survive an unreadable index file\n"
+        let record = try #require(store.record(text, for: document, kind: .baseline))
+        await store.waitForPendingWrites()
+        let index = snapshotIndexFile(for: document, historyDirectory: historyDirectory)
+        try FileManager.default.setAttributes([.posixPermissions: 0], ofItemAtPath: index.path)
+        defer { try? FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: index.path) }
+
+        await runSnapshotPrune(store)
+
+        try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: index.path)
+        #expect(store.content(for: record) == .text(text))
+    }
+
+    @Test func pruneKeepsOldHistoryForLiveDocument() async throws {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("downright-prune-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let historyDirectory = root.appendingPathComponent("history", isDirectory: true)
+        let store = SnapshotStore(historyDirectory: historyDirectory)
+        let url = root.appendingPathComponent("live.md")
+        try Data("# Live\n".utf8).write(to: url)
+        let file = snapshotIndexFile(for: url, historyDirectory: historyDirectory)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        try writeSnapshotIndex(path: url.path, age: 90 * 24 * 60 * 60, to: file)
+        await runSnapshotPrune(store)
+        #expect(FileManager.default.fileExists(atPath: file.path))
+    }
+
+    @Test func pruneDoesNotRewriteUnchangedIndex() async throws {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("downright-prune-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let historyDirectory = root.appendingPathComponent("history", isDirectory: true)
+        let store = SnapshotStore(historyDirectory: historyDirectory)
+        let url = root.appendingPathComponent("stable.md")
+        try Data("# Stable\n".utf8).write(to: url)
+        let file = snapshotIndexFile(for: url, historyDirectory: historyDirectory)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        store.record("# Stable\n", for: url, kind: .baseline)
+        await store.waitForPendingWrites()
+        let mark = Date(timeIntervalSince1970: 1_000_000)
+        try FileManager.default.setAttributes([.modificationDate: mark], ofItemAtPath: file.path)
+        await runSnapshotPrune(store)
+
+        let attributes = try FileManager.default.attributesOfItem(atPath: file.path)
+        #expect(attributes[.modificationDate] as? Date == mark)
+    }
+
+    @Test func abandonedReadingStateIsCollectedButLiveStateRemains() throws {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("downright-state-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let live = root.appendingPathComponent("live.md")
+        try Data("# Live\n".utf8).write(to: live)
+        let recent = root.appendingPathComponent("recent.md")
+        let stale = root.appendingPathComponent("stale.md")
+        let supportDirectory = root.appendingPathComponent("support", isDirectory: true)
+        let store = DocumentStateStore(supportDirectory: supportDirectory)
+        func stateFile(_ url: URL) -> URL {
+            supportDirectory.appendingPathComponent("state", isDirectory: true)
+                .appendingPathComponent(SnapshotStore.documentKey(for: url) + ".json")
+        }
+        defer {
+            for url in [live, recent, stale] {
+                try? FileManager.default.removeItem(at: stateFile(url))
+            }
+        }
+
+        for url in [live, recent] {
+            var state = DocumentState(path: url.path)
+            state.lastOpened = Date()
+            store.save(state, for: url)
+        }
+        var oldState = DocumentState(path: stale.path)
+        oldState.lastOpened = .distantPast
+        store.save(oldState, for: stale)
+
+        store.pruneAbandonedStates()
+
+        #expect(FileManager.default.fileExists(atPath: stateFile(live).path))
+        #expect(FileManager.default.fileExists(atPath: stateFile(recent).path))
+        #expect(FileManager.default.fileExists(atPath: stateFile(stale).path))
+        store.pruneAbandonedStates()
+        #expect(!FileManager.default.fileExists(atPath: stateFile(stale).path))
+    }
+
+    @Test func readingStatePruneForgetsTransientAbsenceAfterRestore() throws {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("downright-state-gap-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let support = root.appendingPathComponent("support", isDirectory: true)
+        let store = DocumentStateStore(supportDirectory: support)
+        let document = root.appendingPathComponent("document.md")
+        let stateFile = support.appendingPathComponent("state", isDirectory: true)
+            .appendingPathComponent(SnapshotStore.documentKey(for: document) + ".json")
+        var state = DocumentState(path: document.path)
+        state.lastOpened = .distantPast
+        store.save(state, for: document)
+
+        store.pruneAbandonedStates()
+        try Data("restored\n".utf8).write(to: document)
+        store.pruneAbandonedStates()
+        try FileManager.default.removeItem(at: document)
+        store.pruneAbandonedStates()
+        #expect(FileManager.default.fileExists(atPath: stateFile.path))
+        store.pruneAbandonedStates()
+        #expect(!FileManager.default.fileExists(atPath: stateFile.path))
+    }
+
+    @Test func scheduledReadingStatePruneReachesDelayedConfirmation() async throws {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("downright-state-scheduled-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let support = root.appendingPathComponent("support", isDirectory: true)
+        let store = DocumentStateStore(
+            supportDirectory: support,
+            abandonedStateConfirmationDelay: 0.05
+        )
+        let document = root.appendingPathComponent("missing.md")
+        let stateFile = support.appendingPathComponent("state", isDirectory: true)
+            .appendingPathComponent(SnapshotStore.documentKey(for: document) + ".json")
+        var state = DocumentState(path: document.path)
+        state.lastOpened = .distantPast
+        store.save(state, for: document)
+
+        store.schedulePruneAbandonedStates()
+        let deadline = Date().addingTimeInterval(1)
+        while FileManager.default.fileExists(atPath: stateFile.path), Date() < deadline {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(!FileManager.default.fileExists(atPath: stateFile.path))
+    }
+
+    @Test func freshReadingStateCancelsPendingAbandonment() throws {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("downright-state-refresh-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let support = root.appendingPathComponent("support", isDirectory: true)
+        let store = DocumentStateStore(supportDirectory: support)
+        let document = root.appendingPathComponent("missing.md")
+        let stateFile = support.appendingPathComponent("state", isDirectory: true)
+            .appendingPathComponent(SnapshotStore.documentKey(for: document) + ".json")
+        var stale = DocumentState(path: document.path)
+        stale.lastOpened = .distantPast
+        store.save(stale, for: document)
+        store.pruneAbandonedStates()
+
+        var fresh = DocumentState(path: document.path)
+        fresh.lastOpened = Date()
+        fresh.selectionLocation = 42
+        store.save(fresh, for: document)
+        store.pruneAbandonedStates()
+
+        #expect(FileManager.default.fileExists(atPath: stateFile.path))
+        #expect(store.state(for: document).selectionLocation == 42)
     }
 
     @Test func contentHashIsStable() {
@@ -377,6 +687,61 @@ struct AppLayerTests {
             !resolver.resolve(PathToken(rawPath: "src/auth/session.ts", line: 42)).exists,
             "a file the agent claims to have touched that isn't there must resolve as missing"
         )
+    }
+
+    @Test @MainActor
+    func pathResolverWarmsCacheAndReturnsOnMainQueue() async throws {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("downright-path-warm-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        try Data("ready\n".utf8).write(to: root.appendingPathComponent("ready.md"))
+
+        let resolver = PathResolver(documentURL: root.appendingPathComponent("document.md"))
+        #expect(resolver.cachedResolution(for: PathToken(rawPath: "ready.md")) == nil)
+        await withCheckedContinuation { continuation in
+            resolver.warm([
+                PathToken(rawPath: "ready.md"),
+                PathToken(rawPath: "ready.md", line: 9),
+                PathToken(rawPath: "missing.md"),
+            ]) {
+                #expect(Thread.isMainThread)
+                continuation.resume()
+            }
+        }
+
+        #expect(resolver.resolve(PathToken(rawPath: "ready.md", line: 9)).exists)
+        #expect(resolver.resolve(PathToken(rawPath: "ready.md", line: 9)).line == 9)
+        #expect(!resolver.resolve(PathToken(rawPath: "missing.md")).exists)
+        #expect(resolver.cachedResolution(for: PathToken(rawPath: "ready.md"))?.exists == true)
+
+        try FileManager.default.removeItem(at: root.appendingPathComponent("ready.md"))
+        await withCheckedContinuation { continuation in
+            resolver.warm([PathToken(rawPath: "ready.md")]) { continuation.resume() }
+        }
+        #expect(
+            resolver.cachedResolution(for: PathToken(rawPath: "ready.md"))?.exists == true,
+            "a current-generation cache hit must not be restatted on every reparse"
+        )
+    }
+
+    @Test @MainActor
+    func newlyParsedPathTokenRemainsUncachedUntilBackgroundWarmCompletes() async throws {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("downright-new-path-token-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let resolver = PathResolver(documentURL: root.appendingPathComponent("document.md"))
+        let newToken = PathToken(rawPath: "generated.md")
+
+        // This token represents one introduced by the new parse after an
+        // external rewrite. Decoration must not synchronously stat it.
+        #expect(resolver.cachedResolution(for: newToken) == nil)
+        try Data("generated\n".utf8).write(to: root.appendingPathComponent(newToken.rawPath))
+        await withCheckedContinuation { continuation in
+            resolver.warm([newToken]) { continuation.resume() }
+        }
+        #expect(resolver.cachedResolution(for: newToken)?.exists == true)
     }
 
     @Test func gitRootDiscoveryStopsAtTheRepository() throws {

--- a/Tests/DownrightAppTests/EditingKeyReproTests.swift
+++ b/Tests/DownrightAppTests/EditingKeyReproTests.swift
@@ -484,6 +484,64 @@ struct EditingKeyReproTests {
         #expect(abs((primary.enclosingScrollView?.contentView.bounds.origin.y ?? 0) - splitViewport) < 1)
     }
 
+    @Test("opening split view preserves the current reading position")
+    func openingSplitViewPreservesCurrentReadingPosition() throws {
+        let url = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("EditingKeyReproSplitOpen-\(UUID().uuidString).md")
+        defer { try? FileManager.default.removeItem(at: url) }
+        let text = (0..<60).map {
+            "## Section \($0)\n\nParagraph \($0) keeps the split opening at the current reading position."
+        }.joined(separator: "\n\n")
+        let controller = try makeController(text: text, file: url)
+        defer { controller.close() }
+
+        controller.showWindow(nil)
+        controller.window?.makeKeyAndOrderFront(nil)
+        controller.window?.setContentSize(NSSize(width: 1000, height: 640))
+        controller.window?.layoutIfNeeded()
+        let primary = controller.primaryContainer.textView
+        primary.resizeToFitContent()
+        let target = (text as NSString).range(of: "Section 40").location
+        primary.scroll(toOffset: target, position: .top, animated: false)
+        let expected = primary.topVisibleOffset
+        #expect(expected > 0)
+
+        controller.toggleSplitView()
+        controller.window?.layoutIfNeeded()
+        let split = try #require(controller.splitContainer?.textView)
+        split.resizeToFitContent()
+
+        // The half-width pane can resolve the same rendered heading to either
+        // side of its hidden Markdown marker. Both offsets are the same line.
+        #expect(abs(split.topVisibleOffset - expected) < 8)
+    }
+
+    @Test("enabling path resolution warms the open document immediately")
+    func enablingPathResolutionWarmsCurrentDocument() async throws {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("EditingKeyReproPathPreference-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let url = root.appendingPathComponent("document.md")
+        try Data("ready\n".utf8).write(to: root.appendingPathComponent("generated.md"))
+
+        let original = Preferences.shared.values.resolvePathTokens
+        Preferences.shared.update { $0.resolvePathTokens = false }
+        defer { Preferences.shared.update { $0.resolvePathTokens = original } }
+        let controller = try makeController(text: "`generated.md`", file: url)
+        defer { controller.close() }
+        let token = PathToken(rawPath: "generated.md")
+        #expect(controller.pathResolver?.cachedResolution(for: token) == nil)
+
+        Preferences.shared.update { $0.resolvePathTokens = true }
+        let deadline = Date().addingTimeInterval(2)
+        while controller.pathResolver?.cachedResolution(for: token) == nil,
+              Date() < deadline {
+            await Task.yield()
+        }
+        #expect(controller.pathResolver?.cachedResolution(for: token)?.exists == true)
+    }
+
     @Test("Tab after live edits cannot stack fragments or move the camera")
     func tabAfterLiveEditsKeepsLayoutAndViewportStable() throws {
         let url = URL(fileURLWithPath: NSTemporaryDirectory())

--- a/Tests/DownrightAppTests/ReviewBaselineTests.swift
+++ b/Tests/DownrightAppTests/ReviewBaselineTests.swift
@@ -39,6 +39,18 @@ struct ReviewBaselineTests {
         return root
     }
 
+    @MainActor
+    private static func makeIsolatedDocument(in root: URL) -> MarkdownDocument {
+        let support = root.appendingPathComponent("support", isDirectory: true)
+        return MarkdownDocument(
+            parseWorker: MarkdownParseWorker(),
+            snapshotStore: SnapshotStore(
+                historyDirectory: support.appendingPathComponent("history", isDirectory: true)
+            ),
+            documentStateStore: DocumentStateStore(supportDirectory: support)
+        )
+    }
+
     private static let original = """
     # Report
 
@@ -73,7 +85,7 @@ struct ReviewBaselineTests {
         let url = root.appendingPathComponent("report.md")
         try Data(Self.original.utf8).write(to: url)
 
-        let document = MarkdownDocument()
+        let document = Self.makeIsolatedDocument(in: root)
         try document.open(url)
         defer { document.close() }
 
@@ -114,7 +126,7 @@ struct ReviewBaselineTests {
         let url = root.appendingPathComponent("report.md")
         try Data(Self.original.utf8).write(to: url)
 
-        let document = MarkdownDocument()
+        let document = Self.makeIsolatedDocument(in: root)
         try document.open(url)
         defer { document.close() }
 
@@ -453,5 +465,62 @@ struct ReviewBaselineTests {
         // The save that would have failed for no visible reason is now refused
         // with the conflict already on screen.
         #expect(throws: SaveError.self) { try document.save() }
+    }
+
+    @Test @MainActor
+    func undoWalksBackThroughBurstOfExternalWrites() async throws {
+        let root = try Self.makeSandbox()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let url = root.appendingPathComponent("report.md")
+        try Data(Self.original.utf8).write(to: url)
+
+        let document = Self.makeIsolatedDocument(in: root)
+        try document.open(url)
+        defer { document.close() }
+
+        for write in Self.writes {
+            try Data(write.utf8).write(to: url)
+            document.handleExternalWrite()
+            document.flushPendingExternalWrite()
+            #expect(await waitForExternalText(write, in: document))
+        }
+
+        for expected in Self.writes.dropLast().reversed() {
+            document.undoManager.undo()
+            #expect(document.text == expected)
+        }
+        document.undoManager.undo()
+        #expect(document.text == Self.original)
+    }
+
+    @Test @MainActor
+    func redoRestoresExternalVersion() async throws {
+        let root = try Self.makeSandbox()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let url = root.appendingPathComponent("report.md")
+        try Data(Self.original.utf8).write(to: url)
+
+        let document = Self.makeIsolatedDocument(in: root)
+        try document.open(url)
+        defer { document.close() }
+
+        try Data(Self.writes[2].utf8).write(to: url)
+        document.handleExternalWrite()
+        document.flushPendingExternalWrite()
+        #expect(await waitForExternalText(Self.writes[2], in: document))
+
+        document.undoManager.undo()
+        #expect(document.text == Self.original)
+        document.undoManager.redo()
+        #expect(document.text == Self.writes[2])
+    }
+
+    @Test @MainActor
+    func externalChangeUndoStackIsBounded() {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("downright-undo-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let document = Self.makeIsolatedDocument(in: root)
+        #expect(document.undoManager.levelsOfUndo == 200)
     }
 }

--- a/Tests/DownrightUITests/DownrightActivatedAppTests.swift
+++ b/Tests/DownrightUITests/DownrightActivatedAppTests.swift
@@ -109,6 +109,43 @@ final class DownrightActivatedAppTests: XCTestCase {
         add(XCTAttachment(screenshot: window.screenshot()))
     }
 
+    func testSplitViewCreatesTwoInteractiveDocumentPanes() throws {
+        app.launch()
+        app.activate()
+        XCTAssertTrue(app.wait(for: .runningForeground, timeout: 20))
+
+        let window = app.windows.firstMatch
+        XCTAssertTrue(window.waitForExistence(timeout: 15))
+
+        let windowMenu = app.menuBars.menuBarItems["Window"]
+        XCTAssertTrue(windowMenu.waitForExistence(timeout: 10), "the Window menu was not built")
+        windowMenu.click()
+        let splitView = app.menuItems["Split View"]
+        XCTAssertTrue(splitView.waitForExistence(timeout: 10), "the split-view command is missing")
+        XCTAssertTrue(splitView.isEnabled, "the split-view command is disabled for a document")
+        splitView.click()
+
+        let editors = window.textViews.matching(identifier: "Document editor")
+        XCTAssertEqual(editors.count, 2, "split view did not expose two document editors")
+        let left = editors.element(boundBy: 0)
+        let right = editors.element(boundBy: 1)
+        XCTAssertTrue(left.isHittable)
+        XCTAssertTrue(right.isHittable)
+        XCTAssertLessThan(left.frame.midX, right.frame.midX)
+        let splitScreenshot = XCTAttachment(screenshot: window.screenshot())
+        splitScreenshot.lifetime = .keepAlways
+        add(splitScreenshot)
+
+        right.click()
+        right.typeText("!")
+
+        windowMenu.click()
+        app.menuItems["Split View"].click()
+        XCTAssertEqual(window.textViews.matching(identifier: "Document editor").count, 1)
+        let survivingValue = window.textViews["Document editor"].value as? String
+        XCTAssertTrue(survivingValue?.contains("!") == true)
+    }
+
     /// Release-only smoke coverage for the path that previously crashed:
     /// launch a production-configured app built as an older version, invoke
     /// the real menu command, let Sparkle drive the custom panel through its

--- a/Tests/MarkdownRenderTests/TypingInvalidationTests.swift
+++ b/Tests/MarkdownRenderTests/TypingInvalidationTests.swift
@@ -4,6 +4,100 @@ import MarkdownCore
 import Testing
 
 @MainActor
+private final class PathExistenceProbe: MarkdownTextViewDelegate {
+    private(set) var calls = 0
+    var exists = true
+
+    func markdownTextView(_ view: MarkdownTextView, pathExistsFor token: PathToken) -> Bool {
+        calls += 1
+        return exists
+    }
+}
+
+@MainActor
+@Test("Split panes cannot restore stale path existence after a shared refresh")
+func splitPathCachesInvalidateTogether() throws {
+    let text = "`fixtures/report.md`"
+    let document = MarkdownParser.parse(text)
+    let token = try #require(document.pathTokens.first)
+    let storage = NSTextStorage(string: text)
+    let primary = MarkdownTextView(frame: .zero, storage: storage)
+    let split = MarkdownTextView(frame: .zero, storage: storage)
+    let probe = PathExistenceProbe()
+    probe.exists = false
+    primary.markdownDelegate = probe
+    split.markdownDelegate = probe
+    primary.update(document: document, dirty: .wholesale)
+    split.update(document: document, dirty: .wholesale)
+    #expect(storage.attribute(.drPathExists, at: token.range.location, effectiveRange: nil) as? Bool == false)
+
+    probe.exists = true
+    primary.invalidatePathExistenceCache()
+    split.invalidatePathExistenceCache()
+    primary.refreshPathExistence()
+    #expect(storage.attribute(.drPathExists, at: token.range.location, effectiveRange: nil) as? Bool == true)
+
+    split.update(document: document, dirty: DirtySet(ranges: [token.range], isWholesale: false))
+    #expect(storage.attribute(.drPathExists, at: token.range.location, effectiveRange: nil) as? Bool == true)
+}
+
+@MainActor
+@Test("Dense path refreshes yield between bounded attribute batches")
+func densePathRefreshIsChunked() async throws {
+    let text = (0..<512).map { "`fixtures/file-\($0).md`" }.joined(separator: "\n")
+    let document = MarkdownParser.parse(text)
+    #expect(document.pathTokens.count == 512)
+
+    let storage = NSTextStorage(string: text)
+    let view = MarkdownTextView(
+        frame: NSRect(x: 0, y: 0, width: 720, height: 420),
+        storage: storage
+    )
+    view.update(document: document, dirty: .wholesale)
+    let probe = PathExistenceProbe()
+    view.markdownDelegate = probe
+
+    view.refreshPathExistence()
+    #expect(probe.calls == 128, "the first main-loop turn must stay bounded")
+
+    let deadline = Date().addingTimeInterval(2)
+    while probe.calls < document.pathTokens.count, Date() < deadline {
+        await Task.yield()
+    }
+    #expect(probe.calls == document.pathTokens.count)
+}
+
+@MainActor
+@Test("A cancelled dense path clear can restart after a parse commit")
+func cancelledDensePathClearRestarts() async throws {
+    let text = (0..<512).map { "`missing/file-\($0).md`" }.joined(separator: "\n")
+    let document = MarkdownParser.parse(text)
+    let storage = NSTextStorage(string: text)
+    let view = MarkdownTextView(frame: .zero, storage: storage)
+    let probe = PathExistenceProbe()
+    probe.exists = false
+    view.markdownDelegate = probe
+    view.update(document: document, dirty: .wholesale)
+
+    probe.exists = true
+    view.refreshPathExistence()
+    #expect(probe.calls >= 128)
+    // A parse commit cancels the remaining scheduled batches.
+    view.update(document: document, dirty: DirtySet(ranges: [document.pathTokens[0].range], isWholesale: false))
+    view.refreshPathExistence()
+
+    let deadline = Date().addingTimeInterval(2)
+    while Date() < deadline {
+        let allNeutral = document.pathTokens.allSatisfy {
+            storage.attribute(.drPathExists, at: $0.range.location, effectiveRange: nil) as? Bool == true
+        }
+        if allNeutral { return }
+        await Task.yield()
+    }
+    Issue.record("the restarted clear left stale missing-path attributes")
+}
+
+@MainActor
 @Test("Document-mode parse commits never publish a whole-storage attribute edit")
 func documentTypingKeepsAttributeInvalidationLocal() {
     let paragraph = "A paragraph whose attributes should remain outside the dirty edit scope."


### PR DESCRIPTION
## Summary
- reconcile the remaining split-view and long-session reliability work after the Everyday Trust release
- make history and reading-state pruning fail closed, generation-safe, mounted-volume-aware, and isolated from real user support data in tests
- bound external-change undo memory and move path checks/attribute repair off the synchronous editing path
- add durable repository guidance and update architecture/privacy retention contracts

## Validation
- `RUN_DRBENCH=1 Scripts/check.sh` — 1,130 tests / 97 suites; release typing p95 0.15 ms; semantic convergence p95 35.27 ms
- `Scripts/check-app.sh` with isolated acceptance bundle — exact bundle verification passed; activated-app source editing/undo and split-view interaction passed
- independent adversarial re-review: ship-clear
- `git diff --check` clean