### PR TITLE
Release integration: updater cadence, density rail, reliability/security audit fixes, and document gestures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,12 @@ on:
 permissions:
   contents: read
 
+# A force-push or a new commit on a PR branch supersedes the previous run:
+# the full macos-26 lane is expensive, and only the newest result matters.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   swift:
     # AppKit Liquid Glass symbols are part of the macOS 26 SDK.  macos-15's

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,8 +33,10 @@ jobs:
     timeout-minutes: 90
     permissions:
       contents: write        # publish the GitHub Release + assets
-      id-token: write        # GitHub Pages deployment
-      pages: write
+      # No id-token/pages here: this job only *uploads* the Pages artifact.
+      # The OIDC-signed deployment happens in `deploy`, which holds exactly
+      # the grants it needs — this job must not, being the one that handles
+      # every signing secret.
 
     env:
       MARKETING_VERSION_FILE: Config/version.env

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ This file contains Downright-specific context, invariants, and evidence gates. F
 - Keep the one-TextKit-2-surface architecture unless the task explicitly changes that contract. Incremental typing must not cause a whole-document rebuild; length-changing edits must invalidate all shifted ranges and fragments.
 - Make source mutations and undo boundaries explicit. Storage, autosave, watcher, and external-write changes need focused coverage for the relevant clean/dirty states and, when applicable, atomic replacement, deletion/rename, own-write suppression, conflict/review, failure, and recovery.
 - Never translate an I/O failure into “no change,” recreate a deleted file silently, overwrite source after a rendering failure, or save after the user chose Discard.
-- Downright has no app telemetry and does not upload document contents. Public acquisition means GitHub Release `.dmg` asset requests across stable and versioned DMGs; exclude Sparkle ZIP/delta requests and never describe requests as unique people or completed installs.
+- Downright has no app telemetry and does not upload document contents. The one recurring network request a production build makes on its own is a conditional `GET` of the public appcast, carrying no identifier and reading only a version; it stops with the "check automatically" setting, and it may trigger a Sparkle check but never parses the feed or installs anything. Public acquisition means GitHub Release `.dmg` asset requests across stable and versioned DMGs; exclude Sparkle ZIP/delta requests and never describe requests as unique people or completed installs.
 
 ## Validation by Surface
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,8 @@ every release; Sparkle orders updates by it.
 ### Fixed
 
 - Stopped idle history maintenance from rewriting every unchanged index, made
-  long-session pruning half-hourly, and added mounted-volume-aware collection
-  of stale history and reading-state files.
+  long-session pruning half-hourly, and retained the newest history and reading
+  state when a document path disappears.
 - Bounded external-change undo history and moved path-existence rechecks to a
   background cache warm so long-lived, frequently rewritten documents cannot
   grow memory indefinitely or stall the main thread on filesystem checks.
@@ -34,9 +34,9 @@ every release; Sparkle orders updates by it.
   background parsing and incremental TextKit commits preserve selection and
   scroll anchors while bounded real-window frame gates cover 10k–50k-line
   documents, IME composition, split view, and concurrent scrolling.
-- **Repaired browser-rich paste boundaries.** HTML, WebArchive, RTF, and RTFD
-  imports preserve useful paragraph, list, table, code, and link structure
-  without guessing at unsupported image or vendor payloads.
+- **Repaired browser-rich paste boundaries.** Explicit Paste as Markdown
+  converts HTML, WebArchive, RTF, and RTFD into useful paragraph, list, table,
+  code, and link structure without changing ordinary Paste's visible text.
 - **Fixed a crash on ordinary prose.** Any document containing a one-character
   word before `:digits` — "John 3:16", "meet at 9:30", `` `a:1` `` — fatally
   trapped the path-token scanner during the per-keystroke reparse.
@@ -97,14 +97,12 @@ every release; Sparkle orders updates by it.
 
 ### Added
 
-- **Calm, explicit document trust states.** The toolbar now communicates
-  Edited, Saving, briefly Saved, Changed externally, Conflict, and Save failed,
-  with accessible labels and focused mutation provenance such as Paste,
-  Toggle Task, Replace, panel actions, and Undo.
-- **Contents / Outline is a first-class command.** It is visible in the
-  overflow menu and remains available through View, the command palette,
-  accessibility, and configurable keybindings. It reuses the pinnable
-  inspector rather than adding a permanent sidebar.
+- **Calm, explicit document trust states.** The toolbar stays silent during
+  ordinary editing and saving, and communicates only exceptional states:
+  Changed externally, File missing, Conflict, and Save failed.
+- **Contents / Outline remains an advanced command.** It is available through
+  View, the command palette, accessibility, and configurable keybindings
+  without occupying the permanent toolbar, overflow menu, or Welcome guide.
 - **Universal clipboard flavors.** Copy now publishes lossless private
   Markdown, plain text, RTF, and sanitized semantic HTML so native and browser
   targets retain headings, lists, emphasis, links, tables, and code structure.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,17 @@ every release; Sparkle orders updates by it.
   "check automatically" setting as Sparkle's own schedule. It is a trigger, not
   a trust path — it learns only that the feed moved and asks Sparkle to look, so
   every signature check and download stays exactly where it was.
+- **Detents on the density rail.** Reading the section stack now taps once per
+  mark the pointer takes up, hovering and scrubbing alike, so the rail can be
+  counted through by hand instead of only by eye. The taps share one budget
+  with the landing punch and are floored at 50 ms apart: a slow read ticks mark
+  by mark, a fast sweep thins to a rhythm rather than buzzing, and a jump that
+  lands on the mark you just crossed answers once rather than twice. Leaving
+  the stack is silent — the rail sits against the window edge, so an exit is
+  the one transition that happens without anyone meaning it. Reduce Motion,
+  from the system or from a reader profile, silences the rail entirely: its
+  springs were already parked under that setting, which left the landing tap
+  answering a movement that no longer happens.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,24 @@ every release; Sparkle orders updates by it.
 - The npm installer verifies the fetched install script against a pinned
   SHA-256 before running it, so a compromised installer endpoint cannot execute
   arbitrary code at user privileges.
+- **Opening a path from a document can no longer execute it.** Links and path
+  tokens that resolve to an application bundle, a Terminal-run script (`.app`,
+  `.command`, `.tool`, …), or an extension-less executable are revealed in
+  Finder instead of handed to LaunchServices — "open in your editor" never
+  meant "run this". Ordinary documents (PDFs, images, `.sh` files) open as
+  before.
+- Own-write detection in the file watcher is now state-based rather than
+  clock-based: suppression opens when the save starts and closes at the
+  acknowledgement, however long the write takes. On a slow or network volume,
+  saving no longer risks your own file bouncing back as a phantom "changed on
+  disk" conflict; a watchdog fails open if an acknowledgement were ever lost.
+  Directory watches (the sibling list) honor the same filter, so writing
+  sidecars into the workspace folder no longer wakes pointless rescans.
+- The safe-HTML cross-block pairing for README-style `<details>` elements now
+  requires the partner tag to be written as a real HTML block. A mention of
+  `<details>` inside a code span or a sentence can no longer license hiding a
+  stray literal tag in another block; genuine split-element documents pair up
+  exactly as before.
 
 - Stopped idle history maintenance from rewriting every unchanged index, made
   long-session pruning half-hourly, and retained the newest history and reading

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,13 +98,13 @@ every release; Sparkle orders updates by it.
 ### Added
 
 - **Calm, explicit document trust states.** The toolbar now communicates
-  Edited, Saving, briefly Saved, Changed on disk, Conflict, and Save failed,
+  Edited, Saving, briefly Saved, Changed externally, Conflict, and Save failed,
   with accessible labels and focused mutation provenance such as Paste,
   Toggle Task, Replace, panel actions, and Undo.
 - **Contents / Outline is a first-class command.** It is visible in the
-  toolbar and overflow menu, remains available through View, the command
-  palette, accessibility, and configurable keybindings, and reuses the
-  pinnable inspector rather than adding a permanent sidebar.
+  overflow menu and remains available through View, the command palette,
+  accessibility, and configurable keybindings. It reuses the pinnable
+  inspector rather than adding a permanent sidebar.
 - **Universal clipboard flavors.** Copy now publishes lossless private
   Markdown, plain text, RTF, and sanitized semantic HTML so native and browser
   targets retain headings, lists, emphasis, links, tables, and code structure.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,25 @@ every release; Sparkle orders updates by it.
   "check automatically" setting as Sparkle's own schedule. It is a trigger, not
   a trust path — it learns only that the feed moved and asks Sparkle to look, so
   every signature check and download stays exactly where it was.
+- **Two-finger swipe between Document and Source.** Sideways across the
+  document switches presentation, and the titlebar's mode rail travels with
+  your fingers, reaching the far segment exactly where releasing would commit.
+  Release short of that — or flick back the way you came — and it returns
+  having changed nothing.
+
+  On most documents the page you are leaving really does travel off while the
+  one you are entering follows it in, both tracking your fingers one to one.
+  That needs the incoming presentation rendered before a finger moves, which is
+  affordable up to roughly twelve hundred lines: measured engagement is 6 ms at
+  240 lines and 26 ms at 950, against a budget of three frames. Past that the
+  page leans against your fingers instead and the switch happens on release —
+  because a gesture that stalls at the moment it catches is worse than one that
+  promised less. The choice is made per gesture from a per-line cost the app
+  measures on your machine rather than a constant baked in on someone else's.
+
+  Vertical scrolling is untouched: a gesture is only claimed once it is
+  decidedly sideways, never from a mouse wheel, and never from a momentum tail.
+  Abandoning a swipe costs nothing on either path.
 - **Detents on the density rail.** Reading the section stack now taps once per
   mark the pointer takes up, hovering and scrubbing alike, so the rail can be
   counted through by hand instead of only by eye. The taps share one budget
@@ -41,6 +60,50 @@ every release; Sparkle orders updates by it.
   from the system or from a reader profile, silences the rail entirely: its
   springs were already parked under that setting, which left the landing tap
   answering a movement that no longer happens.
+- **Share.** File ▸ Share (⌃⌘S) hands the document to the system share sheet —
+  Mail, Messages, AirDrop, Notes — and File ▸ Share as PDF sends the same
+  rendered page Print and Export PDF produce. Both send a *file*, so an AirDrop
+  arrives as a `.md` or a `.pdf` the receiver can open rather than a nameless
+  blob of pasted text. A saved, unmodified document shares its own file
+  untouched; one with unsaved edits shares a throwaway copy of what is actually
+  on screen, byte-faithful to the document's own encoding and line endings,
+  because sharing the stale file on disk would be a silent lie and saving on the
+  reader's behalf is not Share's decision to make. An Untitled window shares too,
+  under a real filename.
+- **Insert from iPhone or iPad.** Edit ▸ Insert picks up macOS's Take Photo and
+  Scan Documents when a nearby device can serve them. The capture is written as
+  a real image file next to the document — `notes-photo.png`, never overwriting
+  an earlier one — and a single Markdown reference is inserted at the caret as
+  one undoable edit. Nothing else in the document moves: a selection is inserted
+  *around*, not replaced, because the shutter is on a phone and whatever was
+  highlighted here is long out of sight by the time the photo lands. The name is
+  chosen so the written path and the parsed destination are the same string, so
+  the image renders with no trust prompt and arrives with no Asset Doctor
+  warnings. A document that has never been saved has no folder to write beside,
+  so macOS does not offer the capture there at all rather than accepting a photo
+  it would then have to put somewhere unportable.
+- **Drop files onto the document.** Dragging an image, a Markdown file, or
+  anything else onto the page inserts a reference to it at the position under
+  the pointer — not at the caret — with a drop caret showing exactly where it
+  will land while you are still holding the drag. An image already inside the
+  document's folder is referenced where it stands and never duplicated; one from
+  outside is copied in beside the document so the reference stays relative,
+  portable, and free of a trust prompt. A file that is not an image becomes a
+  link, inline, and is never copied: a link is a reference, not an embed. Image
+  data with no file behind it — dragged out of a browser or a preview window —
+  is written next to the document first. Destinations are chosen so they need no
+  percent-encoding, because Downright's renderer resolves a destination as a
+  literal path and would go looking for the `%`; a name with a space uses
+  CommonMark's `<…>` form instead. Every drop is one undoable edit, and a write
+  that fails inserts nothing and takes its own half-written files back out.
+- **Force click and Quick Look.** Force-clicking a path token or a link to a
+  local file opens a Quick Look preview of it; force-clicking an ordinary word
+  still gets macOS's Look Up popover, untouched. File ▸ Quick Look (⌘Y) does the
+  same for whatever the caret is on, and an embedded image opens in Downright's
+  own lightbox rather than a second image viewer. Space is deliberately *not*
+  bound to it in the shortcut table: the document surface always has a caret in
+  both of the modes you can reach, and a space that sometimes is not a space is
+  worse than a chord you have to learn.
 
 ### Changed
 
@@ -56,6 +119,15 @@ every release; Sparkle orders updates by it.
   window no longer writes the file — previously it did, which is exactly the
   unsolicited write the setting exists to prevent when an agent may be editing
   the same file.
+- **Document↔Source switching is two to three times faster.** Switching to
+  Source used to compute block metrics, heading fonts and list indents for every
+  block in the document and then overwrite all of them microseconds later with
+  "monospace, everything" — only the colours ever survived. Source mode now
+  applies what survives and skips what does not, and the whole-document
+  attribute passes were merged so the storage's runs are rewritten once rather
+  than three times. On a 2,000-line file the switch went from 273 ms to around
+  110 ms, and every route into Source is faster for it: the toolbar rail, ⌘⇧E,
+  and the swipe alike.
 - `SUScheduledCheckInterval` drops from 24 hours to 1 hour. It is now the
   fallback for an app that was asleep, offline, or in Low Power Mode while a
   build shipped, rather than the mechanism by which updates are noticed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,31 @@ every release; Sparkle orders updates by it.
 
 ## [Unreleased]
 
+### Added
+
+- **Update Now.** A build published from a push to `main` now reaches a running
+  copy in about a minute instead of on the next daily check, and the pill that
+  offers it acts instead of opening a window. One press installs and relaunches,
+  carrying its own progress in the titlebar; the update panel stays where it was
+  for menu checks, errors, and no-update results. Resting on the button unfurls
+  a glass panel of the release notes — the appcast already embeds them, so it
+  costs no extra request — which you can move into, and which trims to whole
+  lines rather than clipping a sentence in half. An update that lands while you
+  are in the app gets one accent pass on arrival; one that was already waiting
+  when the window opened does not pretend it just arrived.
+- The appcast is watched while the app is open: a conditional request roughly
+  every 90 seconds in front and every 15 minutes behind, stopped entirely with
+  no network and in Low Power Mode while backgrounded, and governed by the same
+  "check automatically" setting as Sparkle's own schedule. It is a trigger, not
+  a trust path — it learns only that the feed moved and asks Sparkle to look, so
+  every signature check and download stays exactly where it was.
+
+### Changed
+
+- `SUScheduledCheckInterval` drops from 24 hours to 1 hour. It is now the
+  fallback for an app that was asleep, offline, or in Low Power Mode while a
+  build shipped, rather than the mechanism by which updates are noticed.
+
 ### Fixed
 
 - Stopped idle history maintenance from rewriting every unchanged index, made

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,11 +44,56 @@ every release; Sparkle orders updates by it.
 
 ### Changed
 
+- External-effect trust grants are now pinned to the exact URL you approved.
+  An "always allow" given to one link or automation inside a folder no longer
+  silently authorizes every future URL of that kind in the same folder — a
+  different scheme or address asks again. Grants recorded before this change
+  fail closed for external effects and are re-recorded with their URL the next
+  time you approve them; purely local permissions (reading assets, opening
+  paths) keep working untouched.
+- The occlusion save now belongs to the autosave setting it always behaved
+  like. With autosave off (the default), covering or miniaturizing a dirty
+  window no longer writes the file — previously it did, which is exactly the
+  unsolicited write the setting exists to prevent when an agent may be editing
+  the same file.
 - `SUScheduledCheckInterval` drops from 24 hours to 1 hour. It is now the
   fallback for an app that was asleep, offline, or in Low Power Mode while a
   build shipped, rather than the mechanism by which updates are noticed.
 
 ### Fixed
+
+- **A discarded buffer can no longer reach disk.** Choosing Discard in the
+  close or quit prompt used to leave the document dirty while queued autosave
+  work and window-occlusion saves stayed armed: the write could land while the
+  confirmation was still on screen or as the window tore down, committing the
+  very edits you had just declined to keep. Every implicit save path now stops
+  at the choice, and a closed document refuses writes outright.
+- **Closed an export hole that could produce live `javascript:` links.**
+  Browsers strip tabs and newlines out of URLs before parsing them, so a
+  destination written as `java<TAB>script:` passed the CLI exporter's scheme
+  block and came back to life inside the browser — the same trick also let a
+  tabbed `http:` image through as a live remote request. Destinations are now
+  normalized before analysis and emitted in that same normalized form.
+- Fragment metadata (code-block copy ranges, image-load invalidation, table
+  geometry) now follows edits made outside the text view's own typing funnel:
+  document commands, undo/redo, and absorbed external rewrites shift the
+  payload ranges along with the attribute runs they ride on. Copying a code
+  block after typing above it no longer grabs the wrong span.
+- The repository gate now fails when version consistency or theme contrast
+  checks fail, instead of printing their reports and exiting green.
+- Update probes on hosts that serve no `ETag` now send `If-Modified-Since`
+  from the stored document date, so an unchanged feed answers `304` instead of
+  being re-downloaded and hashed every cycle.
+- Saves flush the replacement generation to stable storage before the atomic
+  swap publishes it, so a crash or power loss right after a save cannot leave
+  the document file truncated or empty.
+- Agent hook commands single-quote the executable path, so no character in an
+  unusual install location can open a shell expansion context inside the
+  agent's settings. Hooks installed by earlier builds are recognized and
+  migrated to the quoted form in place instead of being duplicated.
+- The npm installer verifies the fetched install script against a pinned
+  SHA-256 before running it, so a compromised installer endpoint cannot execute
+  arbitrary code at user privileges.
 
 - Stopped idle history maintenance from rewriting every unchanged index, made
   long-session pruning half-hourly, and retained the newest history and reading

--- a/Config/Downright-Info.plist
+++ b/Config/Downright-Info.plist
@@ -34,8 +34,15 @@
 	<true/>
 	<key>SUAutomaticallyUpdate</key>
 	<true/>
+	<!-- The fallback floor, not the mechanism. `ReleaseWatch` notices a moved
+	     appcast within about a minute while the app is open, which is what
+	     makes a build published from a push to `main` reachable the same
+	     sitting. This interval is what still catches an app that was asleep,
+	     offline, or in Low Power Mode when that happened; Sparkle enforces a
+	     one-hour floor on scheduled checks, so this is as short as the
+	     scheduler itself can usefully be. -->
 	<key>SUScheduledCheckInterval</key>
-	<integer>86400</integer>
+	<integer>3600</integer>
 	<key>SUVerifyUpdateBeforeExtraction</key>
 	<true/>
 	<key>SURequireSignedFeed</key>

--- a/Docs/ARCHITECTURE.md
+++ b/Docs/ARCHITECTURE.md
@@ -85,13 +85,10 @@ writes replace the inode. On an external write:
 
 Snapshots deduplicate by content hash. Retention applies the configured age,
 per-document, and global byte caps without rewriting unchanged indexes; a
-half-hour maintenance interval bounds long-running sessions. History for a
-deleted document becomes eligible after the configured snapshot age; its
-reading-position state uses a fixed 30-day age. Both require two distinct
-observations that the path is absent, and the containing volume must be
-mounted. An unreadable path, an I/O error, an unmounted volume, or a path
-restored between observations is preserved. These checks deliberately fail
-closed around atomic replacements.
+half-hour maintenance interval bounds long-running sessions. The newest
+snapshot for each document is retained even after the document moves or its
+path disappears. Reading-position state is not deleted based on path presence;
+broader cleanup requires an explicit user action.
 
 Snapshot restore is a text edit, not a hidden file replacement. Persistence
 tests inject temporary support roots, and the repository gate also refuses to

--- a/Docs/PERFORMANCE.md
+++ b/Docs/PERFORMANCE.md
@@ -11,11 +11,30 @@ pipeline. Do not replace a failed measurement with a claim.
 | Keystroke response, 5,000-line file | <8 ms | Source edit, paragraph map, dirty decoration | p95 below target |
 | Scroll | 120 fps on ProMotion | Long-document scroll trace | No sustained frame drop |
 | Structural zoom | <300 ms | Level 1–5 transition trace | Anchor stays fixed; no dropped frames |
+| Document↔Source swipe, engage and abandon (give path) | <8 ms | `PresentationSwipeBudgetTests`, 2,000-line file | Below target; nothing rendered inside the gesture |
+| Document↔Source swipe, engage (drag path) | <50 ms | `PresentationSwitchBudget`, documents under its line budget | Below target; measured 6 ms at 240 lines, 26 ms at 950 |
+| Document↔Source swipe, per tracking frame | <1 ms | `PresentationSwipeBudgetTests` | Below target |
 | Quick Look preview | <400 ms | Preview extension render | p95 below target |
 | Quick Look peak memory | <60 MB | Resident memory polling | Never exceeds target |
 | 1 MB document memory | <150 MB | App open and idle measurement | Peak below target |
 | Quick Look safety fallback | 60 MB | Memory guard | Plain text fallback above guard |
 | Large Quick Look file | 2 MB | Preview policy | Initial blocks plus Open in App |
+
+The swipe budgets exist because the obvious implementation misses them by an
+order of magnitude. Dragging the Source presentation in under the fingers
+requires rendering it first, which is a whole-document TextKit rebuild. The
+gesture therefore measures before it promises: `PresentationSwitchBudget` holds
+a per-line cost, seeded from a release sweep and recalibrated from every switch
+the app performs, and the swipe takes the drag only where the estimate fits
+inside the engagement budget. Above it the gesture translates one layer instead
+and switches on release through the same path the toolbar rail uses, for the
+same cost and no more.
+
+Two things make the drag affordable at all. The outgoing page is captured by
+`CALayer.render` at half resolution — 3 ms, against 30 ms for a full-resolution
+`cacheDisplay`, because it composites what is already rasterised rather than
+re-running TextKit — and the incoming side is not captured at all, since it is
+the live text view with the mode change already applied behind the still.
 
 The 8 ms keystroke target is the P0 architecture gate. Semantic parsing runs
 outside this synchronous path. Its result is revision checked before the app

--- a/Docs/PRIVACY.md
+++ b/Docs/PRIVACY.md
@@ -51,12 +51,9 @@ the network.
 ## Retention and deletion
 
 Snapshots are local and content-addressed. The app applies configured age and
-size caps. A missing path's snapshot index becomes eligible at the configured
-snapshot age; its reading-position state becomes eligible after 30 days. Both
-may be collected only after two separate checks confirm that the path is
-absent and its containing volume is mounted. Downright preserves this local
-metadata when the path is unreadable, the filesystem answer is uncertain, the
-volume is unavailable, or the file returns between checks.
+size caps while retaining each document's newest snapshot. Missing paths do
+not cause snapshot indexes or reading-position state to be deleted; files can
+move, repositories can be relocated, and external volumes can be unavailable.
 
 Users can delete snapshot history from the app. Settings and themes can be
 removed from the Downright support folder. The app does not claim ownership of

--- a/Docs/PRIVACY.md
+++ b/Docs/PRIVACY.md
@@ -18,10 +18,34 @@ file names by default. It does not require a cloud service.
 | Recent documents | macOS recent-document services | Start window |
 | Workspace siblings | Memory during the workspace session | Sidebar display |
 | Optional AI input | On-device Apple Intelligence | User-requested action |
+| Update check | Public appcast host | Offer a new build |
 
 Downright does not copy a whole folder into a database. It does not upload
 workspace files. A path shown in a document is not opened or executed until the
 user clicks it.
+
+## Update checks
+
+A production build asks the public appcast whether a newer build exists. It is
+an ordinary conditional `GET` for one static file, over HTTPS, carrying no
+account, no identifier, no cookie, no system profile, and no information about
+the documents the user has open. `SUEnableSystemProfiling` is off. Nothing is
+uploaded; the app only reads a version.
+
+While the app is open it repeats that request periodically so a build published
+during the session is offered during the session rather than up to a day later.
+The repeat is deliberately cheap and deliberately quiet:
+
+- The request is conditional. An unchanged feed answers `304` with no body.
+- It stops entirely with no network, and in Low Power Mode while the app is in
+  the background.
+- It slows to a background cadence whenever the app is not frontmost.
+- It learns exactly one bit — the feed is not the one last seen — and hands
+  that to Sparkle. It never parses the feed and cannot cause an install.
+
+Dev and ad-hoc builds carry no updater configuration and make no such request
+at all. A user who does not want update checks can turn them off in Settings,
+which stops the scheduled check and this watch together.
 
 ## Apple Intelligence
 
@@ -81,6 +105,7 @@ The product page and settings must state:
 2. AI is optional and on-device in the supported feature.
 3. The app does not need an account or cloud sync.
 4. Files are not uploaded by the core app.
+   Update checks read a public version feed and send nothing about the user.
 5. The user controls snapshots and shared diagnostics.
 
 Privacy tests must cover offline operation, Quick Look, workspace scanning,

--- a/Docs/RELEASE.md
+++ b/Docs/RELEASE.md
@@ -51,6 +51,49 @@ Scripts/sync-versions.sh fix    # rewrite the consumers from version.env
 - Pills live in document titlebars and the start window; the update panel is a
   single nonmodal window that renders release notes through the app's own
   `MarkdownTextView`.
+- `Sources/DownrightApp/Updater/ReleaseWatch.swift` — notices that the appcast
+  moved and asks Sparkle to look. See "Update latency" below.
+- The pill acts rather than opens: one press installs and relaunches, and
+  resting on it unfurls `UpdateNotesPopover` with the notes the appcast already
+  embedded. Unsaved work is *not* handled in the updater — Sparkle's install
+  asks the app to terminate, which runs `applicationShouldTerminate` and the
+  app's one policy for dirty buffers. A cancelled quit lands the machine in
+  `.waitingForTermination`, which is what the "Restart to Update" pill reports.
+
+## Update latency
+
+Every push to `main` publishes a signed appcast, so the practical question is
+how long an already-running copy takes to notice. Three things decide it:
+
+| Stage | Cost |
+|---|---|
+| Push → signed appcast live on Pages | the release workflow's own run time |
+| Appcast live → `ReleaseWatch` notices | ~90s frontmost, ~15 min backgrounded |
+| Noticed → pill offers it | one Sparkle background check |
+
+`ReleaseWatch` is a **trigger, not a trust path**. It issues a conditional
+`GET` against `SUFeedURL`, and on a changed validator calls
+`checkForUpdatesInBackground()`. It never parses the appcast, never compares
+versions, never reads an enclosure URL, and cannot cause an install: every
+signature check, ordering decision, and download stays inside Sparkle.
+Shortening the latency of an update therefore leaves the security model of one
+untouched.
+
+`SUScheduledCheckInterval` (1 hour) remains as the fallback for an app that was
+asleep, offline, or in Low Power Mode while a build shipped. Sparkle enforces a
+one-hour floor on scheduled checks, which is why the watch drives its own
+trigger rather than simply setting a shorter interval.
+
+To work on the update surface without waiting out a release, launch a **debug**
+build with `--downright-demo-update`. It fills in synthetic metadata so the
+pill, its arrival, and the hover notes can be exercised directly; it touches
+neither Sparkle nor the feed, and `#if DEBUG` keeps it out of the Release
+configuration the notarised archive is built with.
+
+```bash
+CONFIGURATION=debug SCRATCH=.build-demo Scripts/bundle-app.sh
+open .build-demo/bundle/Downright.app --args --downright-demo-update
+```
 
 Dev/ad-hoc bundles omit the Sparkle Info.plist block, which disables the
 updater entirely (`UpdateCoordinator.start()` refuses to run). Production keys

--- a/README.md
+++ b/README.md
@@ -176,6 +176,17 @@ All bindings are editable in **Settings → Keys**.
 | `⌃⌥⌘1`–`5` | Structural zoom | `⌥⇧↑` / `↓` | Previous / next change |
 | `⌘\` | Split view | `⌘L` | Toggle task at caret |
 
+Two fingers sideways across the document switch between Document and Source.
+The titlebar's mode rail travels with your fingers, so you can see how far is
+far enough; release short of that and it returns having changed nothing. On
+documents short enough to render the other presentation in time — most of them —
+the pages themselves slide past each other under your fingers.
+
+Hold ⇧ and swipe sideways to move back and forward through jump history.
+Pinch to change text size, ⌘-scroll to do the same with a mouse, and ⌥-scroll to
+step through the structural detail levels. Double-tap with two fingers toggles a
+larger text size.
+
 ## Themes and appearance
 
 Downright follows macOS Light and Dark appearances by default. Light and dark

--- a/README.md
+++ b/README.md
@@ -233,6 +233,14 @@ APP_SOURCE=.build-xcode/Build/Products/Release/Downright.app Scripts/install.sh
 down README.md
 ```
 
+`install.sh` links the `down` CLI into `/usr/local/bin`, which needs write
+access on a default macOS setup. To link somewhere writable instead, set
+`BIN_DEST` (and put that directory on your `PATH`):
+
+```bash
+BIN_DEST="$HOME/.local/bin" APP_SOURCE=.build-xcode/Build/Products/Release/Downright.app Scripts/install.sh
+```
+
 For a faster SwiftPM development build without Finder extensions:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Download the latest signed and notarized release from
 3. Launch it once to configure Markdown file associations, Quick Look, and the
    CLI.
 
-### Homebrew
+### Homebrew cask
 
 The public tap installs the same production app into `/Applications`:
 
@@ -100,9 +100,9 @@ request in the release asset download count.
 This is the developer tap. The tap-free `brew install --cask downright`
 command is not advertised until an official Homebrew Cask is accepted.
 
-### Terminal installer
+### Command-line options
 
-The first-party installer downloads the latest signed build, verifies its
+The first-party shell installer downloads the latest signed build, verifies its
 published checksum and app signature, installs it into `/Applications`,
 registers the Finder integrations, and links `down` and `md` when possible:
 
@@ -111,7 +111,7 @@ curl -fsSL https://downright.cc/install | bash
 ```
 
 If Node.js 18 or newer is already installed, the npm launcher runs the same
-first-party installer:
+first-party macOS installer:
 
 ```bash
 npx --yes downright-installer

--- a/README.md
+++ b/README.md
@@ -120,6 +120,10 @@ npx --yes downright-installer
 Every installation path leaves automatic Sparkle updates enabled. The curl
 path needs no Node.js; the npm path is macOS-only and requires Node.js 18+.
 
+A build published while the app is open is offered within about a minute: the
+titlebar shows **Update Now**, one press installs it and relaunches, and
+resting on the button shows what changed before you commit to it.
+
 ## Why Downright
 
 - **Exact source.** Rendering decorates the original text storage; it does not

--- a/Resources/Welcome.md
+++ b/Resources/Welcome.md
@@ -40,7 +40,6 @@ A table:
 | Press | What happens |
 | --- | --- |
 | {{shortcut:commandPalette}} | Command palette, for anything you cannot remember |
-| {{shortcut:documentLens}} | {{command:documentLens}} |
 | {{shortcut:taskPanel}} | Tasks |
 | {{shortcut:nextHeading}} | Jump to the next heading |
 

--- a/Scripts/check-homebrew-eligibility.mjs
+++ b/Scripts/check-homebrew-eligibility.mjs
@@ -11,9 +11,14 @@ if (process.argv.includes("--help")) {
   process.exit(0);
 }
 
-const response = await fetch(url, {
-  headers: { accept: "application/vnd.github+json", "user-agent": "downright-homebrew-readiness" },
-});
+// Unauthenticated GitHub API calls share a 60 req/h budget per source IP, so
+// a shared CI runner can be rate-limited into a raw failure.  Use
+// GITHUB_TOKEN when the environment provides one (read-only public data; the
+// token only raises the limit and is never logged).
+const headers = { accept: "application/vnd.github+json", "user-agent": "downright-homebrew-readiness" };
+if (process.env.GITHUB_TOKEN) headers.authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+
+const response = await fetch(url, { headers });
 if (!response.ok) throw new Error(`GitHub API returned ${response.status}`);
 const repo = await response.json();
 const result = {

--- a/Scripts/check.sh
+++ b/Scripts/check.sh
@@ -89,8 +89,15 @@ fi
 
 echo
 echo "==> Version consistency (single source: Config/version.env)"
-"$ROOT/Scripts/sync-versions.sh"
+# This script runs without `set -e` on purpose (the test step inspects its own
+# status), so every gate here must be checked explicitly.  A drift report that
+# only prints is a release gate that always passes.
+if ! "$ROOT/Scripts/sync-versions.sh"; then
+    echo "    FAILED"
+    exit 1
+fi
 
+echo
 echo "==> Sparkle is linked only by the host app"
 SPARKLE_IMPORTS="$(grep -rln 'import Sparkle' Sources --include='*.swift' || true)"
 if [ -z "$SPARKLE_IMPORTS" ]; then
@@ -108,7 +115,12 @@ echo "    ok"
 
 echo
 echo "==> Theme contrast"
-python3 "$ROOT/Scripts/check-contrast.py"
+# Same rule as the version gate above: a WCAG regression must fail the run,
+# not just decorate its output.
+if ! python3 "$ROOT/Scripts/check-contrast.py"; then
+    echo "    FAILED"
+    exit 1
+fi
 
 echo
 echo "==> Sanity: the runner must actually have run something"

--- a/Scripts/report-download-counts.sh
+++ b/Scripts/report-download-counts.sh
@@ -11,6 +11,13 @@ RELEASE="latest"
 JSON=0
 ALL=0
 
+# One asset-naming contract for every mode: a versioned artifact may carry the
+# "-<build>-<sha>" release suffix, and a milestone-style bare version counts
+# the same whether the report covers one release or all of them.  These are
+# handed to jq through --arg, which takes the value raw — single backslashes.
+VERSIONED_DMG_PATTERN='^Downright-[0-9]+\.[0-9]+\.[0-9]+(-[0-9]+-[0-9a-f]+)?\.dmg$'
+UPDATE_ZIP_PATTERN='^Downright-[0-9]+\.[0-9]+\.[0-9]+(-[0-9]+-[0-9a-f]+)?\.zip$'
+
 usage() {
     echo "usage: Scripts/report-download-counts.sh [--release latest|TAG] [--all] [--json]" >&2
 }
@@ -75,9 +82,9 @@ if [ "$ALL" = "1" ]; then
     RELEASES="$(jq -s 'add // []' "$RELEASES_FILE")"
     RELEASE_COUNT="$(printf '%s' "$RELEASES" | jq 'length')"
     STABLE_DMGS="$(printf '%s' "$RELEASES" | jq -r '[.[] | .assets[]? | select(.name == "Downright.dmg") | .download_count] | add // 0')"
-    VERSIONED_DMGS="$(printf '%s' "$RELEASES" | jq -r '[.[] | .assets[]? | select(.name | test("^Downright-[0-9]+\\.[0-9]+\\.[0-9]+(-[0-9]+-[0-9a-f]+)?\\.dmg$")) | .download_count] | add // 0')"
+    VERSIONED_DMGS="$(printf '%s' "$RELEASES" | jq -r --arg pattern "$VERSIONED_DMG_PATTERN" '[.[] | .assets[]? | select(.name | test($pattern)) | .download_count] | add // 0')"
     ACQUISITION_DMGS=$((STABLE_DMGS + VERSIONED_DMGS))
-    UPDATE_ZIPS="$(printf '%s' "$RELEASES" | jq -r '[.[] | .assets[]? | select(.name | test("^Downright-[0-9]+\\.[0-9]+\\.[0-9]+(-[0-9]+-[0-9a-f]+)?\\.zip$")) | .download_count] | add // 0')"
+    UPDATE_ZIPS="$(printf '%s' "$RELEASES" | jq -r --arg pattern "$UPDATE_ZIP_PATTERN" '[.[] | .assets[]? | select(.name | test($pattern)) | .download_count] | add // 0')"
 
     if [ "$JSON" = "1" ]; then
         printf '%s' "$RELEASES" | jq --arg repository "$REPOSITORY" \
@@ -109,9 +116,9 @@ TAG="$(printf '%s' "$RESPONSE" | jq -r '.tag_name // empty')"
 [ -n "$TAG" ] || { echo "release not found: $RELEASE" >&2; exit 1; }
 
 STABLE_DMG="$(printf '%s' "$RESPONSE" | jq -r '[.assets[] | select(.name == "Downright.dmg") | .download_count] | add // 0')"
-VERSIONED_DMGS="$(printf '%s' "$RESPONSE" | jq -r '[.assets[] | select(.name | test("^Downright-[0-9]+\\.[0-9]+\\.[0-9]+-[0-9]+-[0-9a-f]+\\.dmg$")) | .download_count] | add // 0')"
+VERSIONED_DMGS="$(printf '%s' "$RESPONSE" | jq -r --arg pattern "$VERSIONED_DMG_PATTERN" '[.assets[] | select(.name | test($pattern)) | .download_count] | add // 0')"
 ACQUISITION_DMGS=$((STABLE_DMG + VERSIONED_DMGS))
-UPDATE_ZIPS="$(printf '%s' "$RESPONSE" | jq -r '[.assets[] | select(.name | test("^Downright-[0-9]+\\.[0-9]+\\.[0-9]+(-[0-9]+-[0-9a-f]+)?\\.zip$")) | .download_count] | add // 0')"
+UPDATE_ZIPS="$(printf '%s' "$RESPONSE" | jq -r --arg pattern "$UPDATE_ZIP_PATTERN" '[.assets[] | select(.name | test($pattern)) | .download_count] | add // 0')"
 
 if [ "$JSON" = "1" ]; then
     printf '%s' "$RESPONSE" | jq --arg repository "$REPOSITORY" \

--- a/Sources/DownrightApp/AI/DocumentStateStore.swift
+++ b/Sources/DownrightApp/AI/DocumentStateStore.swift
@@ -123,99 +123,15 @@ final class DocumentStateStore {
     private var cacheOrder: [String] = []
     private let maximumCachedStates = 256
     private let lock = NSLock()
-    private let pruneQueue = DispatchQueue(label: "com.ezzy.downright.state-prune", qos: .utility)
-
-    /// A deleted document keeps its reading position long enough to be
-    /// restored from the Trash, without making the state directory a permanent
-    /// record of every document ever opened.
-    private let abandonedStateMaximumAge: TimeInterval = 30 * 24 * 60 * 60
-    private let abandonedStateConfirmationDelay: TimeInterval
     private let supportDirectory: URL
     private let stateDirectory: URL
-    private var abandonedCandidates: [String: String] = [:]
 
-    /// `supportDirectory` is injectable so state-pruning tests cannot touch the
-    /// user's real reading positions or recents.
-    init(
-        supportDirectory: URL = AppPaths.supportDirectory,
-        abandonedStateConfirmationDelay: TimeInterval = 30
-    ) {
+    /// `supportDirectory` is injectable so tests cannot touch the user's real
+    /// reading positions or recents.
+    init(supportDirectory: URL = AppPaths.supportDirectory) {
         self.supportDirectory = supportDirectory.standardizedFileURL
         self.stateDirectory = self.supportDirectory.appendingPathComponent("state", isDirectory: true)
-        self.abandonedStateConfirmationDelay = abandonedStateConfirmationDelay
         AppPaths.ensure(self.stateDirectory)
-    }
-
-    /// Drops stale reading state for documents that no longer exist. This is a
-    /// launch job: nothing else deletes these files, and doing the directory
-    /// walk off the main thread keeps opening a document responsive.
-    func schedulePruneAbandonedStates() {
-        pruneQueue.async { [self] in
-            pruneAbandonedStates()
-            // A second, meaningfully separated observation confirms absence
-            // without installing a permanent maintenance timer.
-            pruneQueue.asyncAfter(deadline: .now() + abandonedStateConfirmationDelay) { [self] in
-                pruneAbandonedStates()
-            }
-        }
-    }
-
-    @discardableResult
-    func pruneAbandonedStates() -> Int {
-        guard let files = try? fm.contentsOfDirectory(
-            at: stateDirectory,
-            includingPropertiesForKeys: nil
-        ) else { return 0 }
-
-        let cutoff = Date().addingTimeInterval(-abandonedStateMaximumAge)
-        var removed = 0
-        for file in files where file.pathExtension == "json" {
-            let key = file.deletingPathExtension().lastPathComponent
-            guard let data = try? Data(contentsOf: file),
-                  let state = try? JSONDecoder.snapshotDecoder.decode(DocumentState.self, from: data)
-            else {
-                _ = lock.withLock { abandonedCandidates.removeValue(forKey: key) }
-                continue
-            }
-
-            guard state.lastOpened < cutoff else {
-                _ = lock.withLock { abandonedCandidates.removeValue(forKey: key) }
-                continue
-            }
-            let presence = state.path.isEmpty
-                ? SnapshotStore.PathPresence.absent
-                : SnapshotStore.pathPresence(for: state.path)
-            guard presence == .absent,
-                  (state.path.isEmpty || SnapshotStore.volumeIsMounted(for: state.path)) else {
-                _ = lock.withLock { abandonedCandidates.removeValue(forKey: key) }
-                continue
-            }
-            let signature = DocumentIO.contentHash(data)
-            let confirmed = lock.withLock {
-                guard abandonedCandidates[key] == signature else {
-                    abandonedCandidates[key] = signature
-                    return false
-                }
-                return true
-            }
-            guard confirmed else { continue }
-            let didRemove = lock.withLock {
-                // A save can refresh this state while the prune is walking.
-                // Delete only the exact stale generation we inspected.
-                guard (try? Data(contentsOf: file)) == data else { return false }
-                do {
-                    try fm.removeItem(at: file)
-                } catch {
-                    return false
-                }
-                cache.removeValue(forKey: key)
-                cacheOrder.removeAll { $0 == key }
-                abandonedCandidates.removeValue(forKey: key)
-                return true
-            }
-            if didRemove { removed += 1 }
-        }
-        return removed
     }
 
     // MARK: - Per-document state
@@ -249,7 +165,6 @@ final class DocumentStateStore {
         lock.withLock {
             storeInCache(state, forKey: key)
             try? data.write(to: fileURL, options: .atomic)
-            _ = abandonedCandidates.removeValue(forKey: key)
         }
     }
 

--- a/Sources/DownrightApp/AI/FileWatcher.swift
+++ b/Sources/DownrightApp/AI/FileWatcher.swift
@@ -69,7 +69,20 @@ final class FileWatcher {
     /// coalesce with the event.
     private var forceContentDigestOnNextCheck = false
     /// Writes we made ourselves must not come back to us as external changes.
-    private var suppressUntil: Date = .distantPast
+    ///
+    /// Suppression is a *state*, not a clock: it opens with
+    /// `suppressOwnWrite()` and closes at `acknowledgeOwnWrite(contents:)` or
+    /// `cancelOwnWriteSuppression()`, however long the write takes — on a
+    /// network volume an atomic save can easily outlive any fixed window, and
+    /// a window that expires early delivers our own bytes back as a phantom
+    /// external change. Two bounded clocks remain, neither load-bearing:
+    /// a watchdog that fails open if an acknowledgement is somehow lost, and
+    /// a short post-acknowledge grace that keeps late FSEvents from the same
+    /// write from being reconciled as externals before the state pass sees
+    /// them.
+    private var ownWriteInFlight = false
+    private var ownWriteWatchdogDeadline = Date.distantPast
+    private var settleGraceUntil = Date.distantPast
     /// The last snapshot observed while an own-write suppression window was
     /// open.  This is deliberately separate from `lastSnapshot`: advancing the
     /// baseline before deciding whether a snapshot is ours is the race that
@@ -165,13 +178,22 @@ final class FileWatcher {
     /// Call immediately before writing the file ourselves.  Our own write would
     /// otherwise arrive back as an external change and re-mark the whole
     /// document — the toggle-a-checkbox case (§8.5) makes this obvious fast.
+    ///
+    /// Suppression stays open until the matching acknowledgement (or cancel),
+    /// regardless of how long the write takes; `interval` only sizes the
+    /// lost-acknowledgement watchdog.
     func suppressOwnWrite(for interval: TimeInterval = 0.6) {
         onQueue {
             ownWriteGeneration &+= 1
             suppressionBaseline = lastSnapshot
             expectedOwnSnapshot = nil
             suppressedSnapshots.removeAll(keepingCapacity: true)
-            suppressUntil = Date().addingTimeInterval(interval)
+            ownWriteInFlight = true
+            settleGraceUntil = .distantPast
+            // A save that never acknowledged must not mute the watcher
+            // forever: fail open after a generous multiple of the caller's
+            // expectation, floored well above any honest slow volume.
+            ownWriteWatchdogDeadline = Date().addingTimeInterval(max(5.0, interval * 4))
         }
     }
 
@@ -198,7 +220,9 @@ final class FileWatcher {
                 // as an external observation for the reconciliation pass.
                 recordSuppressedSnapshot(actual)
             }
-            suppressUntil = Date().addingTimeInterval(0.25)
+            // The write has landed; the very next observation reconciles.
+            ownWriteInFlight = false
+            settleGraceUntil = Date().addingTimeInterval(0.25)
         }
     }
 
@@ -208,7 +232,8 @@ final class FileWatcher {
         onQueue {
             expectedOwnSnapshot = nil
             suppressedSnapshots.removeAll(keepingCapacity: true)
-            suppressUntil = .distantPast
+            ownWriteInFlight = false
+            settleGraceUntil = .distantPast
             forceContentDigestOnNextCheck = true
             scheduleCheck(forceContentDigest: true)
         }
@@ -314,7 +339,18 @@ final class FileWatcher {
         return ext.isEmpty || interestingExtensions.contains(ext)
     }
 
+    /// Delivers a coalesced `.changed` for directory watches.
+    ///
+    /// Contract: a directory watch reports *any* interesting churn under the
+    /// root — it has no single file to attribute events to. While own-write
+    /// suppression is open (the owner writing sidecars or review notes into
+    /// the watched folder), deliveries are skipped so the app's own writes
+    /// cannot wake an idempotent rescan; the next genuine change re-triggers
+    /// one. Any future owner that treats these events as content-to-reload
+    /// inherits this filter automatically and must not rely on receiving
+    /// events for its own writes.
     private func scheduleDirectoryChange() {
+        guard !isSuppressingOwnWrites() else { return }
         coalesceWorkItem?.cancel()
         let gen = generation
         let item = DispatchWorkItem { [weak self] in
@@ -372,19 +408,48 @@ final class FileWatcher {
         onQueue { check(forceContentDigest: false) }
     }
 
+    /// Forces the lost-acknowledgement watchdog to fire on the next check, so
+    /// the fail-open path is deterministic instead of waiting out its floor.
+    func tripSuppressionWatchdogForTesting() {
+        onQueue { ownWriteWatchdogDeadline = .distantPast }
+    }
+
+    /// Drives directory-watch event matching directly, without depending on
+    /// FSEvents delivery timing.
+    func deliverDirectoryEventForTesting(paths: [String]) {
+        onQueue { handleStreamEvents(paths: paths) }
+    }
+
+    /// Whether own-write suppression is currently absorbing observations.
+    /// In-flight covers the whole save transaction; the settle grace only
+    /// keeps late events from the just-landed write from racing the state
+    /// reconciliation. Correctness never depends on the grace expiring.
+    private func isSuppressingOwnWrites(now: Date = Date()) -> Bool {
+        ownWriteInFlight || now < settleGraceUntil
+    }
+
     private func check(forceContentDigest: Bool = false) {
         pollProbeCount &+= 1
+        // Lost acknowledgement: fail open rather than stay deaf forever.
+        if ownWriteInFlight, Date() >= ownWriteWatchdogDeadline {
+            ownWriteInFlight = false
+            forceContentDigestOnNextCheck = true
+        }
         let metadata = FileWatcher.metadata(of: url) ?? .missing
         let metadataChanged = !FileWatcher.metadataMatches(metadata, lastSnapshot)
         let periodicContentProbe = pollProbeCount % contentDigestPollStride == 0
-        let suppressionActive = Date() < suppressUntil
-        guard forceContentDigest || metadataChanged || periodicContentProbe || !suppressedSnapshots.isEmpty else {
+        guard forceContentDigest
+                || metadataChanged
+                || periodicContentProbe
+                || !suppressedSnapshots.isEmpty
+                || expectedOwnSnapshot != nil
+        else {
             return
         }
 
         let now = FileWatcher.snapshot(of: url, includeContentDigest: true)
 
-        if suppressionActive {
+        if isSuppressingOwnWrites() {
             guard now != lastSnapshot else { return }
             if let expectedOwnSnapshot, now == expectedOwnSnapshot {
                 // Consume our own replacement, but do not discard an external
@@ -397,7 +462,7 @@ final class FileWatcher {
             return
         }
 
-        if !suppressedSnapshots.isEmpty {
+        if !suppressedSnapshots.isEmpty || expectedOwnSnapshot != nil {
             reconcileSuppressedChange(final: now)
             return
         }
@@ -433,7 +498,8 @@ final class FileWatcher {
         suppressionBaseline = nil
         expectedOwnSnapshot = nil
         suppressedSnapshots.removeAll(keepingCapacity: true)
-        suppressUntil = .distantPast
+        ownWriteInFlight = false
+        settleGraceUntil = .distantPast
         lastSnapshot = final
 
         if let observedExternal {
@@ -449,7 +515,7 @@ final class FileWatcher {
     }
 
     private func recordCurrentSnapshotIfSuppressed() {
-        guard Date() < suppressUntil else { return }
+        guard isSuppressingOwnWrites() else { return }
         let snapshot = FileWatcher.snapshot(of: url)
         guard snapshot != lastSnapshot else { return }
         if let expectedOwnSnapshot, snapshot == expectedOwnSnapshot {

--- a/Sources/DownrightApp/AI/MarkdownDocument.swift
+++ b/Sources/DownrightApp/AI/MarkdownDocument.swift
@@ -498,6 +498,10 @@ final class MarkdownDocument: NSObject {
     }
 
     func save(intent: SaveIntent = .normal) throws {
+        // A closed document has no owner left to consent to a write.  Stragglers
+        // (queued autosave work, occlusion events during teardown) must neither
+        // touch the file nor raise a failure alert for a window that is gone.
+        guard !isClosed else { return }
         guard let url else {
             let error = CocoaError(.fileNoSuchFile)
             publishSaveFailure(error)
@@ -719,6 +723,10 @@ final class MarkdownDocument: NSObject {
 
     @discardableResult
     func saveIfNeeded(intent: SaveIntent = .normal) -> Result<Void, Error> {
+        // Same lifetime rule as save(): after close() the document is inert.
+        // Reporting success here keeps straggler implicit saves silent instead
+        // of surfacing errors for a window that no longer exists.
+        guard !isClosed else { return .success(()) }
         guard isDirty else { return .success(()) }
         guard url != nil else {
             let error = CocoaError(.fileNoSuchFile)

--- a/Sources/DownrightApp/AI/MarkdownDocument.swift
+++ b/Sources/DownrightApp/AI/MarkdownDocument.swift
@@ -818,6 +818,25 @@ final class MarkdownDocument: NSObject {
         ScrollAnchoring.offset(for: state.anchor, in: parsed)
     }
 
+    /// Keep reference-valued fragment metadata aligned with the storage while
+    /// the parser works on its immutable snapshot.  Mirrors the projection in
+    /// MarkdownTextView's editing funnel so document-level mutations (commands,
+    /// undo/redo, external absorption) cannot leave payloads pointing at
+    /// pre-edit offsets.
+    private func projectFragmentPayloads(across range: NSRange, insertedLength: Int) {
+        var seen = Set<ObjectIdentifier>()
+        let start = max(0, min(range.location, storage.length))
+        storage.enumerateAttribute(
+            .drFragment,
+            in: NSRange(location: start, length: storage.length - start)
+        ) { value, _, _ in
+            guard let payload = value as? FragmentPayload else { return }
+            let identity = ObjectIdentifier(payload)
+            guard seen.insert(identity).inserted else { return }
+            payload.projectSourceRanges(across: range, insertedLength: insertedLength)
+        }
+    }
+
     // MARK: - Editing
     //
     // Every mutation funnels through here so undo, dirty tracking, and change
@@ -849,6 +868,14 @@ final class MarkdownDocument: NSObject {
         if let actionName { undoManager.setActionName(actionName) }
         undoManager.endUndoGrouping()
 
+        // Attribute runs move with the storage edit, but the fragment payload
+        // objects riding on them are reference values whose ranges do not.
+        // Project them across this edit exactly as MarkdownTextView does for
+        // its own editing funnel; otherwise every unchanged block below an
+        // insertion keeps pointing at pre-edit offsets until some later edit
+        // happens to redecorate it (stale code-block copies, image loads
+        // invalidating the wrong range).
+        projectFragmentPayloads(across: range, insertedLength: (replacement as NSString).length)
         storage.beginEditing()
         storage.replaceCharacters(in: range, with: replacement)
         storage.endEditing()
@@ -1451,6 +1478,12 @@ final class MarkdownDocument: NSObject {
                       hunk.oldRange.upperBound <= storage.length,
                       hunk.newRange.location >= 0,
                       hunk.newRange.upperBound <= incomingText.length else { continue }
+                // Same reference-payload rule as replace(): hunk edits shift
+                // the runs below them without moving payload ranges.
+                projectFragmentPayloads(
+                    across: hunk.oldRange,
+                    insertedLength: incomingText.substring(with: hunk.newRange).utf16.count
+                )
                 storage.replaceCharacters(
                     in: hunk.oldRange,
                     with: incomingText.substring(with: hunk.newRange)

--- a/Sources/DownrightApp/AI/PathResolver.swift
+++ b/Sources/DownrightApp/AI/PathResolver.swift
@@ -215,6 +215,16 @@ enum ExternalEditor: String, CaseIterable, Codable {
     }
 
     func open(_ file: URL, line: Int?) {
+        // Every editor path below means "edit this file", never "run it":
+        // an application bundle or Terminal script linked from a document is
+        // revealed in Finder instead of handed to any opener.
+        guard !DocumentTypes.executesWhenOpened(file) else {
+            NSWorkspace.shared.selectFile(
+                file.path,
+                inFileViewerRootedAtPath: file.deletingLastPathComponent().path
+            )
+            return
+        }
         if let schemeURL = url(for: file, line: line) {
             NSWorkspace.shared.open(schemeURL)
             return

--- a/Sources/DownrightApp/AI/SnapshotStore.swift
+++ b/Sources/DownrightApp/AI/SnapshotStore.swift
@@ -1,6 +1,5 @@
 import Foundation
 import MarkdownCore
-import Darwin
 
 /// Local time-travel (§8.3).
 ///
@@ -117,8 +116,6 @@ final class SnapshotStore: @unchecked Sendable {
     private var evictedVersionsByDocument: [String: Int] = [:]
     private var lastReport = PruneReport()
     private let historyDirectory: URL
-    private var abandonedCandidates: [String: String] = [:]
-    private let abandonedConfirmationDelay: TimeInterval = 30
 
     /// `historyDirectory` is injectable so maintenance tests can exercise real
     /// filesystem behavior without ever traversing the user's production
@@ -233,10 +230,6 @@ final class SnapshotStore: @unchecked Sendable {
         queue.async { [self] in
             lastPrune = Date()
             _ = prune()
-            queue.asyncAfter(deadline: .now() + abandonedConfirmationDelay) { [self] in
-                lastPrune = Date()
-                _ = prune()
-            }
         }
     }
 
@@ -346,53 +339,6 @@ final class SnapshotStore: @unchecked Sendable {
         prune()
     }
 
-    /// A missing path is abandoned only after its newest version has aged out
-    /// and the containing volume is mounted. This avoids deleting history for
-    /// an atomic replacement in flight or an unplugged external volume.
-    private func isAbandoned(_ index: Index, key: String, cutoff: Date) -> Bool {
-        guard let newest = index.versions.last, newest.date < cutoff else {
-            abandonedCandidates.removeValue(forKey: key)
-            return false
-        }
-        let presence = index.path.isEmpty ? PathPresence.absent : Self.pathPresence(for: index.path)
-        guard presence == .absent,
-              (index.path.isEmpty || Self.volumeIsMounted(for: index.path)) else {
-            abandonedCandidates.removeValue(forKey: key)
-            return false
-        }
-        // ENOENT is also the middle of an atomic replacement. Require the same
-        // old index to be absent in two distinct prune generations.
-        let signature = "\(index.path)\u{0}\(newest.hash)\u{0}\(newest.date.timeIntervalSinceReferenceDate)"
-        guard abandonedCandidates[key] == signature else {
-            abandonedCandidates[key] = signature
-            return false
-        }
-        return true
-    }
-
-    enum PathPresence: Equatable {
-        case present
-        case absent
-        case indeterminate
-    }
-
-    /// Uses `lstat` so permission and I/O failures are not collapsed into the
-    /// same answer as a confirmed missing path.
-    static func pathPresence(for path: String) -> PathPresence {
-        var info = stat()
-        if lstat(path, &info) == 0 { return .present }
-        switch errno {
-        case ENOENT, ENOTDIR: return .absent
-        default: return .indeterminate
-        }
-    }
-
-    static func volumeIsMounted(for path: String) -> Bool {
-        let components = (path as NSString).pathComponents
-        guard components.count > 2, components[1] == "Volumes" else { return true }
-        return pathPresence(for: "/Volumes/" + components[2]) == .present
-    }
-
     /// Trims every document against the age cap and its **own** size budget,
     /// then applies the global cap as a backstop, then garbage-collects objects
     /// no index references any more.
@@ -428,7 +374,6 @@ final class SnapshotStore: @unchecked Sendable {
             guard let data = try? Data(contentsOf: indexFile),
                   var index = try? JSONDecoder.snapshotDecoder.decode(Index.self, from: data)
             else {
-                abandonedCandidates.removeValue(forKey: documentKey)
                 hasIncompleteReferenceKnowledge = true
                 continue
             }
@@ -445,31 +390,6 @@ final class SnapshotStore: @unchecked Sendable {
             var total = index.versions.reduce(0) { $0 + $1.byteCount }
             while total > limits.2, index.versions.count > 1 {
                 total -= index.versions.removeFirst().byteCount
-            }
-
-            if isAbandoned(index, key: documentKey, cutoff: cutoff) {
-                let removed = pendingLock.withLock {
-                    do {
-                        try fm.removeItem(at: indexFile)
-                    } catch {
-                        return false
-                    }
-                    // Atomic with deletion: a concurrent record must either
-                    // see the old durable index or reload the now-empty one.
-                    stateByDocument.removeValue(forKey: documentKey)
-                    stateOrder.removeAll { $0 == documentKey }
-                    return true
-                }
-                if removed {
-                    if before > 0 {
-                        report.droppedVersions[documentKey, default: 0] += before
-                    }
-                } else {
-                    liveIndexes.append(indexFile)
-                    referenced.formUnion(index.versions.map(\.hash))
-                    if let newest = index.versions.last?.hash { newestHashes.insert(newest) }
-                }
-                continue
             }
 
             let dropped = before - index.versions.count

--- a/Sources/DownrightApp/App/AppDelegate.swift
+++ b/Sources/DownrightApp/App/AppDelegate.swift
@@ -153,7 +153,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // History pruning at launch rather than on a timer: it touches the disk
         // and there is no reason to do it while the user is reading (§8.3).
         SnapshotStore.shared.schedulePrune()
-        DocumentStateStore.shared.schedulePruneAbandonedStates()
 
         hasFinishedLaunching = true
 

--- a/Sources/DownrightApp/App/AppDelegate.swift
+++ b/Sources/DownrightApp/App/AppDelegate.swift
@@ -252,6 +252,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         for controller in windowControllers where controller.markdownDocument.isDirty {
             controller.window?.makeKeyAndOrderFront(nil)
             guard controller.confirmPendingChangesBeforeClose(markDiscardForWindowClose: true) else {
+                // A Discard answered during this cancelled attempt keeps
+                // holding: the buffer it refused is still on screen, and only
+                // fresh work (the next edit) re-arms implicit saves.
                 return .terminateCancel
             }
         }

--- a/Sources/DownrightApp/App/AppDelegate.swift
+++ b/Sources/DownrightApp/App/AppDelegate.swift
@@ -77,6 +77,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var launchLine: Int?
     /// Set by `down --review`; applies to command-line documents in this launch only.
     private var launchReview = false
+    /// Debug-only `--downright-demo-update`: show the "Update Now" pill with
+    /// synthetic metadata so the update surface can be worked on directly.
+    private var launchDemoUpdate = false
     /// Launch Services can deliver an open request between NSApplication's
     /// will-finish and did-finish callbacks. Keep that request alive until the
     /// app has installed its menus, preferences, and first-run surfaces rather
@@ -108,6 +111,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // Start the Sparkle updater after launch, as the spec requires.  Dev
         // bundles without the Sparkle Info.plist block make this a no-op.
         UpdateCoordinator.shared.start()
+#if DEBUG
+        if launchDemoUpdate {
+            // Deliberately after the first window is up: the pill's arrival
+            // emphasis is defined as "landed while the reader was here", so
+            // firing it before there is a window to land in would only ever
+            // exercise the silent path.
+            DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                MainActor.assumeIsolated {
+                    UpdateCoordinator.shared.presentDemoUpdateForDebugging()
+                }
+            }
+        }
+#endif
         NotificationCenter.default.addObserver(
             self, selector: #selector(preferencesDidChange),
             name: Preferences.didChange, object: nil
@@ -251,6 +267,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             launchLine = Int(arguments[index + 1])
         }
         launchReview = arguments.contains("--downright-review")
+        launchDemoUpdate = arguments.contains("--downright-demo-update")
     }
 
     // MARK: - Opening

--- a/Sources/DownrightApp/App/DocumentScrollGestures.swift
+++ b/Sources/DownrightApp/App/DocumentScrollGestures.swift
@@ -1,0 +1,320 @@
+import AppKit
+import MarkdownRender
+
+/// The plumbing every scroll-driven gesture over the document surface shares.
+///
+/// `MarkdownTextView` offers the host every scroll event before the scroll
+/// view sees it, and the host now has more than one answer: a modifier turns
+/// the wheel into a zoom, ⇧ and two fingers move through jump history, and two
+/// bare fingers switch Document↔Source.  They cannot all be asked at once —
+/// two gestures claiming the same event is a page that scrolls *and* zooms —
+/// so they are asked in order and the first to claim wins.
+///
+/// What lives here is only what is genuinely common: the ordering rule, the
+/// arithmetic of a sideways swipe, and the page's give.  Every threshold stays
+/// with the gesture it describes, because the numbers *are* the feel and two
+/// gestures that happen to share a formula do not share a feel.
+
+// MARK: - Modifiers
+
+/// The modifiers that can change what a scroll over the document means.
+///
+/// Caps Lock, fn and the numeric-pad flag ride along on perfectly ordinary
+/// events and must never decide a gesture, so every handler tests the four
+/// that matter and only those — and tests them for equality, not membership,
+/// or ⇧⌘-scroll would fire two gestures that disagree about the page.
+enum ScrollGestureModifiers {
+    static let considered: NSEvent.ModifierFlags = [.command, .option, .control, .shift]
+
+    static func held(in event: NSEvent) -> NSEvent.ModifierFlags {
+        event.modifierFlags.intersection(considered)
+    }
+}
+
+// MARK: - Chain
+
+/// One gesture the document surface can hand a scroll event to.
+@MainActor
+protocol ScrollGestureHandler: AnyObject {
+    /// Offer the event.  Returning `true` consumes it and the scroll view
+    /// never sees it; a handler that is still deciding must return `false` so
+    /// ordinary scrolling never waits on the decision.
+    @discardableResult
+    func handle(_ event: NSEvent) -> Bool
+
+    /// `true` while this handler is physically in the middle of a gesture it
+    /// has already taken.  A handler that says so is routed the rest of the
+    /// gesture on its own: the alternative is a modifier pressed mid-swipe
+    /// handing the events to somebody else and leaving a translated pane
+    /// nobody owns.
+    var isClaimingGesture: Bool { get }
+}
+
+extension ScrollGestureHandler {
+    var isClaimingGesture: Bool { false }
+}
+
+/// The document surface's gestures, in the order they get to claim an event.
+///
+/// Order is a real decision, not a list.  The modifier zooms decide on a
+/// single event, so they can be asked first and answer immediately.  The two
+/// swipes need travel before they can tell themselves apart from a scroll, and
+/// while they are deciding they hand the event back — which is exactly why the
+/// one that needs ⇧ has to be asked before the one that needs nothing, and why
+/// the bare swipe stands down whenever a modifier is held.
+@MainActor
+final class ScrollGestureChain {
+    private let handlers: [any ScrollGestureHandler]
+
+    init(_ handlers: [any ScrollGestureHandler]) {
+        self.handlers = handlers
+    }
+
+    @discardableResult
+    func handle(_ event: NSEvent) -> Bool {
+        // A gesture that has already caught keeps every remaining event of it,
+        // including the ones it will decline.  Polling from the top here would
+        // let a late modifier steal a swipe that is already on screen.
+        if let owner = handlers.first(where: { $0.isClaimingGesture }) {
+            return owner.handle(event)
+        }
+        for handler in handlers {
+            if handler.handle(event) { return true }
+        }
+        return false
+    }
+}
+
+// MARK: - Swipe physics
+
+/// The arithmetic behind a sideways swipe over the document surface.
+///
+/// Stateless and parameterised: each gesture states its own numbers and gets
+/// the same physics, so the Document↔Source swipe and the Back/Forward swipe
+/// resolve an axis, a commit and a give the same way while feeling like the
+/// different things they are.
+enum DocumentSwipePhysics {
+    enum Claim: Equatable {
+        /// Still ambiguous. The event belongs to the scroll view for now, so
+        /// vertical scrolling never waits on this decision.
+        case undecided
+        /// A sideways gesture: the document surface stops scrolling.
+        case swipe
+        /// Ordinary scrolling. Stop testing for the rest of the gesture.
+        case scroll
+    }
+
+    static func claim(
+        horizontal: CGFloat,
+        vertical: CGFloat,
+        intentThreshold: CGFloat,
+        axisDominance: CGFloat
+    ) -> Claim {
+        let across = abs(horizontal)
+        let along = abs(vertical)
+        if across >= intentThreshold, across >= along * axisDominance { return .swipe }
+        if along >= intentThreshold { return .scroll }
+        return .undecided
+    }
+
+    /// A share of the pane, bounded at both ends: a narrow split pane must not
+    /// commit on a twitch, and a full-width window must not demand a swipe
+    /// longer than the trackpad.
+    static func commitDistance(
+        paneWidth: CGFloat,
+        fraction: CGFloat,
+        minimum: CGFloat,
+        maximum: CGFloat
+    ) -> CGFloat {
+        min(max(paneWidth * fraction, minimum), maximum)
+    }
+
+    static func shouldCommit(
+        translation: CGFloat,
+        velocity: CGFloat,
+        distance: CGFloat,
+        flickVelocity: CGFloat
+    ) -> Bool {
+        guard translation != 0 else { return false }
+        if abs(translation) >= distance { return true }
+        // A flick commits even when short — but a reversal at the end of the
+        // gesture means "put it back", however fast the hand was moving.
+        return abs(velocity) >= flickVelocity && (velocity < 0) == (translation < 0)
+    }
+
+    /// The page's give: asymptotic, so it always answers the fingers and never
+    /// arrives anywhere.  A linear give would need a clamp, and a clamp is a
+    /// dead stop the hand can feel.
+    static func give(_ translation: CGFloat, limit: CGFloat) -> CGFloat {
+        guard limit > 0 else { return 0 }
+        let sign: CGFloat = translation < 0 ? -1 : 1
+        let distance = abs(translation)
+        return sign * limit * (1 - 1 / (distance / (limit * 0.9) + 1))
+    }
+
+    /// Smoothed instantaneous velocity, in points per second.
+    ///
+    /// One 8 ms frame is far too short a window to tell a flick from a jitter
+    /// at the end of a slow drag, so each sample only moves the estimate part
+    /// of the way.
+    static func velocity(
+        current: CGFloat,
+        delta: CGFloat,
+        elapsed: TimeInterval
+    ) -> CGFloat {
+        guard elapsed > 0.0005 else { return current }
+        let instantaneous = delta / CGFloat(elapsed)
+        return current == 0 ? instantaneous : current * 0.6 + instantaneous * 0.4
+    }
+}
+
+// MARK: - Give
+
+/// One pane's give: the live text surface translated against the fingers.
+///
+/// A layer transform, not a frame change and not a snapshot — nothing is
+/// re-rendered, nothing is laid out, and the compositor does the whole job.
+/// The gutter and footnote rail stay put, the way a scroller does: they
+/// annotate the page rather than travel with it.
+@MainActor
+final class PaneGive {
+    private(set) weak var pane: MarkdownContainerView?
+    private let wasMasking: Bool
+
+    init?(pane: MarkdownContainerView) {
+        guard pane.bounds.width > 1 else { return nil }
+        // Asked for rather than assumed. The document window is layer-backed
+        // in practice, but a give that silently does nothing when it is not
+        // is worse than a one-off backing store on the first swipe.
+        pane.wantsLayer = true
+        pane.scrollView.wantsLayer = true
+        guard let paneLayer = pane.layer, pane.scrollView.layer != nil else { return nil }
+        self.pane = pane
+        // The page has to be clipped to its own frame while it travels, or the
+        // give paints over whatever sits beside it.
+        wasMasking = paneLayer.masksToBounds
+        paneLayer.masksToBounds = true
+    }
+
+    func place(_ offset: CGFloat) {
+        guard let layer = pane?.scrollView.layer else { return }
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        layer.transform = CATransform3DMakeTranslation(offset, 0, 0)
+        CATransaction.commit()
+    }
+
+    func release() {
+        guard let pane else { return }
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        pane.scrollView.layer?.transform = CATransform3DIdentity
+        pane.layer?.masksToBounds = wasMasking
+        CATransaction.commit()
+    }
+}
+
+/// Every pane's give at once, plus the spring that puts them back.
+///
+/// A sideways gesture over a split window moves both panes together — the mode
+/// and the reading position are the window's, not one pane's — and an
+/// abandoned gesture owes the reader a return, not a snap.  Both swipes want
+/// exactly this, so neither of them owns it.
+@MainActor
+final class PaneGiveTrack {
+    private var surfaces: [PaneGive] = []
+    private var driver: Motion.SpringDriver?
+    /// Critically damped: the page returning past its own resting place would
+    /// read as a bounce nothing caused.
+    private var offset = Motion.SpringScalar(
+        value: 0,
+        perceptualDuration: Motion.springQuick
+    )
+    private var landing: (() -> Void)?
+    private var pendingLanding = false
+
+    deinit { driver?.park() }
+
+    /// `true` from `settle(completion:)` until the panes are back at rest.
+    private(set) var isSettling = false
+    var isEngaged: Bool { !surfaces.isEmpty }
+
+    /// Take hold of the panes.  Nothing is rendered and nothing is laid out;
+    /// the cost is one backing store per pane, once.
+    func engage(_ panes: [MarkdownContainerView]) {
+        release()
+        surfaces = panes.compactMap(PaneGive.init(pane:))
+        offset.snap(to: 0)
+    }
+
+    func place(_ value: CGFloat) {
+        offset.snap(to: value)
+        for surface in surfaces { surface.place(value) }
+    }
+
+    /// Spring the panes home and call `completion` when they arrive.  With no
+    /// give in flight there is nothing to wait for, so `completion` runs now.
+    func settle(completion: @escaping () -> Void) {
+        guard !surfaces.isEmpty else {
+            completion()
+            return
+        }
+        isSettling = true
+        landing = completion
+        offset.target(0)
+        guard let anchor = surfaces.first?.pane, anchor.window != nil else {
+            land()
+            return
+        }
+        let driver = self.driver ?? Motion.SpringDriver(
+            view: anchor,
+            advance: { [weak self] dt in self?.tick(dt: dt) ?? false },
+            apply: { [weak self] in self?.apply() }
+        )
+        self.driver = driver
+        if !driver.arm() { land() }
+    }
+
+    /// Hand the panes back where they were with no spring at all.  A commit
+    /// takes this path: the transition that follows draws from the pane's
+    /// resting frame and must not start from a translated layer.
+    func release() {
+        isSettling = false
+        pendingLanding = false
+        landing = nil
+        driver?.park()
+        let finishing = surfaces
+        surfaces = []
+        for surface in finishing { surface.release() }
+    }
+
+    /// No display link to spring on — off-screen, or a window already gone.
+    private func land() {
+        offset.snap(to: 0)
+        pendingLanding = false
+        for surface in surfaces { surface.place(0) }
+        finish()
+    }
+
+    private func tick(dt: CGFloat) -> Bool {
+        let moving = offset.advance(dt: dt)
+        if !moving { pendingLanding = true }
+        return moving
+    }
+
+    private func apply() {
+        for surface in surfaces { surface.place(offset.value) }
+        if pendingLanding {
+            pendingLanding = false
+            finish()
+        }
+    }
+
+    private func finish() {
+        guard isSettling else { return }
+        let completion = landing
+        landing = nil
+        isSettling = false
+        completion?()
+    }
+}

--- a/Sources/DownrightApp/App/DocumentTypes.swift
+++ b/Sources/DownrightApp/App/DocumentTypes.swift
@@ -20,4 +20,37 @@ enum DocumentTypes {
     static func isMarkdown(_ pathExtension: String) -> Bool {
         fileExtensions.contains(pathExtension.lowercased())
     }
+
+    /// Extensions LaunchServices *executes* when asked to "open" them, rather
+    /// than presenting a document: application bundles and Terminal-run
+    /// scripts. A path link or token resolving to one of these must never
+    /// hand the target to `NSWorkspace.open` — the documented contract is
+    /// "open in your editor", not "run whatever this document points at".
+    private static let executableExtensions: Set<String> = [
+        "app", "bundle", "appex", "xpc", "plugin", "kext",
+        "prefpane", "qlgenerator", "workflow", "action",
+        "command", "term", "terminal", "tool",
+    ]
+
+    /// Whether opening `url` through LaunchServices would run code instead of
+    /// showing a document. Directories are judged by their bundle extension;
+    /// plain files by a known executing extension or an executable bit with
+    /// no document extension at all (an extension-less compiled tool or
+    /// `chmod +x` script).
+    static func executesWhenOpened(_ url: URL) -> Bool {
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory) else {
+            return false
+        }
+        let pathExtension = url.pathExtension.lowercased()
+        if isDirectory.boolValue {
+            return executableExtensions.contains(pathExtension)
+        }
+        if executableExtensions.contains(pathExtension) {
+            return true
+        }
+        // An executable-bit file with no extension at all is a raw binary or
+        // a chmod'ed script; either way "open" means run.
+        return pathExtension.isEmpty && FileManager.default.isExecutableFile(atPath: url.path)
+    }
 }

--- a/Sources/DownrightApp/App/DocumentWindowController+Actions.swift
+++ b/Sources/DownrightApp/App/DocumentWindowController+Actions.swift
@@ -287,13 +287,11 @@ enum CodeFileExtensions {
 // activity, the panels a reader reaches for, task progress, overflow — that
 // never nudges the centre rail.
 //
-// Contents / Outline and Find are in that cluster rather than inside `···` on
-// purpose.
+// Find is in that cluster rather than inside `···` on purpose.
 // The overflow was the only interactive control on the trailing edge, which
-// put every panel in the app one unlabelled glyph and one menu away in a
-// window with room for three more buttons.  `···` keeps what a reader reaches
-// for occasionally; the two panels they reach for constantly are out where
-// they can be seen and hit.
+// put a frequent document action one unlabelled glyph and one menu away in a
+// window with room for another button.  `···` keeps what a reader reaches for
+// occasionally; Find stays visible because it is used constantly.
 //
 // The cluster ships as a single toolbar item, not five: AppKit pads every
 // custom-view item by its own margin — a tax even a hidden 1pt placeholder
@@ -358,13 +356,6 @@ extension DocumentWindowController: NSToolbarDelegate, NSMenuDelegate, NSToolbar
             return item
 
         case Self.clusterItem:
-            let contentsButton = ToolbarActionButton(
-                symbol: "list.bullet.indent", label: Command.documentLens.title,
-                help: "Show or hide the document Contents and Outline",
-                target: self, action: #selector(toolbarShowDocumentLens(_:)),
-                usesGlassSurface: true
-            )
-            contentsButton.styleSheet = activeStyleSheet
             let findButton = ToolbarActionButton(
                 symbol: "magnifyingglass", label: "Find",
                 help: "Find in this document",
@@ -383,7 +374,6 @@ extension DocumentWindowController: NSToolbarDelegate, NSMenuDelegate, NSToolbar
             let item = NSToolbarItem(itemIdentifier: identifier)
             item.view = ToolbarTrailingCluster(views: [
                 activityIndicator,
-                contentsButton,
                 findButton,
                 progressRing,
                 pill,

--- a/Sources/DownrightApp/App/DocumentWindowController+Actions.swift
+++ b/Sources/DownrightApp/App/DocumentWindowController+Actions.swift
@@ -401,10 +401,6 @@ extension DocumentWindowController: NSToolbarDelegate, NSMenuDelegate, NSToolbar
             let menuRep = NSMenuItem(title: "Actions", action: nil, keyEquivalent: "")
             let repMenu = NSMenu(title: "Actions")
             repMenu.addItem(menuItem(
-                title: Command.documentLens.title, symbol: "list.bullet.indent",
-                action: #selector(toolbarShowDocumentLens(_:))
-            ))
-            repMenu.addItem(menuItem(
                 title: "Find", symbol: "magnifyingglass",
                 action: #selector(toolbarShowFind(_:))
             ))
@@ -538,10 +534,6 @@ extension DocumentWindowController: NSToolbarDelegate, NSMenuDelegate, NSToolbar
         toggleTaskPanel()
     }
 
-    @objc private func toolbarShowDocumentLens(_ sender: Any?) {
-        perform(.documentLens)
-    }
-
     @objc private func toolbarToggleSourceFocus(_ sender: Any?) {
         toolbarModeChanged(primaryContainer.textView.sourceFocus == .none ? 1 : 0)
     }
@@ -567,7 +559,6 @@ extension DocumentWindowController: NSToolbarDelegate, NSMenuDelegate, NSToolbar
         menu.delegate = self
 
         menu.addItem(sectionHeader("Panels"))
-        addCommands([.documentLens], to: menu)
         menu.addItem(menuItem(title: "Tasks", symbol: "checkmark.circle", action: #selector(toolbarShowTasks(_:))))
         menu.addItem(menuItem(title: "History", symbol: "clock.arrow.circlepath", action: #selector(toolbarShowHistory(_:))))
 

--- a/Sources/DownrightApp/App/DocumentWindowController+Actions.swift
+++ b/Sources/DownrightApp/App/DocumentWindowController+Actions.swift
@@ -338,7 +338,7 @@ extension DocumentWindowController: NSToolbarDelegate, NSMenuDelegate, NSToolbar
 
         case Self.modeItem:
             let control = ToolbarPresentationControl { [weak self] selectedSegment in
-                self?.toolbarModeChanged(selectedSegment)
+                self?.changePresentation(to: selectedSegment)
             }
             control.isHidden = false
             toolbarPresentationControl = control
@@ -440,8 +440,56 @@ extension DocumentWindowController: NSToolbarDelegate, NSMenuDelegate, NSToolbar
         true
     }
 
-    private func toolbarModeChanged(_ selectedSegment: Int) {
+    /// The presentation the document is actually in: `0` Document, `1` Source.
+    /// Read from the text surface rather than the rail, which a swipe in
+    /// flight has scrubbed somewhere between the two.
+    var presentationSegment: Int {
+        primaryContainer.textView.sourceFocus != .none
+            || (splitContainer.map { $0.textView.sourceFocus != .none } ?? false) ? 1 : 0
+    }
+
+    /// Switch presentation.  Shared by the rail and the two-finger swipe, so
+    /// both land on exactly one transition and one cost — the swipe adds no
+    /// rendering of its own precisely because this is not cheap.
+    /// How many lines the open document has.  The swipe asks, because whether
+    /// it can afford to drag the next presentation in under the fingers is a
+    /// question about this document's length.
+    var documentLineCount: Int {
+        markdownDocument.parsed.lineStarts.count
+    }
+
+    /// Switch presentation with no transition of its own.
+    ///
+    /// The live drag takes this rather than `changePresentation(to:)`: it is
+    /// already drawing the transition itself, it drives the rail itself, and it
+    /// performs the switch *behind* a still of the outgoing page — so a second
+    /// animation would flicker and a rail refresh would snap the indicator out
+    /// from under the fingers.  It also has to be able to put the mode back
+    /// when a drag is abandoned, which an animated switch cannot do quietly.
+    func setPresentationSegment(_ segment: Int) {
+        let showSource = segment == 1
+        let started = DispatchTime.now().uptimeNanoseconds
+        for pane in documentPanes {
+            if showSource {
+                pane.textView.focusEntireSource()
+            } else {
+                pane.textView.clearSourceFocus()
+            }
+        }
+        recordPresentationSwitchCost(since: started)
+    }
+
+    /// Feed what the switch actually cost back into the swipe's budget, so the
+    /// estimate is calibrated on this machine and this document rather than on
+    /// the one the constant was measured on.
+    private func recordPresentationSwitchCost(since started: UInt64) {
+        let elapsed = Double(DispatchTime.now().uptimeNanoseconds - started) / 1_000_000
+        PresentationSwitchBudget.record(cost: elapsed, lines: documentLineCount)
+    }
+
+    func changePresentation(to selectedSegment: Int) {
         let showSource = selectedSegment == 1
+        let started = DispatchTime.now().uptimeNanoseconds
         for pane in documentPanes {
             let outgoing = activeStyleSheet.reduceMotion ? nil : snapshot(of: pane)
             if showSource {
@@ -451,6 +499,7 @@ extension DocumentWindowController: NSToolbarDelegate, NSMenuDelegate, NSToolbar
             }
             animatePresentationChange(in: pane, outgoing: outgoing, showSource: showSource)
         }
+        recordPresentationSwitchCost(since: started)
         refreshSourceFocusToolbar()
         // The mode control should change presentation, then return the user to
         // the editor. Leaving first responder on the toolbar makes an editable
@@ -535,7 +584,7 @@ extension DocumentWindowController: NSToolbarDelegate, NSMenuDelegate, NSToolbar
     }
 
     @objc private func toolbarToggleSourceFocus(_ sender: Any?) {
-        toolbarModeChanged(primaryContainer.textView.sourceFocus == .none ? 1 : 0)
+        changePresentation(to: primaryContainer.textView.sourceFocus == .none ? 1 : 0)
     }
 
     @objc private func toolbarShowHistory(_ sender: Any?) {
@@ -577,6 +626,9 @@ extension DocumentWindowController: NSToolbarDelegate, NSMenuDelegate, NSToolbar
         addCommands([.tidyDocument, .readerProfiles], to: menu)
 
         menu.addItem(sectionHeader("Share"))
+        // The section header has always said Share; until now everything under
+        // it wrote a file the reader then had to go and find.
+        addCommands([.share, .shareAsPDF], to: menu)
         let export = NSMenu(title: "Export")
         addCommands([.exportPDF, .exportHTML, .exportSelectionAsImage], to: export)
         let exportItem = NSMenuItem(title: "Export", action: nil, keyEquivalent: "")

--- a/Sources/DownrightApp/App/DocumentWindowController+AssetInsertion.swift
+++ b/Sources/DownrightApp/App/DocumentWindowController+AssetInsertion.swift
@@ -1,0 +1,151 @@
+import AppKit
+import MarkdownCore
+import MarkdownRender
+
+/// Everything that puts a new asset into the document: a drag dropped on the
+/// text surface, and — through the one shared insertion below — a Continuity
+/// Camera capture.
+///
+/// The two arrive by completely different routes and have exactly one thing in
+/// common: a file lands next to the document and one Markdown reference to it
+/// lands in the source, as a single explicit mutation with its own undo
+/// boundary.  That last part is why they share `insertAssetMarkdown` rather
+/// than each having their own copy — two implementations of "insert an asset"
+/// would eventually disagree about the undo boundary, the caret, or the
+/// refresh, and all three are invisible until they are wrong.
+@MainActor
+extension DocumentWindowController {
+
+    // MARK: - Drops (§7.1)
+
+    /// Asked once per drag, before anything is drawn.
+    ///
+    /// This is where the never-saved window is answered.  A drag carrying real
+    /// *files* is always accepted: even with no folder to be relative to, a
+    /// `file:` destination points at something that exists.  A drag carrying
+    /// only image *bytes* is refused, because there is nowhere to put them —
+    /// see `DroppedAsset.plan` for the full reasoning, which is the same one
+    /// Continuity Camera uses to decline an untitled window.
+    func markdownTextView(_ view: MarkdownTextView, canAcceptDrop drop: DocumentDrop) -> Bool {
+        switch DroppedAsset.payload(from: drop.pasteboard) {
+        case .files: return true
+        case .imageData: return markdownDocument.url != nil
+        case nil: return false
+        }
+    }
+
+    func markdownTextView(_ view: MarkdownTextView, didAcceptDrop drop: DocumentDrop) -> Bool {
+        guard let payload = DroppedAsset.payload(from: drop.pasteboard) else { return false }
+        let directory = markdownDocument.url?.deletingLastPathComponent()
+        let insertions = DroppedAsset.plan(
+            for: payload,
+            documentDirectory: directory,
+            documentBaseName: markdownDocument.url?.deletingPathExtension().lastPathComponent
+                ?? markdownDocument.displayName,
+            isTaken: { name in
+                guard let directory else { return false }
+                return FileManager.default.fileExists(
+                    atPath: directory.appendingPathComponent(name).path
+                )
+            }
+        )
+        guard !insertions.isEmpty else { return false }
+        return commitDrop(insertions, into: directory, at: drop.sourceOffset)
+    }
+
+    /// Writes first, then inserts — and inserts nothing at all if a write
+    /// fails.
+    ///
+    /// A half-applied drop is the worst outcome available here: three images
+    /// dragged in together, two on disk, and a reference to a third that was
+    /// never written, drawn as a missing asset in a document the reader now has
+    /// to repair by hand.  So the files this operation created are removed
+    /// again on failure — which is a rollback of this operation's own writes,
+    /// not a deletion of anything the reader owns — and the error is reported
+    /// rather than being quietly turned into "nothing happened" (§3.1).
+    private func commitDrop(
+        _ insertions: [DroppedAsset.Insertion],
+        into directory: URL?,
+        at offset: Int
+    ) -> Bool {
+        let writes = insertions.compactMap(\.write)
+        // Only a plan that writes needs a folder, and `DroppedAsset` never
+        // produces one that does without checking.  Refusing here as well is
+        // the same invariant enforced at the point of the write rather than
+        // only at the point of the plan.
+        guard writes.isEmpty || directory != nil else { return false }
+
+        var created: [URL] = []
+        for write in writes {
+            guard let directory else { break }
+            let target = directory.appendingPathComponent(write.fileName)
+            do {
+                switch write.contents {
+                case .data(let data):
+                    // `.withoutOverwriting` closes the gap between picking a
+                    // free name and using it: a drop must never be able to
+                    // replace a file that appeared in between, because that
+                    // file could be an asset the document already references.
+                    try data.write(to: target, options: .withoutOverwriting)
+                case .copyOf(let origin):
+                    try FileManager.default.copyItem(at: origin, to: target)
+                }
+                created.append(target)
+            } catch {
+                created.forEach { try? FileManager.default.removeItem(at: $0) }
+                presentOperationError("Couldn’t add the dropped file", error: error)
+                return false
+            }
+        }
+
+        guard let edit = DroppedAsset.edit(
+            insertions: insertions, in: markdownDocument.text, at: offset
+        ) else {
+            created.forEach { try? FileManager.default.removeItem(at: $0) }
+            return false
+        }
+        // The name is what the reader reads in Edit ▸ Undo, so it names what
+        // they did rather than what the code did.
+        let actionName: String
+        if insertions.count > 1 {
+            actionName = "Insert Files"
+        } else {
+            actionName = insertions[0].isBlock ? "Insert Image" : "Insert Link"
+        }
+        insertAssetMarkdown(edit, actionName: actionName)
+        return true
+    }
+
+    // MARK: - The one insertion
+
+    /// One insertion, with an undo boundary, and nothing else.
+    ///
+    /// Deliberately inserts at a zero-length range rather than replacing the
+    /// selection.  A drop lands where the pointer is, not where the caret is,
+    /// and a capture arrives seconds after the reader last looked at the
+    /// document — in both cases whatever happens to be selected is not part of
+    /// what they asked for, and consuming it would delete a paragraph they
+    /// cannot see.
+    ///
+    /// Undo takes the reference back out and leaves the written file where it
+    /// is.  Deleting a file the reader has not asked to delete is the more
+    /// destructive half of the pair, and for a capture the file is the only
+    /// copy.
+    func insertAssetMarkdown(
+        _ insertion: (replacement: String, origin: Int, caret: Int),
+        actionName: String
+    ) {
+        applyInPlaceDocumentEdits(
+            [TextEdit(
+                range: NSRange(location: insertion.origin, length: 0),
+                replacement: insertion.replacement,
+                summary: actionName
+            )],
+            actionName: actionName
+        )
+        containerTextView.setSourceSelectedRanges([NSRange(location: insertion.caret, length: 0)])
+        // The file appeared after the last render pass, so the image fragment
+        // is holding a "missing asset" result for a path that now exists.
+        documentPanes.forEach { $0.textView.refreshLocalAssets() }
+    }
+}

--- a/Sources/DownrightApp/App/DocumentWindowController+Commands.swift
+++ b/Sources/DownrightApp/App/DocumentWindowController+Commands.swift
@@ -35,7 +35,8 @@ extension DocumentWindowController: CommandResponder {
             canGoForward: jumpHistory.canGoForward,
             isSpeaking: isSpeakingDocument,
             caretIsInTable: caretIsInTable,
-            hasChangeMarks: !markdownDocument.changes.decoratedMarks.isEmpty
+            hasChangeMarks: !markdownDocument.changes.decoratedMarks.isEmpty,
+            hasQuickLookTarget: hasQuickLookTarget
         )
     }
 
@@ -222,6 +223,10 @@ extension DocumentWindowController: CommandResponder {
             authorizeLocalEffect(.launchPathOrEditor, target: url) {
                 NSWorkspace.shared.activateFileViewerSelecting([url])
             }
+        // Reports whether anything was previewed, so a Quick Look aimed at
+        // nothing can fall back the way the caller expects rather than
+        // silently swallowing the key.
+        case .quickLook: return quickLookAtSelection()
         case .openInEditor:
             guard let url = markdownDocument.url else { return true }
             authorizeLocalEffect(.launchPathOrEditor, target: url) {
@@ -238,6 +243,8 @@ extension DocumentWindowController: CommandResponder {
         case .exportHTML: exportHTML()
         case .exportPDF: exportPDF()
         case .exportSelectionAsImage: exportSelectionAsImage()
+        case .share: shareDocument()
+        case .shareAsPDF: shareDocumentAsPDF()
         case .increaseTextSize: adjustTextSize(by: 1)
         case .decreaseTextSize: adjustTextSize(by: -1)
         case .resetTextSize: Preferences.shared.update { $0.textSizeAdjustment = 0 }

--- a/Sources/DownrightApp/App/DocumentWindowController+ContinuityCamera.swift
+++ b/Sources/DownrightApp/App/DocumentWindowController+ContinuityCamera.swift
@@ -1,0 +1,112 @@
+import AppKit
+import MarkdownCore
+
+/// Continuity Camera: "Take Photo" and "Scan Documents", served by a nearby
+/// iPhone or iPad straight into the document at the caret.
+///
+/// The machinery is the Services one.  AppKit inserts the two menu items into
+/// `MainMenu`'s Insert submenu (the placeholder carrying
+/// `NSMenuItem.importFromDeviceIdentifier`) only when something in the
+/// responder chain says it can accept an image, and delivers the capture by
+/// calling `readSelection(from:)` on whatever said so.
+///
+/// The window controller is the responder that says so, not the text view: the
+/// text view has `importsGraphics` off — it holds Markdown source, not an
+/// attributed string with attachments — so it correctly declines image return
+/// types and passes the question up the chain to here, which is the object that
+/// knows where the document lives on disk.
+@MainActor
+extension DocumentWindowController: @preconcurrency NSServicesMenuRequestor {
+
+    /// Advertises the image return types Continuity Camera looks for.
+    ///
+    /// Gated on the document having a file, and this is the deliberate answer
+    /// to the never-saved window.  A Markdown image reference is a *path*, and
+    /// until the document exists on disk there is no folder to make that path
+    /// relative to.  Every alternative is worse than not offering the capture:
+    /// an absolute path into a temporary folder is flagged non-portable by the
+    /// Asset Doctor, renders only behind a trust prompt (`LocalAssetPolicy`
+    /// trusts a local asset without asking only inside the document's own
+    /// directory), and breaks the moment macOS reclaims the folder.  Declining
+    /// here means AppKit simply does not offer Take Photo for an untitled
+    /// window — the standard macOS presentation for "not available yet" —
+    /// rather than accepting a photo the reader has already taken and then
+    /// failing to place it.
+    override func validRequestor(
+        forSendType sendType: NSPasteboard.PasteboardType?,
+        returnType: NSPasteboard.PasteboardType?
+    ) -> Any? {
+        // A send type means the service also wants to *read* a selection out of
+        // this object, which it cannot: nothing here writes to a pasteboard.
+        let wantsNothingFromUs = sendType == nil || sendType?.rawValue.isEmpty == true
+        if let returnType, wantsNothingFromUs,
+           markdownDocument.url != nil,
+           CapturedImage.acceptsReturnType(returnType) {
+            return self
+        }
+        return super.validRequestor(forSendType: sendType, returnType: returnType)
+    }
+
+    /// Receives the capture.
+    ///
+    /// Writes the image next to the document and inserts one Markdown
+    /// reference at the caret as a single explicit source mutation with its own
+    /// undo boundary.  Returning false leaves the capture unconsumed, which is
+    /// what AppKit needs in order to report the failure itself.
+    func readSelection(from pasteboard: NSPasteboard) -> Bool {
+        // `validRequestor` already refuses an untitled window, so this is the
+        // same invariant enforced at the point of the write rather than only at
+        // the point of the advertisement — a Service invoked another way must
+        // not be able to reach the insertion path with nowhere to put the file.
+        guard let documentURL = markdownDocument.url else { return false }
+        guard let payload = CapturedImage.payload(from: pasteboard) else { return false }
+
+        let directory = documentURL.deletingLastPathComponent()
+        let fileName = CapturedImage.uniqueFileName(
+            in: directory,
+            documentBaseName: documentURL.deletingPathExtension().lastPathComponent,
+            fileExtension: payload.fileExtension
+        )
+        do {
+            // `.withoutOverwriting` closes the gap between picking a free name
+            // and using it.  A capture must never be able to replace a file
+            // that appeared in between — that file could be an asset the
+            // document already references.
+            try payload.data.write(to: directory.appendingPathComponent(fileName), options: .withoutOverwriting)
+        } catch {
+            presentOperationError("Couldn’t save the captured image", error: error)
+            return false
+        }
+
+        insertCapturedImageReference(fileName: fileName)
+        return true
+    }
+
+    /// One insertion at the caret, with an undo boundary, and nothing else.
+    ///
+    /// Deliberately inserts at the *start* of the selection instead of
+    /// replacing it.  Everywhere else in the app a command that acts on a
+    /// selection may consume it, because the user can see the selection while
+    /// they invoke the command.  Here they cannot: the capture is triggered on
+    /// a phone, seconds pass, and whatever the document had selected when the
+    /// menu item was chosen is off screen and out of mind.  Letting a photo
+    /// arrive and silently delete a paragraph would be unrecoverable in every
+    /// sense except the undo stack.
+    ///
+    /// The insertion itself — the edit, the boundary, the caret, the asset
+    /// refresh — is `insertAssetMarkdown`, shared with the drop path so the two
+    /// routes an image can take into a document cannot drift apart.
+    private func insertCapturedImageReference(fileName: String) {
+        // Source coordinates throughout: `sourceSelectedRange` is already in
+        // the document's own UTF-16 space, never a TextKit display offset.
+        insertAssetMarkdown(
+            CapturedImage.insertion(
+                destination: fileName,
+                altText: CapturedImage.altText(forFileNamed: fileName),
+                in: markdownDocument.text,
+                at: containerTextView.sourceSelectedRange.location
+            ),
+            actionName: "Insert Photo"
+        )
+    }
+}

--- a/Sources/DownrightApp/App/DocumentWindowController+Delegates.swift
+++ b/Sources/DownrightApp/App/DocumentWindowController+Delegates.swift
@@ -96,6 +96,15 @@ extension DocumentWindowController: MarkdownTextViewDelegate {
             authorizeLocalEffect(.launchPathOrEditor, target: target) {
                 if DocumentTypes.isMarkdown(target.pathExtension) {
                     (NSApp.delegate as? AppDelegate)?.open(target)
+                } else if DocumentTypes.executesWhenOpened(target) {
+                    // "Open in editor" never means "run this": an application
+                    // bundle or Terminal script linked from a document is
+                    // revealed in Finder instead, so showing where it lives
+                    // stays possible while running it stays a manual act.
+                    NSWorkspace.shared.selectFile(
+                        target.path,
+                        inFileViewerRootedAtPath: target.deletingLastPathComponent().path
+                    )
                 } else {
                     NSWorkspace.shared.open(target)
                 }
@@ -120,6 +129,15 @@ extension DocumentWindowController: MarkdownTextViewDelegate {
                     (NSApp.delegate as? AppDelegate)?.open(target)
                 } else {
                     openInPlace(target)
+                }
+            } else if DocumentTypes.executesWhenOpened(target) {
+                // Same rule as .localFile: reveal execution-capable targets,
+                // never run them from inside a document.
+                authorizeLocalEffect(.launchPathOrEditor, target: target) {
+                    NSWorkspace.shared.selectFile(
+                        target.path,
+                        inFileViewerRootedAtPath: target.deletingLastPathComponent().path
+                    )
                 }
             } else {
                 authorizeLocalEffect(.launchPathOrEditor, target: target) {

--- a/Sources/DownrightApp/App/DocumentWindowController+Delegates.swift
+++ b/Sources/DownrightApp/App/DocumentWindowController+Delegates.swift
@@ -38,6 +38,18 @@ extension DocumentWindowController: MarkdownTextViewDelegate {
             $0.textSizeAdjustment = $0.textSizeAdjustment == 0 ? 3 : 0
         }
     }
+
+    /// Four things can happen on this surface's wheel: ⌘ sizes the text, ⌥
+    /// steps structural detail, ⇧ and two fingers sideways move through jump
+    /// history, and two bare fingers sideways switch Document↔Source.  They
+    /// are asked in that order and the first to claim wins; anything none of
+    /// them has claimed goes straight back, so vertical scrolling — which is
+    /// what almost every one of these events is — is untouched.
+    func markdownTextView(
+        _ view: MarkdownTextView, shouldClaimScrollGesture event: NSEvent
+    ) -> Bool {
+        documentScrollGestures.handle(event)
+    }
     func markdownTextView(
         _ view: MarkdownTextView, didRequestHeadingLevel level: Int?, headingIndex: Int
     ) {

--- a/Sources/DownrightApp/App/DocumentWindowController+Delegates.swift
+++ b/Sources/DownrightApp/App/DocumentWindowController+Delegates.swift
@@ -232,6 +232,33 @@ extension DocumentWindowController: MarkdownTextViewDelegate {
 
     // MARK: Context menus (§7.1)
 
+    /// Opens a path token in the user's editor.  Returns false — and touches
+    /// nothing — when the token does not resolve to an existing file, matching
+    /// `didActivatePathToken` and the documented missing-path contract.
+    @discardableResult
+    func openPathTokenInEditor(_ token: PathToken) -> Bool {
+        guard let resolution = pathResolver?.resolve(token),
+              resolution.exists,
+              let url = resolution.url else { return false }
+        authorizeLocalEffect(.launchPathOrEditor, target: url) {
+            Preferences.shared.values.externalEditor.open(url, line: token.line)
+        }
+        return true
+    }
+
+    /// Reveals a path token's file in Finder; same missing-path rule as
+    /// `openPathTokenInEditor`.
+    @discardableResult
+    func revealPathTokenInFinder(_ token: PathToken) -> Bool {
+        guard let resolution = pathResolver?.resolve(token),
+              resolution.exists,
+              let url = resolution.url else { return false }
+        authorizeLocalEffect(.launchPathOrEditor, target: url) {
+            NSWorkspace.shared.activateFileViewerSelecting([url])
+        }
+        return true
+    }
+
     func markdownTextView(_ view: MarkdownTextView, wantsContextMenuFor target: ContextTarget) -> NSMenu? {
         let menu = NSMenu()
         switch target.kind {
@@ -269,17 +296,14 @@ extension DocumentWindowController: MarkdownTextViewDelegate {
         case .pathToken(let token):
             menu.addItem(editMarkdownItem(view: view, range: target.sourceRange))
             menu.addItem(.separator())
+            // Missing paths stay inert on every surface, including this one:
+            // no editor launch and no Finder reveal may run for a target that
+            // does not exist (§ Workspace and path resolution).
             menu.addItem(actionItem("Open in Editor") { [weak self] in
-                guard let self, let resolution = self.pathResolver?.resolve(token), let url = resolution.url else { return }
-                self.authorizeLocalEffect(.launchPathOrEditor, target: url) {
-                    Preferences.shared.values.externalEditor.open(url, line: token.line)
-                }
+                _ = self?.openPathTokenInEditor(token)
             })
             menu.addItem(actionItem("Reveal in Finder") { [weak self] in
-                guard let self, let url = self.pathResolver?.resolve(token).url else { return }
-                self.authorizeLocalEffect(.launchPathOrEditor, target: url) {
-                    NSWorkspace.shared.activateFileViewerSelecting([url])
-                }
+                _ = self?.revealPathTokenInFinder(token)
             })
             menu.addItem(actionItem("Copy Path") {
                 NSPasteboard.general.clearContents()

--- a/Sources/DownrightApp/App/DocumentWindowController+Share.swift
+++ b/Sources/DownrightApp/App/DocumentWindowController+Share.swift
@@ -1,0 +1,146 @@
+import AppKit
+import MarkdownCore
+import ObjectiveC
+
+private var sharePickerKey: UInt8 = 0
+
+/// Share (§9.5's other half).
+///
+/// Export writes a file the user then has to go and find; Share hands the same
+/// document straight to Mail, Messages, AirDrop, or Notes.  Both end at a real
+/// file on disk — see `DocumentShareSource` for why a text blob is the wrong
+/// thing to give a share sheet — so the only work here is deciding which file,
+/// producing it, and putting the picker somewhere the reader is looking.
+@MainActor
+extension DocumentWindowController: @preconcurrency NSSharingServicePickerDelegate,
+    NSSharingServiceDelegate {
+
+    // MARK: - Commands
+
+    func shareDocument() {
+        let source = DocumentShareSource.choose(
+            url: markdownDocument.url,
+            hasUnsavedChanges: markdownDocument.isDirty,
+            displayName: markdownDocument.displayName
+        )
+        let url: URL
+        do {
+            url = try DocumentShareStaging.fileURL(
+                for: source,
+                text: markdownDocument.text,
+                fidelity: markdownDocument.fidelity
+            )
+        } catch {
+            // Never translate an I/O failure into "nothing happened": the
+            // reader chose Share and would otherwise be left watching a menu
+            // close on silence.
+            presentOperationError("Couldn’t prepare this document for sharing", error: error)
+            return
+        }
+        presentSharingPicker(items: [url])
+    }
+
+    func shareDocumentAsPDF() {
+        // The same renderer Print and Export PDF use, so what the receiver
+        // opens is what the printer would have produced — a stylesheet made
+        // for paper, not a screenshot of the current theme (§9.5).
+        let exporter = HTMLExporter(
+            document: markdownDocument.parsed,
+            theme: currentStyleSheet.theme,
+            title: markdownDocument.displayName,
+            baseDirectory: markdownDocument.url?.deletingLastPathComponent(),
+            imageProvider: NativeFragmentImageProvider(styleSheet: currentStyleSheet),
+            forPrint: true
+        )
+        beginActivity()
+        defer { endActivity() }
+        let url: URL
+        do {
+            url = try DocumentShareStaging.pdfURL(displayName: markdownDocument.displayName)
+        } catch {
+            presentOperationError("Couldn’t prepare this document for sharing", error: error)
+            return
+        }
+        guard PrintRenderer.writePDF(html: exporter.html(), to: url) else {
+            presentOperationError(
+                "Couldn’t prepare this document for sharing",
+                error: NSError(
+                    domain: "Downright.Export", code: 1,
+                    userInfo: [NSLocalizedDescriptionKey: "The PDF renderer could not produce a file to share."]
+                )
+            )
+            return
+        }
+        presentSharingPicker(items: [url])
+    }
+
+    // MARK: - The picker
+
+    /// Held for as long as the sheet is up.  `NSSharingServicePicker` does not
+    /// retain itself, and a picker released at the end of the command's stack
+    /// frame takes its popover with it before the user can pick anything.
+    private var sharingPicker: NSSharingServicePicker? {
+        get { objc_getAssociatedObject(self, &sharePickerKey) as? NSSharingServicePicker }
+        set { objc_setAssociatedObject(self, &sharePickerKey, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC) }
+    }
+
+    private func presentSharingPicker(items: [Any]) {
+        guard let (anchor, rect) = sharingAnchor() else { return }
+        // A second Share while one is open would leave the first picker
+        // orphaned with no way to dismiss it.
+        sharingPicker?.close()
+        let picker = NSSharingServicePicker(items: items)
+        picker.delegate = self
+        sharingPicker = picker
+        picker.show(relativeTo: rect, of: anchor, preferredEdge: .maxY)
+    }
+
+    /// Where the sheet flies out of.
+    ///
+    /// The `···` overflow is the toolbar control that already carries Export,
+    /// so a share invoked from the File menu appears from the same corner as
+    /// one invoked from the toolbar.  When the window is too narrow for the
+    /// cluster the button is gone, and the top edge of the document is the
+    /// honest fallback — a picker pinned to a control that is not on screen
+    /// would open in the wrong place or not at all.
+    private func sharingAnchor() -> (NSView, NSRect)? {
+        if let button = toolbarOverflowButton, button.window != nil, !button.isHiddenOrHasHiddenAncestor {
+            return (button, button.bounds)
+        }
+        guard let content = window?.contentView else { return nil }
+        let rect = NSRect(x: content.bounds.midX, y: content.bounds.maxY - 1, width: 1, height: 1)
+        return (content, rect)
+    }
+
+    // MARK: - NSSharingServicePickerDelegate
+
+    func sharingServicePicker(
+        _ sharingServicePicker: NSSharingServicePicker,
+        delegateFor sharingService: NSSharingService
+    ) -> (any NSSharingServiceDelegate)? {
+        self
+    }
+
+    func sharingServicePicker(
+        _ sharingServicePicker: NSSharingServicePicker,
+        didChoose service: NSSharingService?
+    ) {
+        // Called with a nil service when the picker was dismissed, so this is
+        // the one place that reliably fires either way.
+        if sharingPicker === sharingServicePicker { sharingPicker = nil }
+    }
+
+    // MARK: - NSSharingServiceDelegate
+
+    func sharingService(
+        _ sharingService: NSSharingService,
+        sourceWindowForShareItems items: [Any],
+        sharingContentScope: UnsafeMutablePointer<NSSharingService.SharingContentScope>
+    ) -> NSWindow? {
+        // `.full`: the item being shared is the whole document, not a fragment
+        // of it, which is what makes the Mail/Messages composer animate out of
+        // this window rather than the middle of the screen.
+        sharingContentScope.pointee = .full
+        return window
+    }
+}

--- a/Sources/DownrightApp/App/DocumentWindowController+Trust.swift
+++ b/Sources/DownrightApp/App/DocumentWindowController+Trust.swift
@@ -192,7 +192,12 @@ extension DocumentWindowController: TrustPromptViewDelegate {
             path = nil
         }
         guard let path else { return }
-        guard trustStore.grant(scope: scope, path: path, effects: [request.effect]) else {
+        guard trustStore.grant(
+            scope: scope,
+            path: path,
+            effects: [request.effect],
+            externalURL: request.target.externalURL
+        ) else {
             presentOperationError(
                 "Couldn’t save this trust decision",
                 error: CocoaError(.fileWriteUnknown)

--- a/Sources/DownrightApp/App/DocumentWindowController.swift
+++ b/Sources/DownrightApp/App/DocumentWindowController.swift
@@ -116,6 +116,12 @@ final class DocumentWindowController: NSWindowController {
     private var isPinned = false
     private var focusModeApplied = false
     private var discardChangesOnClose = false
+    /// Set the moment the user chooses Discard in the close/quit prompt and
+    /// never cleared afterwards.  Between that choice and the window actually
+    /// tearing down, occlusion changes and queued autosave work can still fire;
+    /// every implicit write path checks this so a refused buffer is never
+    /// committed behind the user's back.
+    private var implicitSaveSuppressed = false
     private var focusDimmingViews: [FocusDimmingView] = []
     private var isSynchronizingPanes = false
     private var pendingInitialRestoreOffset: Int?
@@ -223,6 +229,9 @@ final class DocumentWindowController: NSWindowController {
         isOpeningDocument = true
         defer { isOpeningDocument = false }
         resetTransientChrome()
+        // The suppression belongs to the buffer the user declined to keep; a
+        // different document opened in this window starts with a clean slate.
+        implicitSaveSuppressed = false
         try markdownDocument.open(url)
         clearStaleFullDocumentSelectionIfNeeded()
         let requestedMode = mode.normalizedForEditing
@@ -1086,11 +1095,16 @@ final class DocumentWindowController: NSWindowController {
     /// and autosave is enabled.  Repeated edits reset the timer, so a rapid
     /// typing burst produces one save, not one per keystroke.
     private func scheduleAutosave() {
+        // scheduleAutosave runs exactly when the buffer turns dirty, i.e. on
+        // fresh work.  A previous Discard decision covered the buffer as it
+        // existed then; new edits are new work and re-arm implicit saves.
+        implicitSaveSuppressed = false
         guard Preferences.shared.values.autosaveEnabled,
               markdownDocument.url != nil else { return }
         autosaveWorkItem?.cancel()
         let work = DispatchWorkItem { [weak self] in
-            guard let self, self.markdownDocument.isDirty else { return }
+            guard let self, self.markdownDocument.isDirty,
+                  !self.implicitSaveSuppressed else { return }
             _ = self.saveDocument()
         }
         autosaveWorkItem = work
@@ -2516,6 +2530,10 @@ final class DocumentWindowController: NSWindowController {
     @discardableResult
     func confirmPendingChangesBeforeClose(markDiscardForWindowClose: Bool) -> Bool {
         discardChangesOnClose = false
+        // The prompt runs a modal loop during which main-queue work items still
+        // drain.  A pending autosave firing here would write the buffer before
+        // the user has even answered "Save changes?", so retire it up front.
+        autosaveWorkItem?.cancel()
         guard markdownDocument.isDirty, markdownDocument.url != nil else { return true }
 
         let alert = NSAlert()
@@ -2529,6 +2547,7 @@ final class DocumentWindowController: NSWindowController {
             return saveDocument()
         case .alertSecondButtonReturn:
             discardChangesOnClose = markDiscardForWindowClose
+            implicitSaveSuppressed = true
             return true
         default:
             return false
@@ -2542,6 +2561,7 @@ final class DocumentWindowController: NSWindowController {
         stopSpeaking()
         derivedUIRefreshWorkItem?.cancel()
         findRefreshWorkItem?.cancel()
+        autosaveWorkItem?.cancel()
         removeFocusDimmingViews(animated: false)
         removeFloatingSurface()
         let selection = primaryContainer.textView.sourceSelectedRange
@@ -2687,6 +2707,12 @@ extension DocumentWindowController: NSWindowDelegate {
 
     func windowDidChangeOcclusionState(_ notification: Notification) {
         guard window?.occlusionState.contains(.visible) == false else { return }
+        // Occlusion is an implicit save, so it belongs to the autosave feature:
+        // with the setting off (the default) a covered or miniaturized window
+        // must never write, because an agent may be editing the same file.  A
+        // discarded buffer is equally ineligible — the user just said no.
+        guard Preferences.shared.values.autosaveEnabled,
+              !implicitSaveSuppressed else { return }
         markdownDocument.saveIfNeeded()
     }
 }

--- a/Sources/DownrightApp/App/DocumentWindowController.swift
+++ b/Sources/DownrightApp/App/DocumentWindowController.swift
@@ -139,6 +139,75 @@ final class DocumentWindowController: NSWindowController {
     var isFocusModeEnabled: Bool { Preferences.shared.values.focusMode }
     var pendingConflict: MarkdownDocument.Conflict?
     weak var toolbarPresentationControl: ToolbarPresentationControl?
+    /// The two-finger Document↔Source swipe over the document surface.  Lazy
+    /// because it closes over the panes and the rail, neither of which exists
+    /// until the window is loaded.
+    lazy var presentationSwipe = PresentationSwipeCoordinator(
+        host: PresentationSwipeCoordinator.Host(
+            panes: { [weak self] in self?.documentPanes ?? [] },
+            styleSheet: { [weak self] in self?.activeStyleSheet ?? .current },
+            selectedSegment: { [weak self] in self?.presentationSegment ?? 0 },
+            commitSegment: { [weak self] segment in
+                self?.changePresentation(to: segment)
+            },
+            trackRail: { [weak self] position in
+                self?.toolbarPresentationControl?.trackSwipe(position: position)
+            },
+            settleRail: { [weak self] segment in
+                self?.toolbarPresentationControl?.settleSwipe(at: segment)
+            },
+            documentLines: { [weak self] in self?.documentLineCount ?? 0 },
+            setSegment: { [weak self] segment in
+                self?.setPresentationSegment(segment)
+            }
+        )
+    )
+    /// ⌘-scroll and ⌥-scroll over the document surface.  Both scales already
+    /// existed and neither was reachable with a mouse: pinch drove text size,
+    /// and structural detail hid behind ⌃⌥⌘1…5.
+    lazy var scrollZoom = ScrollZoomCoordinator(
+        host: ScrollZoomCoordinator.Host(
+            stepTextSize: { [weak self] steps in
+                self?.adjustTextSize(by: CGFloat(steps))
+            },
+            stepDetail: { [weak self] steps in
+                guard let self, steps != 0 else { return }
+                // Routed through the commands rather than the zoom level, so
+                // the gesture, the chord and the View menu can never disagree
+                // about what the ends of the scale are.
+                let command: Command = steps > 0 ? .zoomIn : .zoomOut
+                for _ in 0..<abs(steps) { self.perform(command) }
+            }
+        )
+    )
+    /// The ⇧ two-finger Back/Forward swipe over the document surface.  Lazy
+    /// for the same reason as the presentation swipe: it closes over the panes.
+    lazy var historySwipe = HistorySwipeCoordinator(
+        host: HistorySwipeCoordinator.Host(
+            panes: { [weak self] in self?.documentPanes ?? [] },
+            styleSheet: { [weak self] in self?.activeStyleSheet ?? .current },
+            canMove: { [weak self] direction in
+                guard let self else { return false }
+                switch direction {
+                case .back: return self.jumpHistory.canGoBack
+                case .forward: return self.jumpHistory.canGoForward
+                }
+            },
+            move: { [weak self] direction in
+                switch direction {
+                case .back: self?.goBack()
+                case .forward: self?.goForward()
+                }
+            }
+        )
+    )
+    /// Every gesture the document surface can hand a scroll event to, in the
+    /// order they get to claim it.  The zooms decide on one event and answer
+    /// at once; the two swipes need travel first, and the one that needs ⇧ has
+    /// to be asked before the one that needs nothing held at all.
+    lazy var documentScrollGestures = ScrollGestureChain([
+        scrollZoom, historySwipe, presentationSwipe,
+    ])
     weak var toolbarDocumentIdentityView: ToolbarDocumentIdentityView?
     /// The two panel buttons promoted out of the `···` overflow.  Weak, because
     /// the toolbar item owns its view; the controller only needs them to keep
@@ -2645,6 +2714,10 @@ extension DocumentWindowController: NSWindowDelegate {
     }
 
     func windowDidResize(_ notification: Notification) {
+        // A resize reflows both presentations, so a swipe in flight is holding
+        // stills that no longer describe the document. Ground it first.
+        presentationSwipe.cancelInFlight()
+        historySwipe.cancelInFlight()
         updateFocusDimmingViews()
         refitFloatingSurface()
     }

--- a/Sources/DownrightApp/App/HistorySwipe.swift
+++ b/Sources/DownrightApp/App/HistorySwipe.swift
@@ -1,0 +1,367 @@
+import AppKit
+import MarkdownRender
+
+/// Decisions for the ⇧ two-finger Back/Forward swipe, kept pure so the feel
+/// can be tuned and tested without a trackpad under it.
+///
+/// Jump history has been reachable only from the keyboard and the View menu,
+/// which is odd for a thing whose whole job is "put me back where I was" — the
+/// most reflexive request a reader ever makes.  `JumpHistory` was written with
+/// a gesture in mind: it deliberately refuses to record ordinary scrolling so
+/// that a swipe through the stack stays useful rather than filling with noise.
+/// This is that swipe, six months late.
+///
+/// Bare two fingers sideways already switch Document↔Source, so this needs a
+/// modifier, and ⇧ is the one that is free.  Shift-scroll is conventionally
+/// horizontal scrolling on macOS — but the document surface has no horizontal
+/// axis to scroll (the scroll view's horizontal scroller is off and the text
+/// is measured to the pane), so nothing is being taken from anybody.  The
+/// direction follows Safari exactly: push the page right, uncovering what sits
+/// to its left, and you go back.
+enum HistorySwipePolicy {
+    enum Direction: Equatable {
+        case back
+        case forward
+    }
+
+    /// Held for the whole of the deciding part of the gesture.  Tested for
+    /// equality, so ⇧⌘ is not this gesture and never half-starts it.
+    static let modifiers: NSEvent.ModifierFlags = [.shift]
+
+    static func isSpelledCorrectly(_ held: NSEvent.ModifierFlags) -> Bool {
+        held == modifiers
+    }
+
+    /// Horizontal travel that claims the gesture away from vertical scrolling.
+    /// A shade longer than the presentation swipe's: ⇧ is often held for a
+    /// reason that has nothing to do with this — extending a selection with
+    /// the trackpad, for one — and going somewhere else in the document is a
+    /// bigger surprise than changing presentation.
+    static let intentThreshold: CGFloat = 14
+    /// How far the horizontal component must beat the vertical one, for the
+    /// same reason and a little more strictly.
+    static let axisDominance: CGFloat = 1.5
+    /// Share of the pane that commits on release, bounded at both ends: a
+    /// narrow split pane must not travel on a twitch, and a full-width window
+    /// must not demand a swipe longer than the trackpad.  Shorter than the
+    /// presentation swipe's, because a Back that was not wanted costs one
+    /// Forward to undo and the reader's place is never lost.
+    static let commitFraction: CGFloat = 0.2
+    static let minimumCommitDistance: CGFloat = 56
+    static let maximumCommitDistance: CGFloat = 120
+    /// Points per second that commits a short swipe — the flick.
+    static let flickVelocity: CGFloat = 260
+    /// How far the page travels under the fingers.  A touch further than the
+    /// presentation swipe's, because there is no rail here reporting how far
+    /// along the gesture is: the page's own travel is the only answer the
+    /// reader gets to "is this enough yet?".
+    static let maximumGive: CGFloat = 30
+
+    typealias Claim = DocumentSwipePhysics.Claim
+
+    static func claim(horizontal: CGFloat, vertical: CGFloat) -> Claim {
+        DocumentSwipePhysics.claim(
+            horizontal: horizontal,
+            vertical: vertical,
+            intentThreshold: intentThreshold,
+            axisDominance: axisDominance
+        )
+    }
+
+    /// Where a swipe of this translation is heading.
+    ///
+    /// `translation` is accumulated `scrollingDeltaX`, which AppKit has
+    /// already flipped for the trackpad's scroll-direction preference, so this
+    /// never reads the setting itself.  Positive pushes the page right and
+    /// uncovers what sits to its left, which is where you have already been.
+    static func direction(translation: CGFloat) -> Direction? {
+        if translation > 0 { return .back }
+        if translation < 0 { return .forward }
+        return nil
+    }
+
+    static func commitDistance(paneWidth: CGFloat) -> CGFloat {
+        DocumentSwipePhysics.commitDistance(
+            paneWidth: paneWidth,
+            fraction: commitFraction,
+            minimum: minimumCommitDistance,
+            maximum: maximumCommitDistance
+        )
+    }
+
+    static func shouldCommit(
+        translation: CGFloat,
+        velocity: CGFloat,
+        paneWidth: CGFloat
+    ) -> Bool {
+        DocumentSwipePhysics.shouldCommit(
+            translation: translation,
+            velocity: velocity,
+            distance: commitDistance(paneWidth: paneWidth),
+            flickVelocity: flickVelocity
+        )
+    }
+
+    static func give(_ translation: CGFloat) -> CGFloat {
+        DocumentSwipePhysics.give(translation, limit: maximumGive)
+    }
+}
+
+// MARK: - Coordinator
+
+/// Drives the ⇧ two-finger Back/Forward swipe across every pane in a window.
+///
+/// The window owns jump history; this owns the gesture.  What it needs from
+/// the window arrives as `Host` rather than a back-reference, so the state
+/// machine can be exercised without a document behind it.
+///
+/// Like its sibling it renders nothing during the gesture: the destination is
+/// a scroll position, and scrolling there speculatively so it could be dragged
+/// in would move the reader somewhere they have not asked to go yet.  The page
+/// gives against the fingers, and the trip happens on release.
+@MainActor
+final class HistorySwipeCoordinator: ScrollGestureHandler {
+    struct Host {
+        var panes: () -> [MarkdownContainerView]
+        var styleSheet: () -> StyleSheet
+        /// Whether jump history has anywhere to go that way.  Asked before the
+        /// gesture is claimed, so a swipe into an empty stack never catches:
+        /// a page that gives and then does nothing reads as a bug, and Back at
+        /// the start of a session is the commonest way to find one.
+        var canMove: (HistorySwipePolicy.Direction) -> Bool
+        /// Take the step.  Called once, on release, and never speculatively.
+        var move: (HistorySwipePolicy.Direction) -> Void
+        /// The detent when the swipe passes the point where releasing would
+        /// commit — the same `.alignment` tap the presentation rail uses when
+        /// its indicator reaches the far segment, and the only "far enough
+        /// now" this gesture has.
+        var performHapticFeedback: () -> Void = {
+            NSHapticFeedbackManager.defaultPerformer.perform(.alignment, performanceTime: .now)
+        }
+    }
+
+    private enum State {
+        case idle
+        case undecided
+        case scrolling
+        case swiping
+        case settling
+    }
+
+    private let host: Host
+    private var state: State = .idle
+    private var horizontalTravel: CGFloat = 0
+    private var verticalTravel: CGFloat = 0
+    private var translation: CGFloat = 0
+    private var velocity: CGFloat = 0
+    private var lastTimestamp: TimeInterval = 0
+    private var paneWidth: CGFloat = 0
+    private var direction: HistorySwipePolicy.Direction = .back
+    private var passedCommitPoint = false
+    private var swallowsMomentum = false
+    private let gives = PaneGiveTrack()
+
+    init(host: Host) {
+        self.host = host
+    }
+
+    var isTracking: Bool { state == .swiping }
+    var isSettling: Bool { state == .settling }
+    var isClaimingGesture: Bool { isTracking || isSettling }
+    /// Visible for tests: which way a claimed swipe is heading.
+    var trackedDirectionForTesting: HistorySwipePolicy.Direction? {
+        isTracking ? direction : nil
+    }
+
+    /// The single entry point from the chain.  Returns `true` when the swipe
+    /// has taken the event, in which case the scroll view must not see it.
+    @discardableResult
+    func handle(_ event: NSEvent) -> Bool {
+        // Trackpads only.  A wheel's ⇧-scroll is a single unphased notch with
+        // no travel to measure and no release to commit on, so there is no
+        // interactive gesture to build out of it — Back and Forward stay on
+        // ⌘⌃[ and ⌘⌃] for a mouse.
+        guard event.hasPreciseScrollingDeltas else { return false }
+
+        // Momentum arrives after the fingers are up.  There is nothing left to
+        // track, and it must never buy a second trip — but it is swallowed
+        // rather than handed back, because the coast belongs to a gesture that
+        // has already been answered.  Letting it through would scroll the
+        // document underneath the trip it just committed, or lurch the page
+        // the reader is watching spring home.
+        guard event.momentumPhase.isEmpty else {
+            let swallow = swallowsMomentum || state == .settling
+            if !event.momentumPhase.intersection([.ended, .cancelled]).isEmpty {
+                swallowsMomentum = false
+            }
+            return swallow
+        }
+
+        // Fingers back down ends the last gesture's coast, whatever this new
+        // one turns out to be spelled with — otherwise a swipe's leftover
+        // claim on momentum would eat the tail of somebody else's scroll.
+        if event.phase == .began { swallowsMomentum = false }
+
+        // ⇧ has to be held while the gesture is being decided.  Once it has
+        // caught, letting go of ⇧ must not drop it: the page is travelling and
+        // something has to finish it.
+        if !isClaimingGesture,
+           !HistorySwipePolicy.isSpelledCorrectly(ScrollGestureModifiers.held(in: event)) {
+            // A gesture that started with ⇧ and lost it is over, not paused.
+            if state == .undecided { state = .scrolling }
+            return false
+        }
+
+        switch event.phase {
+        case .began:
+            beginGesture(at: event.timestamp)
+            return false
+        case .changed:
+            return track(event)
+        case .ended, .cancelled:
+            return endGesture(cancelled: event.phase == .cancelled)
+        default:
+            return state == .swiping
+        }
+    }
+
+    /// A resize reflows the page under the give, so the transform stops
+    /// describing anything. Put the page back and let the gesture go.
+    func cancelInFlight() {
+        guard state == .swiping || state == .settling else { return }
+        state = .idle
+        gives.release()
+    }
+
+    // MARK: - Gesture
+
+    private func beginGesture(at timestamp: TimeInterval) {
+        // A new gesture during the settle abandons the tail rather than
+        // fighting it: the reader has already started moving again.
+        if state == .settling { finishSettle() }
+        state = .undecided
+        horizontalTravel = 0
+        verticalTravel = 0
+        translation = 0
+        velocity = 0
+        passedCommitPoint = false
+        swallowsMomentum = false
+        lastTimestamp = timestamp
+    }
+
+    private func track(_ event: NSEvent) -> Bool {
+        switch state {
+        case .idle, .scrolling, .settling:
+            return false
+        case .undecided:
+            horizontalTravel += event.scrollingDeltaX
+            verticalTravel += event.scrollingDeltaY
+            switch HistorySwipePolicy.claim(
+                horizontal: horizontalTravel,
+                vertical: verticalTravel
+            ) {
+            case .undecided:
+                return false
+            case .scroll:
+                state = .scrolling
+                return false
+            case .swipe:
+                // The travel already spent deciding is real movement the
+                // reader made; start from there rather than dropping it.
+                translation = horizontalTravel
+                lastTimestamp = event.timestamp
+                guard beginSwipe() else {
+                    state = .scrolling
+                    return false
+                }
+            }
+        case .swiping:
+            translation += event.scrollingDeltaX
+            velocity = DocumentSwipePhysics.velocity(
+                current: velocity,
+                delta: event.scrollingDeltaX,
+                elapsed: event.timestamp - lastTimestamp
+            )
+            lastTimestamp = event.timestamp
+        }
+
+        applyTranslation()
+        return true
+    }
+
+    private func beginSwipe() -> Bool {
+        guard let heading = HistorySwipePolicy.direction(translation: translation) else {
+            return false
+        }
+        // Nothing that way: hand the gesture back rather than promise a trip
+        // that cannot happen.
+        guard host.canMove(heading) else { return false }
+        let widest = host.panes().map(\.bounds.width).max() ?? 0
+        guard widest > 1 else { return false }
+
+        direction = heading
+        paneWidth = widest
+        state = .swiping
+        // From here the coast after the fingers lift belongs to this gesture,
+        // whichever way it ends.
+        swallowsMomentum = true
+        if !host.styleSheet().reduceMotion {
+            gives.engage(host.panes())
+        }
+        return true
+    }
+
+    private func applyTranslation() {
+        gives.place(HistorySwipePolicy.give(translation))
+        // The detent, once per crossing.  Coming back under it re-arms, so a
+        // reader hovering at the threshold feels the line rather than a burst.
+        let past = abs(translation) >= HistorySwipePolicy.commitDistance(paneWidth: paneWidth)
+        if past != passedCommitPoint {
+            passedCommitPoint = past
+            if past { host.performHapticFeedback() }
+        }
+    }
+
+    private func endGesture(cancelled: Bool) -> Bool {
+        guard state == .swiping else {
+            if state != .settling { state = .idle }
+            return false
+        }
+        let commit = !cancelled
+            && HistorySwipePolicy.shouldCommit(
+                translation: translation,
+                velocity: velocity,
+                paneWidth: paneWidth
+            )
+            // Re-asked at the last moment: the stack cannot change during a
+            // gesture today, but a trip that silently does nothing is a worse
+            // failure than one that never starts.
+            && host.canMove(direction)
+
+        if commit {
+            // Put the page back before the trip: the destination scroll
+            // animates from the pane's resting frame and must not start from
+            // a translated layer.
+            gives.release()
+            state = .idle
+            host.move(direction)
+            return true
+        }
+
+        // Nothing was moved, so nothing has to be undone — an abandoned swipe
+        // costs one spring back to rest.
+        guard gives.isEngaged else {
+            state = .idle
+            return true
+        }
+        state = .settling
+        gives.settle { [weak self] in self?.finishSettle() }
+        return true
+    }
+
+    private func finishSettle() {
+        guard state == .settling else { return }
+        state = .idle
+        gives.release()
+    }
+}

--- a/Sources/DownrightApp/App/MainMenu.swift
+++ b/Sources/DownrightApp/App/MainMenu.swift
@@ -51,6 +51,9 @@ enum MainMenu {
         case dynamicSubmenu(title: String, delegate: NSMenuDelegate)
         /// The one submenu macOS fills in for us.
         case services
+        /// The Continuity Camera submenu macOS fills in for us — Take Photo and
+        /// Scan Documents, served by a nearby iPhone or iPad.
+        case importFromDevice
     }
 
     /// A menu item for an action the app does not own.
@@ -124,7 +127,10 @@ enum MainMenu {
                 // The app's own version history.  macOS's Revert To / Browse
                 // All Versions are NSDocument features Downright does not use.
                 .commands([.versionTimeline]),
-                .commands([.revealInFinder, .openInEditor, .compareFiles]),
+                .commands([.share, .shareAsPDF]),
+                // Quick Look sits with the other "look at this file" items and
+                // above them, the way Finder's File menu orders it.
+                .commands([.quickLook, .revealInFinder, .openInEditor, .compareFiles]),
                 .standard([StandardItem(
                     title: "Page Setup…",
                     selector: #selector(NSApplication.runPageLayout(_:)),
@@ -219,6 +225,7 @@ enum MainMenu {
                     StandardItem(title: "Make Lower Case", selector: #selector(NSResponder.lowercaseWord(_:))),
                     StandardItem(title: "Capitalize", selector: #selector(NSResponder.capitalizeWord(_:))),
                 ]),
+                .importFromDevice,
                 .submenu(title: "Speech", commands: [.speakDocument, .stopSpeaking]),
             ]
 
@@ -355,6 +362,8 @@ enum MainMenu {
                 for standard in items { submenu.addItem(standard.makeMenuItem()) }
             case .services:
                 submenu.addItem(servicesItem())
+            case .importFromDevice:
+                submenu.addItem(importFromDeviceItem())
             case .standardSubmenu(let title, let items):
                 submenu.addItem(hostItem(title: title, items: items.map { $0.makeMenuItem() }))
             case .dynamicSubmenu(let title, let delegate):
@@ -391,6 +400,28 @@ enum MainMenu {
         item.submenu = services
         NSApp.servicesMenu = services
         return item
+    }
+
+    /// The Continuity Camera host, built exactly the way TextEdit's is: an
+    /// "Insert" submenu holding one placeholder whose only meaningful property
+    /// is `NSMenuItem.importFromDeviceIdentifier`.
+    ///
+    /// AppKit swaps that placeholder for "Take Photo" and "Scan Documents" when
+    /// a nearby iPhone or iPad can serve the request *and* the responder chain
+    /// advertises image return types — `DocumentWindowController` does, in
+    /// `validRequestor(forSendType:returnType:)`.  Nothing here has an action:
+    /// the substituted items carry their own, and a hand-written selector would
+    /// only be a second, wrong answer for the state where no device is in
+    /// range.  The visible title is what the user sees until one is.
+    private static func importFromDeviceItem() -> NSMenuItem {
+        let host = NSMenuItem(title: "Insert", action: nil, keyEquivalent: "")
+        let child = NSMenu(title: "Insert")
+        child.autoenablesItems = true
+        let placeholder = NSMenuItem(title: "Import from iPhone or iPad", action: nil, keyEquivalent: "")
+        placeholder.identifier = NSMenuItem.importFromDeviceIdentifier
+        child.addItem(placeholder)
+        host.submenu = child
+        return host
     }
 
     // MARK: - Items

--- a/Sources/DownrightApp/App/MainMenu.swift
+++ b/Sources/DownrightApp/App/MainMenu.swift
@@ -149,13 +149,12 @@ enum MainMenu {
                     StandardItem(
                         title: "Paste as Markdown",
                         selector: #selector(MarkdownTextView.pasteAsMarkdown(_:)),
-                        keyEquivalent: "v", modifiers: [.command, .option]
+                        keyEquivalent: ""
                     ),
-                    // The likeliest paste in a byte-exact Markdown editor.
                     StandardItem(
                         title: "Paste and Match Style",
                         selector: #selector(MarkdownTextView.pasteAndMatchStyle(_:)),
-                        keyEquivalent: "v", modifiers: [.command, .option, .shift]
+                        keyEquivalent: "v", modifiers: [.command, .shift]
                     ),
                     StandardItem(title: "Delete", selector: #selector(NSText.delete(_:))),
                     StandardItem(title: "Select All", selector: #selector(NSText.selectAll(_:)), keyEquivalent: "a"),

--- a/Sources/DownrightApp/App/PresentationDrag.swift
+++ b/Sources/DownrightApp/App/PresentationDrag.swift
@@ -1,0 +1,281 @@
+import AppKit
+import MarkdownRender
+
+/// Whether the two-finger swipe can afford to drag the *next* presentation in
+/// under the fingers, for the document currently in front of the reader.
+///
+/// It is a question about this document on this machine, not a constant.
+/// Source has to be rendered before it can be dragged, and that rebuild is
+/// proportional to document length: measured on Apple silicon in release, a
+/// hundred lines costs single-digit milliseconds and four thousand costs a
+/// fifth of a second.  Below the budget the reader gets the real thing; above
+/// it they get the page's give, which promises less and always answers.
+///
+/// Both are smooth.  What is never acceptable is the third option — engaging
+/// the drag and then stalling — which is what the first version of this
+/// gesture did, and what the budget exists to prevent.
+@MainActor
+enum PresentationSwitchBudget {
+    /// Three frames at 60 Hz.  Past that, the hand notices that the surface
+    /// has stopped answering, and a gesture that stops answering at the moment
+    /// it catches is worse than one that never promised to.
+    static let engagement: Double = 50
+
+    /// What the drag pays regardless of document length: one half-resolution
+    /// still of the outgoing page, and the layout pass the switch leaves
+    /// behind.  Measured at ~3 ms and ~8 ms respectively, rounded up.
+    static let fixedCost: Double = 14
+
+    /// Seeded from a release-build sweep — ~0.03 ms per line of the document,
+    /// consistent from four hundred lines to nine thousand — and refined by
+    /// every switch the app actually performs, because a constant calibrated
+    /// on one Mac is wrong on the next, and wrong in the direction that
+    /// matters: a slower machine would otherwise keep promising a drag it
+    /// cannot deliver.
+    ///
+    /// Lines here means lines of the file, which is what `lineStarts` counts —
+    /// not paragraphs, and not the line count of some corpus the number was
+    /// first measured against. Getting that wrong once already made this
+    /// refuse documents it could comfortably have dragged.
+    private(set) static var millisecondsPerLine: Double = 0.030
+
+    /// Fold a real switch into the estimate.  Short documents are ignored:
+    /// their cost is mostly the fixed overhead, so dividing it by a small line
+    /// count produces a per-line figure that describes nothing.
+    static func record(cost: Double, lines: Int) {
+        guard lines >= 200, cost > 0, cost.isFinite else { return }
+        let sample = cost / Double(lines)
+        millisecondsPerLine = millisecondsPerLine * 0.7 + sample * 0.3
+    }
+
+    static func estimatedCost(lines: Int) -> Double {
+        fixedCost + millisecondsPerLine * Double(max(0, lines))
+    }
+
+    static func allowsDrag(lines: Int) -> Bool {
+        estimatedCost(lines: lines) <= engagement
+    }
+
+    /// Test seam: the estimate is process-wide state, so a test that pushes it
+    /// has to be able to put it back.
+    static func resetCalibrationForTesting(millisecondsPerLine value: Double = 0.030) {
+        millisecondsPerLine = value
+    }
+}
+
+// MARK: - One pane
+
+/// One pane's drag: the presentation being left, as a still, travelling over
+/// the live surface that has already become the presentation being entered.
+///
+/// Only one still, not two.  The incoming side does not need capturing because
+/// it is the real text view — the mode change happens behind the still at the
+/// top of the gesture, so by the time the reader has moved a finger the live
+/// surface underneath is already showing what they are pulling in.
+///
+/// The still is captured at half resolution through `CALayer.render`, which
+/// composites what is already rasterised rather than re-running TextKit:
+/// 3 ms against 30 ms for a full-resolution `cacheDisplay`.  It is the page
+/// *leaving* the screen, in motion, for a fifth of a second.
+@MainActor
+final class PaneDrag {
+    private(set) weak var pane: MarkdownContainerView?
+    private let still = CALayer()
+    private let wasMasking: Bool
+    let width: CGFloat
+
+    /// Half.  A quarter measured barely faster and starts to show on text.
+    private static let stillScale: CGFloat = 0.5
+
+    init?(pane: MarkdownContainerView) {
+        guard pane.bounds.width > 1, pane.bounds.height > 1 else { return nil }
+        pane.wantsLayer = true
+        pane.scrollView.wantsLayer = true
+        guard let paneLayer = pane.layer,
+              let scrollLayer = pane.scrollView.layer,
+              let image = PaneDrag.still(of: pane.scrollView, scale: PaneDrag.stillScale)
+        else { return nil }
+
+        self.pane = pane
+        width = pane.scrollView.bounds.width
+        wasMasking = paneLayer.masksToBounds
+        paneLayer.masksToBounds = true
+
+        still.contents = image
+        still.contentsGravity = .resize
+        still.frame = pane.scrollView.frame
+        // Opaque, because the live surface underneath has already changed mode
+        // and must not show through the page that is still covering it.
+        still.isOpaque = true
+        still.backgroundColor = pane.styleSheet.background.cgColor
+        still.zPosition = scrollLayer.zPosition + 1
+        paneLayer.addSublayer(still)
+    }
+
+    /// `translation` is where the outgoing page has travelled; `direction` is
+    /// its sign, so the incoming surface can be placed exactly one pane away
+    /// and the two tile with no seam.
+    func place(translation: CGFloat, direction: CGFloat) {
+        guard let scrollLayer = pane?.scrollView.layer else { return }
+        let travel = min(max(translation, -width), width)
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        still.transform = CATransform3DMakeTranslation(travel, 0, 0)
+        scrollLayer.transform = CATransform3DMakeTranslation(travel - direction * width, 0, 0)
+        CATransaction.commit()
+    }
+
+    func release() {
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        still.removeFromSuperlayer()
+        pane?.scrollView.layer?.transform = CATransform3DIdentity
+        pane?.layer?.masksToBounds = wasMasking
+        CATransaction.commit()
+    }
+
+    /// `NSGraphicsContext` rather than a bare `CGContext`: AppKit owns the
+    /// flipped-geometry convention these layers were built under, and going
+    /// through it is what keeps the still the right way up.
+    private static func still(of view: NSView, scale: CGFloat) -> CGImage? {
+        guard let layer = view.layer else { return nil }
+        let pixelsWide = Int((view.bounds.width * scale).rounded())
+        let pixelsHigh = Int((view.bounds.height * scale).rounded())
+        guard pixelsWide > 1, pixelsHigh > 1,
+              let representation = NSBitmapImageRep(
+                bitmapDataPlanes: nil,
+                pixelsWide: pixelsWide, pixelsHigh: pixelsHigh,
+                bitsPerSample: 8, samplesPerPixel: 4,
+                hasAlpha: true, isPlanar: false,
+                colorSpaceName: .deviceRGB, bytesPerRow: 0, bitsPerPixel: 0),
+              let context = NSGraphicsContext(bitmapImageRep: representation)
+        else { return nil }
+        NSGraphicsContext.saveGraphicsState()
+        defer { NSGraphicsContext.restoreGraphicsState() }
+        NSGraphicsContext.current = context
+        context.cgContext.scaleBy(x: scale, y: scale)
+        layer.render(in: context.cgContext)
+        return representation.cgImage
+    }
+}
+
+// MARK: - Every pane
+
+/// Every pane's drag at once, plus the spring that finishes it.
+///
+/// Mirrors `PaneGiveTrack` deliberately: the two are alternatives chosen by
+/// budget, and a coordinator should be able to drive either without caring
+/// which it got.
+@MainActor
+final class PaneDragTrack {
+    private var surfaces: [PaneDrag] = []
+    private var driver: Motion.SpringDriver?
+    /// Critically damped.  An overshoot here does not read as bounce, it reads
+    /// as a sliver of the wrong page arriving from the opposite edge.
+    private var offset = Motion.SpringScalar(
+        value: 0,
+        perceptualDuration: Motion.springStandard
+    )
+    private var direction: CGFloat = 1
+    private var landing: (() -> Void)?
+    private var pendingLanding = false
+
+    deinit { driver?.park() }
+
+    private(set) var isSettling = false
+    var isEngaged: Bool { !surfaces.isEmpty }
+
+    /// The travel a completed drag ends on: the widest pane, so a narrower one
+    /// clamps to its own edge rather than stopping short of it.
+    private var completedTravel: CGFloat {
+        direction * (surfaces.map(\.width).max() ?? 0)
+    }
+
+    /// Capture every pane and take hold.  Returns `false` if no pane could be
+    /// captured, in which case the caller must fall back to the give — the
+    /// stills are the whole mechanism and there is no drag without them.
+    @discardableResult
+    func engage(_ panes: [MarkdownContainerView], direction: CGFloat) -> Bool {
+        release()
+        self.direction = direction < 0 ? -1 : 1
+        surfaces = panes.compactMap(PaneDrag.init(pane:))
+        offset.snap(to: 0)
+        return !surfaces.isEmpty
+    }
+
+    func place(_ value: CGFloat) {
+        offset.snap(to: value)
+        for surface in surfaces { surface.place(translation: value, direction: direction) }
+    }
+
+    /// Finish the drag: `committed` flies the outgoing page all the way off and
+    /// leaves the live surface at rest, otherwise it comes home.  `completion`
+    /// runs once the panes have arrived, and is where the caller undoes a mode
+    /// change it made speculatively.
+    func settle(committed: Bool, velocity: CGFloat, completion: @escaping () -> Void) {
+        guard !surfaces.isEmpty else {
+            completion()
+            return
+        }
+        isSettling = true
+        landing = completion
+        let destination = committed ? completedTravel : 0
+        offset.target(destination)
+        // Carry the hand's speed, but only when it already points at the
+        // destination: a kick the other way pushes even a critically damped
+        // spring past its landing, and past the landing is the wrong page.
+        let remaining = destination - offset.value
+        if remaining != 0, (velocity < 0) == (remaining < 0) { offset.kick(velocity) }
+
+        guard let anchor = surfaces.first?.pane, anchor.window != nil else {
+            land(at: destination)
+            return
+        }
+        let driver = self.driver ?? Motion.SpringDriver(
+            view: anchor,
+            advance: { [weak self] dt in self?.tick(dt: dt) ?? false },
+            apply: { [weak self] in self?.apply() }
+        )
+        self.driver = driver
+        if !driver.arm() { land(at: destination) }
+    }
+
+    func release() {
+        isSettling = false
+        pendingLanding = false
+        landing = nil
+        driver?.park()
+        let finishing = surfaces
+        surfaces = []
+        for surface in finishing { surface.release() }
+    }
+
+    private func land(at destination: CGFloat) {
+        offset.snap(to: destination)
+        pendingLanding = false
+        for surface in surfaces { surface.place(translation: destination, direction: direction) }
+        finish()
+    }
+
+    private func tick(dt: CGFloat) -> Bool {
+        let moving = offset.advance(dt: dt)
+        if !moving { pendingLanding = true }
+        return moving
+    }
+
+    private func apply() {
+        for surface in surfaces { surface.place(translation: offset.value, direction: direction) }
+        if pendingLanding {
+            pendingLanding = false
+            finish()
+        }
+    }
+
+    private func finish() {
+        isSettling = false
+        driver?.park()
+        let completion = landing
+        landing = nil
+        completion?()
+    }
+}

--- a/Sources/DownrightApp/App/PresentationSwipe.swift
+++ b/Sources/DownrightApp/App/PresentationSwipe.swift
@@ -1,0 +1,389 @@
+import AppKit
+import MarkdownRender
+
+/// Decisions for the two-finger Document↔Source swipe, kept pure so the feel
+/// can be tuned and tested without a trackpad under it.
+///
+/// The gesture is deliberately cheap.  Dragging the *next* presentation in
+/// under the fingers was tried and measured: Source has to exist before it can
+/// be dragged, and building it costs about 400 ms on a two-thousand-line
+/// document — half a second of dead trackpad at the exact moment the swipe
+/// catches, and the same again to undo if the swipe is then abandoned.  So
+/// nothing is rendered during the gesture.  The rail's indicator is welded to
+/// the fingers, the page gives against them, and the switch happens on release
+/// for exactly what it costs from the toolbar and not a millisecond more.
+enum PresentationSwipePolicy {
+    /// Horizontal travel that claims the gesture away from vertical scrolling.
+    /// Small enough that a deliberate swipe engages almost at once, large
+    /// enough that the sideways component of a fast flick down the page does
+    /// not read as one.
+    static let intentThreshold: CGFloat = 12
+    /// How far the horizontal component must beat the vertical one.  Diagonal
+    /// drift while reading is a scroll; only a decidedly sideways gesture is
+    /// a swipe.
+    static let axisDominance: CGFloat = 1.4
+    /// Share of the pane that commits on release, bounded at both ends: a
+    /// narrow split pane must not switch on a twitch, and a full-width window
+    /// must not demand a swipe longer than the trackpad.
+    static let commitFraction: CGFloat = 0.25
+    static let minimumCommitDistance: CGFloat = 64
+    static let maximumCommitDistance: CGFloat = 140
+    /// Points per second that commits a short swipe — the flick.
+    static let flickVelocity: CGFloat = 260
+    /// How far the page itself travels under the fingers.  Small on purpose:
+    /// it is the physical evidence that the gesture has caught, not a preview
+    /// of what is coming, and it costs one layer transform to draw.
+    static let maximumGive: CGFloat = 28
+
+    typealias Claim = DocumentSwipePhysics.Claim
+
+    static func claim(horizontal: CGFloat, vertical: CGFloat) -> Claim {
+        DocumentSwipePhysics.claim(
+            horizontal: horizontal,
+            vertical: vertical,
+            intentThreshold: intentThreshold,
+            axisDominance: axisDominance
+        )
+    }
+
+    /// Which segment a swipe is heading for: `0` Document, `1` Source.
+    ///
+    /// The page follows the fingers, so pushing it left uncovers what sits to
+    /// the right of the rail.  `translation` is accumulated `scrollingDeltaX`,
+    /// which AppKit has already flipped for the trackpad's scroll-direction
+    /// preference — the same reason a Spaces swipe reverses when natural
+    /// scrolling is off, and the reason this never reads the setting itself.
+    static func targetSegment(translation: CGFloat) -> Int? {
+        if translation < 0 { return 1 }
+        if translation > 0 { return 0 }
+        return nil
+    }
+
+    static func commitDistance(paneWidth: CGFloat) -> CGFloat {
+        DocumentSwipePhysics.commitDistance(
+            paneWidth: paneWidth,
+            fraction: commitFraction,
+            minimum: minimumCommitDistance,
+            maximum: maximumCommitDistance
+        )
+    }
+
+    /// How far through the switch the rail's indicator should read, `0`…`1`.
+    /// It reaches the far segment exactly where releasing would commit, so the
+    /// bar is the answer to "is this far enough yet?".
+    static func railProgress(translation: CGFloat, paneWidth: CGFloat) -> CGFloat {
+        let distance = commitDistance(paneWidth: paneWidth)
+        guard distance > 0 else { return 0 }
+        return min(1, abs(translation) / distance)
+    }
+
+    /// That progress placed on the rail, which runs `0` Document to `1` Source.
+    static func railPosition(progress: CGFloat, origin: Int, target: Int) -> CGFloat {
+        let start = CGFloat(min(max(origin, 0), 1))
+        let end = CGFloat(min(max(target, 0), 1))
+        return start + (end - start) * min(max(progress, 0), 1)
+    }
+
+    static func shouldCommit(
+        translation: CGFloat,
+        velocity: CGFloat,
+        paneWidth: CGFloat
+    ) -> Bool {
+        DocumentSwipePhysics.shouldCommit(
+            translation: translation,
+            velocity: velocity,
+            distance: commitDistance(paneWidth: paneWidth),
+            flickVelocity: flickVelocity
+        )
+    }
+
+    static func give(_ translation: CGFloat) -> CGFloat {
+        DocumentSwipePhysics.give(translation, limit: maximumGive)
+    }
+}
+
+// MARK: - Coordinator
+
+/// Drives the two-finger Document↔Source swipe across every pane in a window
+/// and keeps the titlebar rail's indicator travelling with it.
+///
+/// The window owns the mode; this owns the gesture.  What it needs from the
+/// window arrives as `Host` rather than a back-reference, so the state machine
+/// can be exercised without a document behind it.
+@MainActor
+final class PresentationSwipeCoordinator: ScrollGestureHandler {
+    struct Host {
+        var panes: () -> [MarkdownContainerView]
+        var styleSheet: () -> StyleSheet
+        /// The presentation the document is actually in — `0` Document,
+        /// `1` Source — not what the rail happens to be drawing mid-swipe.
+        var selectedSegment: () -> Int
+        /// Switch presentation, with the same transition the toolbar rail
+        /// uses.  Called once, on release, and never speculatively.
+        var commitSegment: (Int) -> Void
+        /// Move the rail's indicator to `position` (`0` Document, `1` Source).
+        var trackRail: (CGFloat) -> Void
+        /// Land the rail on a segment.
+        var settleRail: (Int) -> Void
+        /// The open document's length, which decides whether the drag is
+        /// affordable — see `PresentationSwitchBudget`.
+        var documentLines: () -> Int
+        /// Switch presentation with no transition of its own.  The drag makes
+        /// the change behind a still at the top of the gesture, and puts it
+        /// back the same way if the gesture is abandoned.
+        var setSegment: (Int) -> Void
+    }
+
+    private enum State {
+        case idle
+        case undecided
+        case scrolling
+        case swiping
+        case settling
+    }
+
+    private let host: Host
+    private var state: State = .idle
+    private var horizontalTravel: CGFloat = 0
+    private var verticalTravel: CGFloat = 0
+    private var translation: CGFloat = 0
+    private var velocity: CGFloat = 0
+    private var lastTimestamp: TimeInterval = 0
+    private var paneWidth: CGFloat = 0
+    private var originSegment = 0
+    private var targetSegment = 0
+    /// Two ways to answer the fingers, chosen per gesture by what the
+    /// document can afford.  Under budget the real thing: the page you are
+    /// leaving travels off while the one you are entering follows it in, both
+    /// tracking 1:1.  Over budget the give: the page leans against your
+    /// fingers and the switch happens on release.  Never both.
+    private let drag = PaneDragTrack()
+    private let gives = PaneGiveTrack()
+
+    init(host: Host) {
+        self.host = host
+    }
+
+    var isTracking: Bool { state == .swiping }
+    var isSettling: Bool { state == .settling }
+    var isClaimingGesture: Bool { isTracking || isSettling }
+
+    /// The single entry point from the text surface.  Returns `true` when the
+    /// swipe has taken the event, in which case the scroll view must not see
+    /// it.
+    @discardableResult
+    func handle(_ event: NSEvent) -> Bool {
+        // Trackpads only.  A wheel with a horizontal tilt has no phases to
+        // build an interactive gesture out of, and stealing it would break
+        // horizontal scrolling for anyone whose mouse has it.
+        guard event.hasPreciseScrollingDeltas else { return false }
+
+        // This is the gesture spelled with nothing held.  ⌘ and ⌥ zoom, ⇧
+        // moves through jump history, and those are asked first — but a swipe
+        // hands the event back for as long as it is still deciding, so this
+        // one has to stand down on its own account rather than rely on the
+        // order.  Once it *has* caught, a modifier pressed halfway through
+        // changes nothing: the page is already travelling under the fingers
+        // and something has to finish it.
+        if !isClaimingGesture, !ScrollGestureModifiers.held(in: event).isEmpty {
+            return false
+        }
+
+        // Momentum arrives after the fingers are up. There is nothing left to
+        // track — but swallow it while the page settles, or a vertical tail
+        // lurches the document the reader is watching return.
+        guard event.momentumPhase.isEmpty else { return state == .settling }
+
+        switch event.phase {
+        case .began:
+            beginGesture(at: event.timestamp)
+            return false
+        case .changed:
+            return track(event)
+        case .ended, .cancelled:
+            return endGesture(cancelled: event.phase == .cancelled)
+        default:
+            return state == .swiping
+        }
+    }
+
+    /// A resize reflows the page under the give, so the transform stops
+    /// describing anything. Put the page back and let the gesture go.
+    func cancelInFlight() {
+        guard state == .swiping || state == .settling else { return }
+        state = .idle
+        // A drag switched the mode speculatively at the top of the gesture.
+        // Grounding it is not a commit, so put the mode back before letting go
+        // of the stills that are hiding the change.
+        if drag.isEngaged, host.selectedSegment() != originSegment {
+            host.setSegment(originSegment)
+        }
+        drag.release()
+        gives.release()
+        host.settleRail(host.selectedSegment())
+    }
+
+    // MARK: - Gesture
+
+    private func beginGesture(at timestamp: TimeInterval) {
+        // A new gesture during the settle abandons the tail rather than
+        // fighting it: the reader has already started moving again.
+        if state == .settling { finishSettle() }
+        state = .undecided
+        horizontalTravel = 0
+        verticalTravel = 0
+        translation = 0
+        velocity = 0
+        lastTimestamp = timestamp
+    }
+
+    private func track(_ event: NSEvent) -> Bool {
+        switch state {
+        case .idle, .scrolling, .settling:
+            return false
+        case .undecided:
+            horizontalTravel += event.scrollingDeltaX
+            verticalTravel += event.scrollingDeltaY
+            switch PresentationSwipePolicy.claim(
+                horizontal: horizontalTravel,
+                vertical: verticalTravel
+            ) {
+            case .undecided:
+                return false
+            case .scroll:
+                state = .scrolling
+                return false
+            case .swipe:
+                // The travel already spent deciding is real movement the
+                // reader made; start from there rather than dropping it.
+                translation = horizontalTravel
+                lastTimestamp = event.timestamp
+                guard beginSwipe() else {
+                    state = .scrolling
+                    return false
+                }
+            }
+        case .swiping:
+            translation += event.scrollingDeltaX
+            velocity = DocumentSwipePhysics.velocity(
+                current: velocity,
+                delta: event.scrollingDeltaX,
+                elapsed: event.timestamp - lastTimestamp
+            )
+            lastTimestamp = event.timestamp
+        }
+
+        applyTranslation()
+        return true
+    }
+
+    private func beginSwipe() -> Bool {
+        guard let target = PresentationSwipePolicy.targetSegment(translation: translation)
+        else { return false }
+        originSegment = host.selectedSegment()
+        // Nothing sits beyond the mode you are already in, so there is no
+        // switch to promise. Hand the gesture back rather than invent a dead
+        // end the reader has to swipe their way out of.
+        guard target != originSegment else { return false }
+        let widest = host.panes().map(\.bounds.width).max() ?? 0
+        guard widest > 1 else { return false }
+
+        targetSegment = target
+        paneWidth = widest
+        state = .swiping
+
+        // Reduce Motion asked for no travelling surfaces at all. Honour the
+        // gesture, skip the choreography: the switch happens on release the
+        // way a click on the rail does.
+        guard !host.styleSheet().reduceMotion else { return true }
+
+        // The drag has to render what it is dragging in before a finger moves.
+        // Ask the budget whether this document can afford that inside a few
+        // frames; if it cannot, the give is not a consolation prize, it is the
+        // right answer — it promises less and it always answers.
+        if PresentationSwitchBudget.allowsDrag(lines: host.documentLines()),
+           drag.engage(host.panes(), direction: translation < 0 ? -1 : 1) {
+            // The stills are covering every pane now, so the rebuild happens
+            // behind them rather than under the fingers.
+            host.setSegment(target)
+        } else {
+            gives.engage(host.panes())
+        }
+        return true
+    }
+
+    private func applyTranslation() {
+        if drag.isEngaged {
+            // Welded to the fingers. The page is really going where you are
+            // pushing it, so there is nothing to damp.
+            drag.place(translation)
+        } else {
+            gives.place(PresentationSwipePolicy.give(translation))
+        }
+        host.trackRail(PresentationSwipePolicy.railPosition(
+            progress: PresentationSwipePolicy.railProgress(
+                translation: translation,
+                paneWidth: paneWidth
+            ),
+            origin: originSegment,
+            target: targetSegment
+        ))
+    }
+
+    private func endGesture(cancelled: Bool) -> Bool {
+        guard state == .swiping else {
+            if state != .settling { state = .idle }
+            return false
+        }
+        let commit = !cancelled && PresentationSwipePolicy.shouldCommit(
+            translation: translation,
+            velocity: velocity,
+            paneWidth: paneWidth
+        )
+        host.settleRail(commit ? targetSegment : originSegment)
+
+        if drag.isEngaged {
+            // The mode was changed at the top of the gesture, so a commit has
+            // nothing left to do but fly the outgoing page off. An abandoned
+            // drag owes the reader the mode back — put it behind the still,
+            // which is covering the pane again by the time this runs.
+            state = .settling
+            drag.settle(committed: commit, velocity: velocity) { [weak self] in
+                guard let self else { return }
+                if !commit, self.host.selectedSegment() != self.originSegment {
+                    self.host.setSegment(self.originSegment)
+                }
+                self.drag.release()
+                self.state = .idle
+            }
+            return true
+        }
+
+        if commit {
+            // Put the page back before the switch: the mode change draws its
+            // own transition from the pane's resting frame and must not start
+            // from a translated layer.
+            gives.release()
+            state = .idle
+            host.commitSegment(targetSegment)
+            return true
+        }
+
+        // Nothing was built, so nothing has to be undone — an abandoned swipe
+        // costs one spring back to rest.
+        guard gives.isEngaged else {
+            state = .idle
+            return true
+        }
+        state = .settling
+        gives.settle { [weak self] in self?.finishSettle() }
+        return true
+    }
+
+    private func finishSettle() {
+        guard state == .settling else { return }
+        state = .idle
+        drag.release()
+        gives.release()
+    }
+}

--- a/Sources/DownrightApp/App/ScrollZoom.swift
+++ b/Sources/DownrightApp/App/ScrollZoom.swift
@@ -1,0 +1,245 @@
+import AppKit
+import MarkdownRender
+
+/// Decisions for the two modifier zooms on the wheel, kept pure so the detent
+/// can be tuned and tested without a trackpad or a mouse under it.
+///
+/// The document surface already zooms two ways, and until now both were shut
+/// to a mouse.  Pinch drives the reading text size; ⌃⌥⌘1…5 drives structural
+/// detail, which is one of the best things the app does and is buried behind a
+/// four-key chord nobody remembers.  A wheel with a modifier on it is the
+/// obvious way in, and it costs nothing: this surface scrolls vertically and
+/// nothing else, so a modified scroll over it is unclaimed.
+///
+/// The two scales want opposite treatment, which is the whole design here.
+/// Text size is a fine ramp with fifteen stops and a cheap reflow — the reader
+/// nudges it until the page looks right, exactly as they do with pinch.
+/// Structural detail is five stops, each of which rewrites what the document
+/// *is*, at the cost of a full relayout.  Five of those in one flick is both
+/// useless and slow, so a gesture is allowed exactly one.
+enum ScrollZoomPolicy {
+    enum Intent: Equatable {
+        /// ⌘ — the reading size of the text, the scale pinch already drives.
+        case textSize
+        /// ⌥ — the structural detail level, the scale ⌃⌥⌘1…5 drives.
+        case structuralDetail
+    }
+
+    /// Exactly ⌘ or exactly ⌥.  ⇧⌘ belongs to jump history and ⌃⌥ belongs to
+    /// nothing at all; a zoom that answered to any superset would fire
+    /// underneath both of them.
+    static func intent(for held: NSEvent.ModifierFlags) -> Intent? {
+        if held == .command { return .textSize }
+        if held == .option { return .structuralDetail }
+        return nil
+    }
+
+    /// Points of trackpad travel per text-size step.  Roughly a knuckle's
+    /// worth: `magnify(with:)` steps every 0.075 of pinch, which is about the
+    /// same amount of hand movement, so the two zooms ramp at the same rate
+    /// and switching devices does not change the feel.
+    static let textSizeStepPoints: CGFloat = 26
+
+    /// Points of trackpad travel before the single structural step a gesture
+    /// is allowed.  Longer than a twitch and longer than the sideways slop in
+    /// a fast vertical flick, so ⌥ held down while reading cannot rewrite the
+    /// document by accident.
+    static let detailStepPoints: CGFloat = 60
+
+    /// A coarse wheel measures in lines, not points, and its notches are
+    /// already detents the hand can feel — so one notch is one step, the way
+    /// every browser has always spelled ⌘-wheel.
+    static let wheelStepLines: CGFloat = 1
+
+    /// …but macOS accelerates a fast spin into deltas of ten lines and more,
+    /// which would turn one flick of the wheel into the whole scale.  Each
+    /// event contributes at most one notch, so the number of steps can only
+    /// ever be the number of notches the hand actually turned.
+    static let maximumWheelLinesPerEvent: CGFloat = 1
+
+    /// Structural steps a single gesture may fire.  One, firmly: the keyboard
+    /// chords are still there for jumping straight to a level, and a reader
+    /// who wants two levels can ask twice.
+    static let detailStepsPerGesture = 1
+
+    /// A wheel has no phases, so "one gesture" has to be inferred from the
+    /// quiet between events.  A deliberate notch-and-look is a fifth of a
+    /// second apart at least; a spin is thirty milliseconds.  This tells them
+    /// apart without asking the reader to lift anything.
+    static let wheelGestureGap: TimeInterval = 0.2
+
+    /// Travel per step, in whatever unit the device reports.
+    static func stepThreshold(_ intent: Intent, precise: Bool) -> CGFloat {
+        guard precise else { return wheelStepLines }
+        switch intent {
+        case .textSize: return textSizeStepPoints
+        case .structuralDetail: return detailStepPoints
+        }
+    }
+
+    /// What one event adds to the gesture's travel.
+    ///
+    /// Precise deltas are already points and are taken as they come.  Coarse
+    /// deltas are lines with macOS's acceleration curve baked in, and that
+    /// curve is the enemy of a detent, so it is thrown away.
+    static func contribution(deltaY: CGFloat, precise: Bool) -> CGFloat {
+        guard !precise else { return deltaY }
+        return min(max(deltaY, -maximumWheelLinesPerEvent), maximumWheelLinesPerEvent)
+    }
+
+    /// Whether a gesture that has already fired `spent` steps may fire more.
+    static func allowsFurtherSteps(_ intent: Intent, spent: Int) -> Bool {
+        switch intent {
+        case .textSize: return true
+        case .structuralDetail: return abs(spent) < detailStepsPerGesture
+        }
+    }
+
+    /// The steps `accumulated` travel has earned, capped by what this gesture
+    /// has left to spend.  Positive is toward more: bigger text, more detail.
+    ///
+    /// Sign follows `scrollingDeltaY` untouched, which AppKit has already
+    /// flipped for the scroll-direction preference — so the direction that
+    /// scrolls toward the top of the document is the direction that zooms in,
+    /// whichever way the reader has their trackpad set up.
+    static func steps(
+        _ intent: Intent,
+        accumulated: CGFloat,
+        spent: Int,
+        precise: Bool
+    ) -> Int {
+        let threshold = stepThreshold(intent, precise: precise)
+        guard threshold > 0, allowsFurtherSteps(intent, spent: spent) else { return 0 }
+        let earned = Int(accumulated / threshold)
+        guard earned != 0 else { return 0 }
+        switch intent {
+        case .textSize:
+            return earned
+        case .structuralDetail:
+            // One event can cross the threshold twice over; it still only
+            // buys the one step the gesture is allowed.
+            let remaining = detailStepsPerGesture - abs(spent)
+            return max(-remaining, min(remaining, earned))
+        }
+    }
+
+    /// Whether an event this far from the last one starts a fresh gesture.
+    /// Only a coarse wheel has to ask — a trackpad says so in its phases.
+    static func startsNewWheelGesture(since elapsed: TimeInterval) -> Bool {
+        elapsed >= wheelGestureGap
+    }
+}
+
+// MARK: - Coordinator
+
+/// Turns ⌘-scroll and ⌥-scroll over the document surface into text-size and
+/// structural-detail steps.
+///
+/// What it needs from the window arrives as `Host` rather than a
+/// back-reference, so the detent can be exercised without a document behind
+/// it.  It renders nothing and animates nothing itself: both scales are
+/// existing commands with their own transitions, and this only decides *when*
+/// to ask for one.
+@MainActor
+final class ScrollZoomCoordinator: ScrollGestureHandler {
+    struct Host {
+        /// Step the reading text size — the path pinch-to-zoom already takes,
+        /// so a mouse lands on exactly the same fifteen stops.
+        var stepTextSize: (Int) -> Void
+        /// Step the structural detail level — the path `.zoomIn` / `.zoomOut`
+        /// take, so the gesture and the chord cannot drift apart.
+        var stepDetail: (Int) -> Void
+        /// The detent under the fingers when a detail level lands.  Structural
+        /// detail is the one scale where a step is a whole new document, and
+        /// the same `.alignment` tap the presentation rail uses is what says
+        /// so before the relayout is visible.
+        var performHapticFeedback: () -> Void = {
+            NSHapticFeedbackManager.defaultPerformer.perform(.alignment, performanceTime: .now)
+        }
+    }
+
+    private let host: Host
+    private var intent: ScrollZoomPolicy.Intent?
+    private var accumulated: CGFloat = 0
+    private var spent = 0
+    private var lastTimestamp: TimeInterval = -.greatestFiniteMagnitude
+
+    init(host: Host) {
+        self.host = host
+    }
+
+    /// Visible for tests: the travel banked toward the next step.
+    var accumulatedTravelForTesting: CGFloat { accumulated }
+    /// Visible for tests: steps this gesture has already fired.
+    var stepsFiredForTesting: Int { spent }
+
+    /// The single entry point from the chain.  Returns `true` when a zoom has
+    /// taken the event, in which case the scroll view must not see it.
+    @discardableResult
+    func handle(_ event: NSEvent) -> Bool {
+        // No modifier, no claim, and not one branch of thinking about it: an
+        // unmodified scroll is the overwhelmingly common case and must cost
+        // nothing on its way past.
+        guard let intent = ScrollZoomPolicy.intent(for: ScrollGestureModifiers.held(in: event))
+        else {
+            self.intent = nil
+            return false
+        }
+
+        let precise = event.hasPreciseScrollingDeltas
+        if intent != self.intent { beginGesture(intent, at: event.timestamp) }
+        // A trackpad announces the gesture; a wheel is only ever inferred from
+        // the quiet before it.
+        if precise {
+            if event.phase == .began { beginGesture(intent, at: event.timestamp) }
+        } else if ScrollZoomPolicy.startsNewWheelGesture(since: event.timestamp - lastTimestamp) {
+            beginGesture(intent, at: event.timestamp)
+        }
+        lastTimestamp = event.timestamp
+
+        // The momentum tail is the trackpad coasting, not the reader zooming.
+        // It is still swallowed: handing it back would scroll the page out
+        // from under a size the reader just settled on.
+        guard event.momentumPhase.isEmpty else { return true }
+
+        if event.phase == .ended || event.phase == .cancelled {
+            endGesture()
+            return true
+        }
+
+        accumulated += ScrollZoomPolicy.contribution(
+            deltaY: event.scrollingDeltaY, precise: precise
+        )
+        let steps = ScrollZoomPolicy.steps(
+            intent, accumulated: accumulated, spent: spent, precise: precise
+        )
+        guard steps != 0 else { return true }
+        accumulated -= CGFloat(steps) * ScrollZoomPolicy.stepThreshold(intent, precise: precise)
+        spent += steps
+
+        switch intent {
+        case .textSize:
+            host.stepTextSize(steps)
+        case .structuralDetail:
+            host.stepDetail(steps)
+            host.performHapticFeedback()
+        }
+        return true
+    }
+
+    private func beginGesture(_ intent: ScrollZoomPolicy.Intent, at timestamp: TimeInterval) {
+        self.intent = intent
+        accumulated = 0
+        spent = 0
+        lastTimestamp = timestamp
+    }
+
+    /// The fingers are up.  Nothing is banked across gestures: travel that did
+    /// not earn a step was the reader changing their mind, and carrying it
+    /// forward would make the *next* gesture fire early for no visible reason.
+    private func endGesture() {
+        intent = nil
+        accumulated = 0
+        spent = 0
+    }
+}

--- a/Sources/DownrightApp/App/ToolbarControls.swift
+++ b/Sources/DownrightApp/App/ToolbarControls.swift
@@ -390,10 +390,8 @@ final class ToolbarDocumentIdentityView: NSView {
 
     private var stateTitle: String? {
         switch documentState.phase {
-        case .neutral: return nil
-        case .edited: return "Edited"
-        case .saving: return "Saving"
-        case .saved: return "Saved"
+        case .neutral, .edited, .saving, .saved:
+            return nil
         case .changedOnDisk:
             return documentState.detail == "File missing" ? "File missing" : "Changed externally"
         case .conflict: return "Conflict"
@@ -431,9 +429,7 @@ final class ToolbarDocumentIdentityView: NSView {
             stateLabel.textColor = .systemRed
         case .changedOnDisk:
             stateLabel.textColor = StyleSheet.current.accent
-        case .edited, .saving, .saved:
-            stateLabel.textColor = .secondaryLabelColor
-        case .neutral:
+        case .neutral, .edited, .saving, .saved:
             stateLabel.textColor = .tertiaryLabelColor
         }
         updateProxyIcon(for: hostWindow?.representedURL)

--- a/Sources/DownrightApp/App/ToolbarControls.swift
+++ b/Sources/DownrightApp/App/ToolbarControls.swift
@@ -55,6 +55,22 @@ enum ToolbarChromePolicy {
         }
     }
 
+    /// The same state for a gesture that reports how far across the rail it
+    /// has travelled rather than where a pointer sits — the two-finger swipe
+    /// happens over the document and has no pointer in the control to read.
+    static func scrubState(
+        position: CGFloat,
+        leftCenterX: CGFloat,
+        rightCenterX: CGFloat
+    ) -> ScrubState {
+        let travelled = min(max(position, 0), 1)
+        return scrubState(
+            pointerX: leftCenterX + (rightCenterX - leftCenterX) * travelled,
+            leftCenterX: leftCenterX,
+            rightCenterX: rightCenterX
+        )
+    }
+
     static func scrubState(
         pointerX: CGFloat,
         leftCenterX: CGFloat,
@@ -694,6 +710,40 @@ final class ToolbarPresentationControl: Motion.SpringSurfaceView {
             applyVisualSelection(selectedSegment)
             updateSelectionIndicator(animated: true)
         }
+    }
+
+    /// Track a gesture that owns the mode change itself — the two-finger
+    /// swipe over the document.  Unlike `updateScrub`, this never calls
+    /// `onChange`: the document has already switched behind the transition,
+    /// and switching again on release would undo it.
+    ///
+    /// `position` runs `0` at Document to `1` at Source.
+    func trackSwipe(position: CGFloat) {
+        let centers = segmentCenters
+        let state = ToolbarChromePolicy.scrubState(
+            position: position,
+            leftCenterX: centers.left,
+            rightCenterX: centers.right
+        )
+        let previousSegment = scrubbedSegment
+        scrubbedSegment = state.segment
+        applyVisualSelection(state.segment)
+        updateSelectionIndicator(centerX: state.indicatorCenterX)
+        if let previousSegment, previousSegment != state.segment {
+            performHapticFeedback()
+        }
+    }
+
+    /// Land the indicator on a segment after such a gesture.  Unconditional
+    /// rather than a `setSelectedSegment` no-op, because a cancelled swipe
+    /// ends on the segment it started from with the rail scrubbed away from it.
+    func settleSwipe(at segment: Int) {
+        let normalized = min(max(segment, 0), 1)
+        scrubbedSegment = nil
+        selectedSegment = normalized
+        setAccessibilityValue(segmentTitles[normalized])
+        applyVisualSelection(normalized)
+        updateSelectionIndicator(animated: window != nil)
     }
 
     private func applyVisualSelection(_ segment: Int) {

--- a/Sources/DownrightApp/App/ToolbarControls.swift
+++ b/Sources/DownrightApp/App/ToolbarControls.swift
@@ -99,6 +99,7 @@ final class ToolbarDocumentIdentityView: NSView {
     private let titleLabel = NSTextField(labelWithString: "")
     private let contextLabel = NSTextField(labelWithString: "")
     private let titleRow = NSStackView()
+    private let secondaryRow = NSStackView()
     private let textColumn = NSStackView()
     private var titleObservation: NSKeyValueObservation?
     private var subtitleObservation: NSKeyValueObservation?
@@ -180,16 +181,21 @@ final class ToolbarDocumentIdentityView: NSView {
 
         titleRow.orientation = .horizontal
         titleRow.alignment = .centerY
-        titleRow.spacing = 5
         titleRow.detachesHiddenViews = true
-        titleRow.addArrangedSubview(stateLabel)
         titleRow.addArrangedSubview(titleLabel)
+
+        secondaryRow.orientation = .horizontal
+        secondaryRow.alignment = .centerY
+        secondaryRow.spacing = 5
+        secondaryRow.detachesHiddenViews = true
+        secondaryRow.addArrangedSubview(stateLabel)
+        secondaryRow.addArrangedSubview(contextLabel)
 
         textColumn.orientation = .vertical
         textColumn.alignment = .leading
         textColumn.spacing = Metrics.lineGap
         textColumn.addArrangedSubview(titleRow)
-        textColumn.addArrangedSubview(contextLabel)
+        textColumn.addArrangedSubview(secondaryRow)
 
         proxyButton.translatesAutoresizingMaskIntoConstraints = false
         textColumn.translatesAutoresizingMaskIntoConstraints = false
@@ -376,34 +382,33 @@ final class ToolbarDocumentIdentityView: NSView {
     }
 
     private var stateDescription: String? {
-        let title: String
-        switch documentState.phase {
-        case .neutral: return nil
-        case .edited: title = "Edited"
-        case .saving: title = "Saving"
-        case .saved: title = "Saved"
-        case .changedOnDisk: title = "Changed on disk"
-        case .conflict: title = "Conflict"
-        case .saveFailed: title = "Save failed"
-        }
+        guard let title = stateTitle else { return nil }
         let provenance = documentState.provenance.map { " — \($0)" } ?? ""
-        let detail = documentState.detail.map { ": \($0)" } ?? ""
+        let detail = documentState.detail.flatMap { $0 == title ? nil : ": \($0)" } ?? ""
         return title + provenance + detail
     }
 
-    private func refreshDocumentState() {
+    private var stateTitle: String? {
         switch documentState.phase {
-        case .neutral:
+        case .neutral: return nil
+        case .edited: return "Edited"
+        case .saving: return "Saving"
+        case .saved: return "Saved"
+        case .changedOnDisk:
+            return documentState.detail == "File missing" ? "File missing" : "Changed externally"
+        case .conflict: return "Conflict"
+        case .saveFailed: return "Save failed"
+        }
+    }
+
+    private func refreshDocumentState() {
+        if let stateTitle {
+            stateLabel.stringValue = stateTitle
+            stateLabel.isHidden = false
+        } else {
             stateLabel.stringValue = ""
             stateLabel.isHidden = true
-        case .edited: stateLabel.stringValue = "Edited"
-        case .saving: stateLabel.stringValue = "Saving"
-        case .saved: stateLabel.stringValue = "Saved"
-        case .changedOnDisk: stateLabel.stringValue = "On disk"
-        case .conflict: stateLabel.stringValue = "Conflict"
-        case .saveFailed: stateLabel.stringValue = "Save failed"
         }
-        if documentState.phase != .neutral { stateLabel.isHidden = false }
         refreshToolTip()
         refreshEmphasis()
         refreshAccessibility()

--- a/Sources/DownrightApp/Assets/CapturedImage.swift
+++ b/Sources/DownrightApp/Assets/CapturedImage.swift
@@ -1,0 +1,225 @@
+import AppKit
+import Foundation
+
+/// Turning a Continuity Camera capture into a file next to the document and a
+/// Markdown reference to it.
+///
+/// Everything here is a pure function over a pasteboard, a directory listing,
+/// or a source string: the window controller decides *when* an image arrives,
+/// this decides *what* gets written and *what text* the document gains.  The
+/// naming rules in particular are worth stating once and testing, because they
+/// have to satisfy three separate consumers at the same time:
+///
+///   * `LocalAssetPolicy` renders a local asset without a trust prompt only
+///     when the destination is relative, traversal-free, and resolves inside
+///     the document's own folder.  So the file goes next to the document and
+///     the reference is a bare filename.
+///   * `AssetReferenceParser` ends a destination at the first space, `#`, or
+///     `?`, and percent-decodes what is left.  A filename containing any of
+///     those — or a literal `%` — parses as a different path than it names.
+///   * `AssetDoctor` warns about absolute paths, unsupported formats, and
+///     missing alt text.  A capture should not arrive pre-diagnosed.
+enum CapturedImage {
+
+    // MARK: - Reading the capture
+
+    /// Image bytes plus the extension they should be written under.
+    struct Payload: Equatable {
+        var data: Data
+        var fileExtension: String
+    }
+
+    /// Types taken verbatim, in preference order.
+    ///
+    /// Verbatim matters: re-encoding a photo to get it onto disk would throw
+    /// away the capture's own compression and colour for nothing.  These three
+    /// are exactly the camera-shaped formats in
+    /// `AssetResolutionContext.supportedExtensions`, so a capture never lands
+    /// as an asset the Asset Doctor immediately flags as unsupported.
+    static let passthroughTypes: [(type: NSPasteboard.PasteboardType, fileExtension: String)] = [
+        (.png, "png"),
+        (NSPasteboard.PasteboardType("public.jpeg"), "jpg"),
+        (NSPasteboard.PasteboardType("public.heic"), "heic"),
+    ]
+
+    /// True for the return types this app can actually turn into a Markdown
+    /// image.  Used both to advertise the responder to AppKit and to decode.
+    static func acceptsReturnType(_ type: NSPasteboard.PasteboardType) -> Bool {
+        NSImage.imageTypes.contains(type.rawValue)
+    }
+
+    static func payload(from pasteboard: NSPasteboard) -> Payload? {
+        for candidate in passthroughTypes {
+            guard pasteboard.availableType(from: [candidate.type]) != nil,
+                  let data = pasteboard.data(forType: candidate.type), !data.isEmpty
+            else { continue }
+            return Payload(data: data, fileExtension: candidate.fileExtension)
+        }
+        // Anything else — TIFF from an older capture path, a PDF page from a
+        // scan — is re-encoded to PNG rather than written under its own
+        // extension.  `.tiff` is not in the supported set and no browser opens
+        // a `.pdf` from an `![…]()`, so passing those through would produce a
+        // reference that renders as a broken image in Downright and in every
+        // exported HTML file.
+        guard let image = NSImage(pasteboard: pasteboard),
+              let tiff = image.tiffRepresentation,
+              let bitmap = NSBitmapImageRep(data: tiff),
+              let png = bitmap.representation(using: .png, properties: [:])
+        else { return nil }
+        return Payload(data: png, fileExtension: "png")
+    }
+
+    // MARK: - Naming the file
+
+    /// A filename component that survives both the filesystem and
+    /// `AssetReferenceParser`.
+    ///
+    /// Whitespace becomes `-` and the characters that would end or re-point the
+    /// destination are dropped outright, so the written path and the parsed
+    /// path are the same string and no percent-encoding is needed anywhere.
+    /// Non-ASCII letters are kept: a document called `Reunión.md` should not
+    /// have its assets renamed to `Reunin`.
+    static func slug(_ name: String) -> String {
+        var out = ""
+        var lastWasDash = false
+        for scalar in name.unicodeScalars {
+            let character = Character(scalar)
+            if character.isWhitespace || scalar == "_" {
+                if !lastWasDash, !out.isEmpty { out.append("-"); lastWasDash = true }
+                continue
+            }
+            // `/ : \0` break the write; `# ? %` break the parse; the rest are
+            // ordinary shell and Markdown hazards not worth carrying.
+            if "/\\:#?%()[]<>|\"'*\u{0}".unicodeScalars.contains(scalar) { continue }
+            if scalar.properties.generalCategory == .control { continue }
+            out.append(character)
+            lastWasDash = false
+        }
+        while out.hasSuffix("-") || out.hasSuffix(".") { out.removeLast() }
+        while out.hasPrefix("-") || out.hasPrefix(".") { out.removeFirst() }
+        return out
+    }
+
+    /// The first free `<stem>[-n].<ext>` in a directory.
+    ///
+    /// Numbered rather than timestamped so the name is deterministic and this
+    /// is testable without injecting a clock, and never reused so a second
+    /// write cannot overwrite the first.  The cap is a guard against a
+    /// pathological directory, not an expected path; past it the name carries a
+    /// UUID, which is ugly but still writes.
+    ///
+    /// Shared with the drop path (`DroppedAsset`), which names a copied-in
+    /// file after the file the reader dragged rather than after the document.
+    /// The collision rule has to be the same one in both places: two different
+    /// answers to "is this name free?" is how one of them ends up clobbering an
+    /// asset the document already references.
+    static func uniqueFileName(
+        stem: String,
+        fileExtension: String,
+        exists: (String) -> Bool
+    ) -> String {
+        for index in 1...999 {
+            let candidate = index == 1
+                ? "\(stem).\(fileExtension)"
+                : "\(stem)-\(index).\(fileExtension)"
+            if !exists(candidate) { return candidate }
+        }
+        return "\(stem)-\(UUID().uuidString).\(fileExtension)"
+    }
+
+    /// The capture's own naming rule: `<document>-photo[-n].<ext>`.
+    static func uniqueFileName(
+        documentBaseName: String,
+        fileExtension: String,
+        exists: (String) -> Bool
+    ) -> String {
+        let base = slug(documentBaseName)
+        return uniqueFileName(
+            stem: base.isEmpty ? "photo" : base + "-photo",
+            fileExtension: fileExtension,
+            exists: exists
+        )
+    }
+
+    static func uniqueFileName(
+        in directory: URL,
+        documentBaseName: String,
+        fileExtension: String
+    ) -> String {
+        uniqueFileName(documentBaseName: documentBaseName, fileExtension: fileExtension) { name in
+            FileManager.default.fileExists(atPath: directory.appendingPathComponent(name).path)
+        }
+    }
+
+    // MARK: - Writing the reference
+
+    /// The text to insert, the zero-length source range to insert it at, and
+    /// where the caret lands afterwards.
+    ///
+    /// A Markdown image is an inline span, so `![…](…)` at the caret is already
+    /// valid wherever the caret is — but a photograph dropped into the middle
+    /// of a sentence is almost never what the reader meant, and a reference
+    /// glued to the previous line is not even rendered as its own block.  So
+    /// the insertion pads itself out to a paragraph of its own, and pads
+    /// exactly as much as the surrounding blank lines are missing.
+    ///
+    /// The padding is part of the inserted string.  Nothing outside
+    /// `[origin, origin)` is touched — see `readSelection(from:)` for why that
+    /// matters when the capture happens on a different device.  `origin` is
+    /// returned rather than recomputed by the caller so the clamp that produced
+    /// the padding and the clamp that produces the edit range cannot drift.
+    static func insertion(
+        destination: String,
+        altText: String,
+        in source: String,
+        at caret: Int
+    ) -> (replacement: String, origin: Int, caret: Int) {
+        insertion(block: "![\(altText)](\(destination))", in: source, at: caret)
+    }
+
+    /// The same padding rule for any block of generated Markdown.
+    ///
+    /// Shared with the drop path, which arrives with a block that may hold
+    /// several references at once.  One implementation because the padding is
+    /// the fiddly part: it has to count the newlines that are *already* there
+    /// on each side, so dropping into an existing blank line adds nothing and
+    /// dropping mid-sentence adds exactly two.
+    static func insertion(
+        block: String,
+        in source: String,
+        at caret: Int
+    ) -> (replacement: String, origin: Int, caret: Int) {
+        let text = source as NSString
+        let position = min(max(0, caret), text.length)
+
+        var leadingNewlines = 0
+        var index = position - 1
+        while index >= 0, leadingNewlines < 2, text.character(at: index) == 0x0A {
+            leadingNewlines += 1
+            index -= 1
+        }
+        let prefix = position == 0 ? "" : String(repeating: "\n", count: 2 - leadingNewlines)
+
+        var trailingNewlines = 0
+        index = position
+        while index < text.length, trailingNewlines < 2, text.character(at: index) == 0x0A {
+            trailingNewlines += 1
+            index += 1
+        }
+        let suffix = position == text.length ? "" : String(repeating: "\n", count: 2 - trailingNewlines)
+
+        return (
+            prefix + block + suffix,
+            position,
+            position + (prefix + block).utf16.count
+        )
+    }
+
+    /// Alt text for a capture.  Never empty — the Asset Doctor flags a missing
+    /// alt as a warning, and a photo that arrives already carrying a diagnostic
+    /// is a worse first impression than a placeholder the user can edit.
+    static func altText(forFileNamed fileName: String) -> String {
+        let stem = (fileName as NSString).deletingPathExtension
+        return stem.isEmpty ? "Photo" : stem
+    }
+}

--- a/Sources/DownrightApp/Assets/DroppedAsset.swift
+++ b/Sources/DownrightApp/Assets/DroppedAsset.swift
@@ -1,0 +1,329 @@
+import AppKit
+import Foundation
+import MarkdownRender
+
+/// Turning something dropped on the document surface into files on disk and
+/// Markdown in the source.
+///
+/// The render layer resolves *where* a drop lands (see `DocumentDrop`); this
+/// decides *what* it becomes, and it is deliberately all pure functions over a
+/// pasteboard, a document URL, and a "is this name taken?" closure.  The
+/// window controller does the writing.
+///
+/// The hard part is not the drag.  It is that a Markdown destination has to
+/// satisfy four consumers at once, and they do not agree with each other:
+///
+///   * `LocalAssetPolicy` — the renderer — resolves a destination as a *path*,
+///     with no percent-decoding at all.  `%20` in a reference is a filename
+///     containing the three characters `%`, `2`, `0`.
+///   * `AssetReferenceParser` — the Asset Doctor — ends a bare destination at
+///     the first space or tab, truncates at `#` or `?`, and *does*
+///     percent-decode.  It also understands the CommonMark `<…>` form.
+///   * `AssetDoctor` warns about absolute paths ("not portable") and
+///     unsupported formats, so a drop should not arrive pre-diagnosed.
+///   * `MarkdownLinkDestination` — what happens when the reader clicks the
+///     thing afterwards — resolves `file:` URLs and paths relative to the
+///     document, and nothing else.  A bare absolute path such as
+///     `/Users/…/notes.md` classifies as *relative* there and is appended to
+///     the document's folder, which opens nothing.
+///
+/// The intersection those four leave is small, and it is what every rule below
+/// is derived from: prefer a bare relative path, fall back to the angle-bracket
+/// form, and use a `file:` URL when nothing relative will do.  Percent-encoding
+/// is never used, because the renderer would not decode it.
+enum DroppedAsset {
+
+    // MARK: - Reading the drag
+
+    enum Payload: Equatable {
+        /// Real files: Finder, Preview, an attachment dragged out of Mail.
+        case files([URL])
+        /// Bytes with no file behind them: an image dragged straight out of a
+        /// browser or a preview window.
+        case imageData(CapturedImage.Payload)
+    }
+
+    /// Files are read first on purpose.  A file drag also exposes its path as
+    /// a string and often an image representation as well, and taking the
+    /// bytes instead of the file would copy an image the reader already has,
+    /// under a name they did not choose, next to a document that could have
+    /// referenced the original where it stood.
+    static func payload(from pasteboard: NSPasteboard) -> Payload? {
+        let urls = pasteboard.readObjects(
+            forClasses: [NSURL.self], options: [.urlReadingFileURLsOnly: true]
+        ) as? [URL] ?? []
+        let existing = urls.filter { FileManager.default.fileExists(atPath: $0.path) }
+        if !existing.isEmpty { return .files(existing) }
+        if let image = CapturedImage.payload(from: pasteboard) { return .imageData(image) }
+        return nil
+    }
+
+    // MARK: - Where a reference points
+
+    /// The three forms a destination may take, in preference order.
+    enum Destination: Equatable {
+        /// `assets/diagram.png` — portable, and the only form the renderer
+        /// draws without a trust prompt (`LocalAssetPolicy.isSafeRelative`).
+        case relative(String)
+        /// `<meeting notes.png>` — still relative and still trusted, and the
+        /// CommonMark-sanctioned way to carry a space.  The parser strips the
+        /// brackets before either the Asset Doctor or the renderer sees the
+        /// path, so both still resolve the real file.
+        case angled(String)
+        /// `file:///Users/…` — not portable and not trusted-by-default, but
+        /// unambiguous.  Used only when there is nothing to be relative *to*.
+        case absolute(URL)
+
+        var markdownText: String {
+            switch self {
+            case .relative(let path): return path
+            case .angled(let path): return "<\(path)>"
+            // `absoluteString` percent-encodes exactly the characters a URL
+            // needs encoded, and `URL(string:)` — which is what both the Asset
+            // Doctor and the link classifier use for a `file:` destination —
+            // decodes them again.  This is the one place percent-encoding is
+            // correct, because here it round-trips.
+            case .absolute(let url): return url.absoluteString
+            }
+        }
+
+        /// True when the reference is relative to the document's own folder,
+        /// which is what makes it portable and prompt-free.
+        var isRelative: Bool {
+            switch self {
+            case .relative, .angled: return true
+            case .absolute: return false
+            }
+        }
+    }
+
+    /// Characters that end or re-point a *bare* destination.  A path holding
+    /// any of them has to use the angle-bracket form.
+    private static let bareHazards: Set<Character> = [" ", "\t", "#", "?", "%", "(", ")"]
+    /// Characters the angle-bracket form cannot carry either.
+    private static let angledHazards: Set<Character> = ["<", ">", "\n", "\r"]
+
+    /// The best destination for a file that already exists on disk.
+    ///
+    /// A file *inside* the document's folder is referenced where it stands and
+    /// never copied: it is already portable, the reader put it there, and
+    /// duplicating it would leave two copies of an asset the document may
+    /// already reference once.
+    static func destination(for file: URL, relativeTo directory: URL?) -> Destination {
+        guard let directory, let relative = relativePath(of: file, in: directory) else {
+            return .absolute(file.standardizedFileURL)
+        }
+        if !relative.contains(where: bareHazards.contains) { return .relative(relative) }
+        if !relative.contains(where: angledHazards.contains) { return .angled(relative) }
+        return .absolute(file.standardizedFileURL)
+    }
+
+    /// `file`'s path relative to `directory`, or nil when it is not inside it.
+    ///
+    /// Both sides are canonicalised through `LocalAssetPolicy`, because that is
+    /// what the renderer will do when it resolves the reference back.  Without
+    /// it a document opened through `/tmp` (a symlink to `/private/tmp`) and an
+    /// image dropped from `/private/tmp` would look like they were in different
+    /// folders and the image would be copied for no reason.
+    ///
+    /// Never produces a `..` path.  A traversal is not `isSafeRelative`, so an
+    /// image referenced through one renders only behind a trust prompt — the
+    /// same reason the capture path writes next to the document.
+    static func relativePath(of file: URL, in directory: URL) -> String? {
+        guard let child = LocalAssetPolicy.canonicalFileURL(file),
+              let root = LocalAssetPolicy.canonicalFileURL(directory),
+              LocalAssetPolicy.isWithin(child, root) else { return nil }
+        let components = child.pathComponents.dropFirst(root.pathComponents.count)
+        guard !components.isEmpty else { return nil }
+        return components.joined(separator: "/")
+    }
+
+    /// Formats Downright can actually draw — the Asset Doctor's own set, so a
+    /// dropped file becomes an `![…]` only when it would not be diagnosed as an
+    /// unsupported format the moment it lands.
+    private static let imageExtensions = AssetResolutionContext().supportedExtensions
+
+    static func isImage(_ url: URL) -> Bool {
+        imageExtensions.contains(url.pathExtension.lowercased())
+    }
+
+    // MARK: - What a drop becomes
+
+    /// A file the drop has to create before its reference means anything.
+    struct Write: Equatable {
+        var fileName: String
+        var contents: Contents
+
+        enum Contents: Equatable {
+            case copyOf(URL)
+            case data(Data)
+        }
+    }
+
+    /// One dropped item, resolved.
+    struct Insertion: Equatable {
+        /// Nil when the reference points at a file that is already in place.
+        var write: Write?
+        var markdown: String
+        /// Images are padded out into a paragraph of their own; a link is
+        /// inline text and lands exactly where the pointer was.
+        var isBlock: Bool
+    }
+
+    /// Everything a drop turns into, in order.
+    ///
+    /// `documentDirectory` is nil for a window that has never been saved, and
+    /// that case is answered differently for each payload rather than refused
+    /// wholesale:
+    ///
+    ///   * A dropped **file** still exists somewhere the reader can point at,
+    ///     so it gets a `file:` destination.  A link to it works immediately.
+    ///     An image does not *draw* yet — `LocalAssetPolicy.request` resolves
+    ///     nothing at all without a document URL, so the reference renders as
+    ///     a missing asset until the window is saved and the reader grants the
+    ///     absolute path trust.  That is a real cost, and it is still the
+    ///     better half of the trade: the Markdown is correct, it names the
+    ///     file the reader actually dropped, and it becomes portable the
+    ///     moment they Save As beside it.  Refusing the drag outright would
+    ///     leave them with nothing and no explanation.
+    ///   * Dropped **bytes** have nowhere to go.  Writing them into a temporary
+    ///     folder would produce a reference that the Asset Doctor flags, that
+    ///     needs trust to draw, and that breaks the first time macOS reclaims
+    ///     the folder — the same reasoning that makes Continuity Camera decline
+    ///     an untitled window.  Refused, and refused up front so the drag is
+    ///     never accepted in the first place.
+    static func plan(
+        for payload: Payload,
+        documentDirectory: URL?,
+        documentBaseName: String,
+        isTaken: (String) -> Bool
+    ) -> [Insertion] {
+        var taken: Set<String> = []
+        func claim(stem: String, fileExtension: String) -> String {
+            let name = CapturedImage.uniqueFileName(stem: stem, fileExtension: fileExtension) {
+                taken.contains($0) || isTaken($0)
+            }
+            taken.insert(name)
+            return name
+        }
+
+        switch payload {
+        case .imageData(let image):
+            guard documentDirectory != nil else { return [] }
+            let base = CapturedImage.slug(documentBaseName)
+            let name = claim(
+                stem: base.isEmpty ? "image" : base + "-image",
+                fileExtension: image.fileExtension
+            )
+            return [Insertion(
+                write: Write(fileName: name, contents: .data(image.data)),
+                markdown: imageMarkdown(alt: altText(for: name), destination: .relative(name)),
+                isBlock: true
+            )]
+
+        case .files(let urls):
+            return urls.map { url in
+                let placement = destination(for: url, relativeTo: documentDirectory)
+                guard isImage(url) else {
+                    // A link is a *reference*, never an embed.  Copying
+                    // somebody's document into this folder because it was
+                    // linked would be a surprising, unasked-for duplication of
+                    // their file — so a non-image is linked where it stands,
+                    // relatively when it can be and by `file:` URL when it
+                    // cannot.
+                    return Insertion(
+                        write: nil,
+                        markdown: linkMarkdown(label: altText(for: url.lastPathComponent),
+                                               destination: placement),
+                        isBlock: false
+                    )
+                }
+                if placement.isRelative || documentDirectory == nil {
+                    return Insertion(
+                        write: nil,
+                        markdown: imageMarkdown(alt: altText(for: url.lastPathComponent),
+                                                destination: placement),
+                        isBlock: true
+                    )
+                }
+                // An image from outside the folder is copied in, which is the
+                // convention the rest of the app already holds to: an absolute
+                // image path is flagged non-portable by the Asset Doctor and
+                // draws only behind a trust prompt, and neither is a reasonable
+                // thing to hand somebody who just dragged a picture in.
+                let stem = CapturedImage.slug(url.deletingPathExtension().lastPathComponent)
+                let name = claim(
+                    stem: stem.isEmpty ? "image" : stem,
+                    fileExtension: url.pathExtension.lowercased()
+                )
+                return Insertion(
+                    write: Write(fileName: name, contents: .copyOf(url)),
+                    markdown: imageMarkdown(
+                        // The alt text keeps the file's real name even though
+                        // the copy is slugged: the reader recognises "Screen
+                        // Shot 2026-08-21", not "Screen-Shot-2026-08-21".
+                        alt: altText(for: url.lastPathComponent),
+                        destination: .relative(name)
+                    ),
+                    isBlock: true
+                )
+            }
+        }
+    }
+
+    /// The one source edit a whole drop becomes.
+    ///
+    /// A drop of more than one item is a list, not a sentence, so it is laid
+    /// out as blocks even when every item in it is a link.  A single link stays
+    /// inline: the reader aimed the pointer at a word, and pushing their
+    /// sentence apart to make room for `[notes](notes.md)` would throw away the
+    /// precision the drop point exists to give them.
+    static func edit(
+        insertions: [Insertion],
+        in source: String,
+        at offset: Int
+    ) -> (replacement: String, origin: Int, caret: Int)? {
+        guard !insertions.isEmpty else { return nil }
+        let isBlock = insertions.count > 1 || insertions.contains(where: \.isBlock)
+        let body = insertions.map(\.markdown).joined(separator: isBlock ? "\n\n" : " ")
+        guard isBlock else {
+            let text = source as NSString
+            let position = min(max(0, offset), text.length)
+            return (body, position, position + body.utf16.count)
+        }
+        return CapturedImage.insertion(block: body, in: source, at: offset)
+    }
+
+    // MARK: - Markdown text
+
+    static func imageMarkdown(alt: String, destination: Destination) -> String {
+        "![\(alt)](\(destination.markdownText))"
+    }
+
+    static func linkMarkdown(label: String, destination: Destination) -> String {
+        "[\(label)](\(destination.markdownText))"
+    }
+
+    /// A label safe to sit between `[` and `]`.
+    ///
+    /// A filename is arbitrary text and may hold brackets or a backslash, any
+    /// of which would end the label early and leave the rest of the reference
+    /// as literal prose.  Escaped rather than stripped, because unlike a
+    /// *filename* — which the app is free to slug when it writes it — a label
+    /// is the only human-readable trace of what the reader actually dropped.
+    static func altText(for fileName: String) -> String {
+        let stem = (fileName as NSString).deletingPathExtension
+        let base = stem.isEmpty ? fileName : stem
+        var out = ""
+        for character in base {
+            if character == "\\" || character == "[" || character == "]" { out.append("\\") }
+            if character.isNewline { out.append(" "); continue }
+            out.append(character)
+        }
+        let trimmed = out.trimmingCharacters(in: .whitespaces)
+        // Never empty: the Asset Doctor reports a missing alt as a warning, and
+        // an image that arrives already carrying a diagnostic is a worse first
+        // impression than a placeholder the reader can edit.
+        return trimmed.isEmpty ? "Image" : trimmed
+    }
+}

--- a/Sources/DownrightApp/Export/DocumentShare.swift
+++ b/Sources/DownrightApp/Export/DocumentShare.swift
@@ -1,0 +1,116 @@
+import Foundation
+import MarkdownCore
+
+/// What Share hands to `NSSharingServicePicker`, and where a throwaway copy of
+/// it goes.
+///
+/// Everything here is a *file*, deliberately.  AirDrop, Mail, Messages, and
+/// Notes all attach what they are given: hand them an `NSString` and the
+/// receiver gets pasted text with no name and no extension, and nothing they
+/// can open in a Markdown reader.  Hand them a URL and AirDrop sends a real
+/// `.md`.  So the only question Share has to answer is *which* file, and the
+/// answer is not always the document's own.
+///
+/// Split out of the window controller because the decision is pure and the
+/// consequences of getting it wrong are silent: sharing the wrong bytes looks
+/// exactly like sharing the right ones until the receiver opens it.
+enum DocumentShareSource: Equatable {
+    /// The document's own file, byte for byte what is on disk.  Used only when
+    /// the buffer and the file agree.
+    case documentFile(URL)
+    /// A copy of the live buffer, written under `fileName` in a staging
+    /// directory.  Covers two states the document file cannot: the never-saved
+    /// window, which has no file at all, and the dirty one, whose file is a
+    /// stale version of what the reader is looking at.
+    case bufferSnapshot(fileName: String)
+
+    /// A saved, clean document shares itself; anything else shares a snapshot.
+    ///
+    /// The dirty case is the one worth being deliberate about.  Sharing the
+    /// file would be the cheaper implementation and a silent lie: the reader
+    /// AirDrops "the document", the receiver gets the version from before the
+    /// last ten minutes of typing, and nothing in either app says so.  Saving
+    /// first would be worse — Share is not a save, and §8.1 does not let an
+    /// implicit path decide to write the user's file for them.  A snapshot of
+    /// the buffer is the only option that sends what is on screen without
+    /// touching the original.
+    static func choose(url: URL?, hasUnsavedChanges: Bool, displayName: String) -> DocumentShareSource {
+        if let url, !hasUnsavedChanges { return .documentFile(url) }
+        return .bufferSnapshot(fileName: snapshotFileName(url: url, displayName: displayName))
+    }
+
+    /// The name the receiver sees.  Keeps the document's own filename when
+    /// there is one — including its extension, because `.markdown` and `.mkd`
+    /// are the user's choice and re-spelling them `.md` would rename their file
+    /// behind their back.
+    static func snapshotFileName(url: URL?, displayName: String) -> String {
+        if let url, !url.lastPathComponent.isEmpty { return url.lastPathComponent }
+        let base = sanitizedFileBaseName(displayName)
+        return base.isEmpty ? "Untitled.md" : base + ".md"
+    }
+
+    /// Strips what a filename cannot carry.  A document display name is
+    /// arbitrary text, and `/` in it would silently redirect the write into
+    /// another directory.
+    static func sanitizedFileBaseName(_ name: String) -> String {
+        var cleaned = name.components(separatedBy: CharacterSet(charactersIn: "/:\0"))
+            .joined(separator: "-")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        // Every leading dot, not just the first: a name that still begins with
+        // one would arrive hidden in the receiver's Downloads folder, and
+        // dropping one dot off `..-..-etc` leaves a name that still does.  A
+        // leading `-` goes with them, because it turns the file into a flag for
+        // whatever command line the receiver eventually points at it.
+        while let first = cleaned.first, first == "." || first == "-" {
+            cleaned.removeFirst()
+        }
+        return cleaned
+    }
+}
+
+/// Where throwaway share copies live, and how they get written.
+///
+/// A fresh subdirectory per share rather than one flat folder: the receiver
+/// should see `notes.md`, not `notes-3.md`, and two shares in the same second
+/// must not race on one path.  These are the system's temporary directory, so
+/// macOS reclaims them; Downright never deletes them out from under a share
+/// that may still be uploading.
+enum DocumentShareStaging {
+    static func makeDirectory(root: URL = FileManager.default.temporaryDirectory) throws -> URL {
+        let directory = root
+            .appendingPathComponent("Downright-Share", isDirectory: true)
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory
+    }
+
+    /// Materialises `source` into something the share sheet can attach.
+    ///
+    /// The snapshot is written with the document's own `fidelity` for the same
+    /// reason Save As is (§3.1): a CRLF / UTF-16 / BOM / no-final-newline
+    /// document that arrives normalised is not the document that was shared.
+    static func fileURL(
+        for source: DocumentShareSource,
+        text: @autoclosure () -> String,
+        fidelity: ByteFidelity,
+        root: URL = FileManager.default.temporaryDirectory
+    ) throws -> URL {
+        switch source {
+        case .documentFile(let url):
+            return url
+        case .bufferSnapshot(let fileName):
+            let directory = try makeDirectory(root: root)
+            let destination = directory.appendingPathComponent(fileName)
+            try DocumentIO.write(text(), to: destination, fidelity: fidelity)
+            return destination
+        }
+    }
+
+    /// The path a rendered PDF is staged at.  Always a snapshot: there is no
+    /// PDF of the document on disk to share instead.
+    static func pdfURL(displayName: String, root: URL = FileManager.default.temporaryDirectory) throws -> URL {
+        let base = DocumentShareSource.sanitizedFileBaseName(displayName)
+        let directory = try makeDirectory(root: root)
+        return directory.appendingPathComponent((base.isEmpty ? "Untitled" : base) + ".pdf")
+    }
+}

--- a/Sources/DownrightApp/Panels/DocumentQuickLook.swift
+++ b/Sources/DownrightApp/Panels/DocumentQuickLook.swift
@@ -1,0 +1,208 @@
+import AppKit
+import MarkdownCore
+import MarkdownRender
+import ObjectiveC
+import Quartz
+
+private var quickLookSessionKey: UInt8 = 0
+
+/// What a Quick Look gesture on the document surface should actually open.
+///
+/// A pure decision, separate from the panel, because the interesting part is
+/// the routing and the routing has three different answers that all look alike
+/// from the outside.  The panel itself is untestable in a headless suite; this
+/// is not.
+enum QuickLookRequest: Equatable {
+    /// An embedded image opens in Downright's own lightbox, not in the system
+    /// panel.  The lightbox is already what a *click* on that image does
+    /// (§7.1), it zooms and pans and shows the alt text as a caption, and
+    /// having force click open a second, different image viewer for the same
+    /// picture would be two answers to one question.
+    case lightbox(source: String)
+    /// Everything else — a path token, a link to a local file — is a question
+    /// about a *file*, which is exactly what `QLPreviewPanel` answers, for
+    /// every type the system has a generator for.  Including Markdown: this
+    /// app ships the Quick Look extension that renders it.
+    case panel(URL)
+
+    /// Resolves a target, or reports that it is not previewable.
+    ///
+    /// Returning nil matters as much as returning a request: a force click that
+    /// resolves to nothing falls back to `NSTextView`'s Look Up popover, which
+    /// is what must still happen on an ordinary word.
+    static func resolve(
+        _ target: ContextTarget,
+        documentURL: URL?,
+        pathResolution: (PathToken) -> PathResolver.Resolution?,
+        fileExists: (URL) -> Bool
+    ) -> QuickLookRequest? {
+        switch target.kind {
+        case .image(let source):
+            return .lightbox(source: source)
+
+        case .pathToken(let token):
+            guard let resolution = pathResolution(token), resolution.exists,
+                  let url = resolution.url else { return nil }
+            return .panel(url.standardizedFileURL)
+
+        case .link(let destination):
+            switch MarkdownLinkDestination.classify(destination) {
+            case .localFile(let url):
+                let target = url.standardizedFileURL
+                return fileExists(target) ? .panel(target) : nil
+            case .relative(let relative):
+                guard let base = documentURL?.deletingLastPathComponent() else { return nil }
+                let target = base.appendingPathComponent(relative).standardizedFileURL
+                return fileExists(target) ? .panel(target) : nil
+            // A web link, an in-document anchor, and an automation URL are all
+            // things Quick Look cannot preview.  Refused rather than opened:
+            // turning a preview gesture into "launch this URL" would route
+            // around the trust prompt that a real click goes through.
+            case .web, .anchor, .automation, .invalid:
+                return nil
+            }
+
+        case .heading, .codeBlock, .table, .selection, .plain:
+            return nil
+        }
+    }
+}
+
+/// The one file the panel is currently showing, plus where it came from.
+///
+/// Held on the controller through an associated object because
+/// `DocumentWindowController`'s stored properties live in a file this feature
+/// does not own; the sharing picker next door keeps its state the same way.
+private final class QuickLookSession {
+    var url: URL?
+    /// Source range of the thing being previewed, so the panel can zoom out of
+    /// the text it came from instead of appearing from the middle of nowhere.
+    var sourceRange: NSRange?
+}
+
+@MainActor
+extension DocumentWindowController: @preconcurrency QLPreviewPanelDataSource,
+    @preconcurrency QLPreviewPanelDelegate {
+
+    private var quickLookSession: QuickLookSession {
+        if let existing = objc_getAssociatedObject(self, &quickLookSessionKey) as? QuickLookSession {
+            return existing
+        }
+        let session = QuickLookSession()
+        objc_setAssociatedObject(self, &quickLookSessionKey, session, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        return session
+    }
+
+    // MARK: - Entry points
+
+    /// A force click landed on something (§7.1).  Reported by the text view in
+    /// source coordinates; the decision about what that means is here.
+    func markdownTextView(_ view: MarkdownTextView, wantsQuickLookFor target: ContextTarget) -> Bool {
+        presentQuickLook(target)
+    }
+
+    /// The Quick Look command, aimed at whatever the selection is on.
+    @discardableResult
+    func quickLookAtSelection() -> Bool {
+        guard let target = containerTextView.quickLookTargetAtSelection() else { return false }
+        return presentQuickLook(target)
+    }
+
+    /// Whether the command should be offered at all.  Reading the attribute
+    /// runs at the caret is cheap; resolving the file is not, so the menu asks
+    /// only the first question and the command asks the second.
+    var hasQuickLookTarget: Bool {
+        containerTextView.quickLookTargetAtSelection() != nil
+    }
+
+    @discardableResult
+    func presentQuickLook(_ target: ContextTarget) -> Bool {
+        guard let request = QuickLookRequest.resolve(
+            target,
+            documentURL: markdownDocument.url,
+            pathResolution: { [weak self] token in self?.pathResolver?.resolve(token) },
+            fileExists: { FileManager.default.fileExists(atPath: $0.path) }
+        ) else { return false }
+
+        switch request {
+        case .lightbox(let source):
+            presentLightbox(source: source, caption: nil)
+        case .panel(let url):
+            // Reading is the least the app can ask for, and it is the same
+            // effect the lightbox and the Asset Doctor request.  Opening a
+            // preview is not launching the file, so this deliberately does not
+            // ask for `.launchPathOrEditor`.
+            authorizeLocalEffect(.readLocalAsset, target: url) { [weak self] in
+                self?.showQuickLookPanel(url: url, sourceRange: target.sourceRange)
+            }
+        }
+        // True either way: the gesture was aimed at a file and was handled,
+        // including when the trust policy answered "ask" and the preview is
+        // waiting on the reader.  Falling through to the dictionary here would
+        // pop a Look Up card over a filename.
+        return true
+    }
+
+    private func showQuickLookPanel(url: URL, sourceRange: NSRange) {
+        let session = quickLookSession
+        session.url = url
+        session.sourceRange = sourceRange
+        guard let panel = QLPreviewPanel.shared() else { return }
+        if QLPreviewPanel.sharedPreviewPanelExists(), panel.isVisible {
+            // Already up on a different file — reload in place rather than
+            // closing and reopening, which would flash the desktop through.
+            panel.reloadData()
+        } else {
+            panel.makeKeyAndOrderFront(nil)
+        }
+    }
+
+    // MARK: - Panel control (the responder-chain handshake)
+
+    override func acceptsPreviewPanelControl(_ panel: QLPreviewPanel!) -> Bool { true }
+
+    override func beginPreviewPanelControl(_ panel: QLPreviewPanel!) {
+        panel.dataSource = self
+        panel.delegate = self
+    }
+
+    override func endPreviewPanelControl(_ panel: QLPreviewPanel!) {
+        // The panel outlives this window controller, so leaving it pointing
+        // here would keep a closed document's controller alive and, worse,
+        // answer for the next document opened in its place.
+        if panel.dataSource === self { panel.dataSource = nil }
+        if panel.delegate === self { panel.delegate = nil }
+        quickLookSession.url = nil
+        quickLookSession.sourceRange = nil
+    }
+
+    // MARK: - Data source
+
+    func numberOfPreviewItems(in panel: QLPreviewPanel!) -> Int {
+        quickLookSession.url == nil ? 0 : 1
+    }
+
+    func previewPanel(_ panel: QLPreviewPanel!, previewItemAt index: Int) -> QLPreviewItem! {
+        quickLookSession.url as NSURL?
+    }
+
+    // MARK: - Delegate
+
+    /// Zooms out of the text the preview came from.  Without this the panel
+    /// scales up from the centre of the screen, which reads as an unrelated
+    /// window opening rather than as the path under the pointer expanding.
+    func previewPanel(
+        _ panel: QLPreviewPanel!, sourceFrameOnScreenFor item: QLPreviewItem!
+    ) -> NSRect {
+        guard let range = quickLookSession.sourceRange,
+              let rect = containerTextView.rect(forOffset: range.location),
+              let window = containerTextView.window else { return .zero }
+        let inWindow = containerTextView.convert(rect, to: nil)
+        // Off-screen (the reader scrolled away, or the preview came from a
+        // command rather than a click) means no anchor at all: `.zero` asks the
+        // panel for its plain fade, which is better than an animation flying
+        // out of a corner the target is not in.
+        guard containerTextView.visibleRect.intersects(rect) else { return .zero }
+        return window.convertToScreen(inWindow)
+    }
+}

--- a/Sources/DownrightApp/Panels/UpdateNotesPopover.swift
+++ b/Sources/DownrightApp/Panels/UpdateNotesPopover.swift
@@ -1,0 +1,649 @@
+import AppKit
+import MarkdownCore
+import MarkdownRender
+
+/// The glass panel that unfurls under "Update Now" while the pointer rests on
+/// it, showing what the waiting build actually changes.
+///
+/// It exists because the press installs.  A button that restarts the app the
+/// moment it is clicked has to answer "into what?" before it is clicked, and a
+/// tooltip cannot carry release notes.  Hovering is the one gesture that can
+/// ask the question without committing to the answer.
+///
+/// Three constraints shape everything here:
+///
+/// * **The pill must never move.**  The panel is a separate child window
+///   hanging below the pill; the button keeps the exact frame the pointer is
+///   already aiming at.
+/// * **The travel must be bridged.**  The window's top edge is flush with the
+///   pill's bottom edge and the visible glass is inset below it, so a pointer
+///   moving from button to panel never crosses dead space.
+/// * **It must not eat the click.**  The window never becomes key, never
+///   activates the app, and hit-tests to nothing outside its own body.
+@MainActor
+final class UpdateNotesPopover {
+    /// Dwell before the panel appears.  Without it, the panel flashes every
+    /// time the pointer sweeps across the titlebar on its way somewhere else,
+    /// and no entrance survives being triggered by accident all day.
+    static let hoverInDelay: TimeInterval = 0.25
+    /// Grace after the pointer leaves both bodies.  Long enough to cross the
+    /// bridge on a diagonal, short enough that leaving feels like leaving.
+    static let dismissGrace: TimeInterval = 0.14
+    /// How often the pointer is tested against the live region.  Cheaper and
+    /// far more predictable than tracking areas spanning two windows.
+    private static let pointerPollInterval: TimeInterval = 0.1
+
+    fileprivate enum Layout {
+        static let width = PanelMetrics.detailWidth
+        /// The transparent strip joining the pill to the glass.  Part of the
+        /// window, so the pointer is still "inside" while crossing it.
+        static let bridgeHeight: CGFloat = 6
+        static let inset: CGFloat = 14
+        static let notesMinimumHeight: CGFloat = 54
+        /// Notes render at the app's own document type scale — this is
+        /// Downright reading its own release notes — so the cap is set in
+        /// lines rather than pixels: about ten of them, which is an opening
+        /// worth reading and still a panel rather than a window.
+        static let notesMaximumHeight: CGFloat = 244
+        /// Room inside the window for the body's shadow to fall.
+        static let shadowMargin = PanelMetrics.floatingShadowMargin
+    }
+
+    /// One pointer, one panel.  A second presentation replaces the first
+    /// rather than leaving two glass bodies on screen.
+    ///
+    /// Strong on purpose, and cleared in `dismiss()`.  The panel has to outlive
+    /// the call that built it — its own pointer tracking is what takes it down
+    /// — so a weak owner here means a body on screen with nothing left alive
+    /// to dismiss it.
+    private static var current: UpdateNotesPopover?
+
+    private let panel: NSPanel
+    private let surface: UpdateNotesSurface
+    private weak var anchor: NSView?
+    private var pointerTimer: Timer?
+    /// Body plus bridge in window coordinates — what the pointer has to stay
+    /// inside, as distinct from the window, which is larger by the room the
+    /// shadow needs to fall into.
+    private let bodyWindowRect: NSRect
+    private var outsideSince: Date?
+    private var isDismissing = false
+    /// The panel dismisses itself on pointer-exit, so the pill it came from
+    /// has to be told rather than asked.
+    var onDismiss: (() -> Void)?
+
+    // MARK: - Presentation
+
+    /// Builds and shows the panel under `anchor`.  Returns nil when there is
+    /// nothing worth showing (no window, no screen, or no update to describe).
+    @discardableResult
+    static func present(
+        from anchor: NSView,
+        metadata: UpdateMetadata?,
+        isReady: Bool,
+        sheet: StyleSheet
+    ) -> UpdateNotesPopover? {
+        current?.dismiss(animated: false)
+        guard let window = anchor.window, window.isVisible, window.screen != nil,
+              let metadata
+        else {
+            return nil
+        }
+        let popover = UpdateNotesPopover(
+            anchor: anchor, window: window, metadata: metadata, isReady: isReady, sheet: sheet
+        )
+        current = popover
+        popover.show()
+        return popover
+    }
+
+    static func dismissCurrent(animated: Bool = true) {
+        current?.dismiss(animated: animated)
+    }
+
+    private init(
+        anchor: NSView,
+        window: NSWindow,
+        metadata: UpdateMetadata,
+        isReady: Bool,
+        sheet: StyleSheet
+    ) {
+        self.anchor = anchor
+
+        let content = UpdateNotesContentView(metadata: metadata, isReady: isReady, sheet: sheet)
+        let bodyHeight = content.preferredHeight(width: Layout.width)
+        surface = UpdateNotesSurface(content: content, sheet: sheet)
+
+        // The window carries the bridge strip above the body and shadow room
+        // around it; the body itself is the only part that paints.
+        let windowSize = NSSize(
+            width: Layout.width + Layout.shadowMargin * 2,
+            height: bodyHeight + Layout.bridgeHeight + Layout.shadowMargin
+        )
+        let anchorFrame = anchor.convert(anchor.bounds, to: nil)
+        let anchorOnScreen = window.convertToScreen(anchorFrame)
+        // Trailing edges align; the window's top edge meets the pill's bottom.
+        var origin = NSPoint(
+            x: anchorOnScreen.maxX - Layout.width - Layout.shadowMargin,
+            y: anchorOnScreen.minY - windowSize.height
+        )
+        if let screen = window.screen {
+            let visible = screen.visibleFrame
+            origin.x = min(max(origin.x, visible.minX - Layout.shadowMargin), visible.maxX - windowSize.width + Layout.shadowMargin)
+            origin.y = max(origin.y, visible.minY)
+        }
+
+        panel = NSPanel(
+            contentRect: NSRect(origin: origin, size: windowSize),
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        panel.isOpaque = false
+        panel.backgroundColor = .clear
+        panel.hasShadow = false  // the body draws its own; a window shadow would
+                                 // need re-invalidating on every frame of the pour
+        panel.becomesKeyOnlyIfNeeded = true
+        panel.hidesOnDeactivate = false
+        panel.isFloatingPanel = false
+        panel.level = .normal
+        panel.isReleasedWhenClosed = false
+        panel.collectionBehavior = [.moveToActiveSpace, .transient]
+        panel.animationBehavior = .none
+        panel.setAccessibilityRole(.popover)
+        panel.setAccessibilityLabel("Release notes for \(metadata.displayVersionString)")
+
+        let root = UpdateNotesRootView(liveInset: Layout.shadowMargin)
+        root.frame = NSRect(origin: .zero, size: windowSize)
+        surface.frame = NSRect(
+            x: Layout.shadowMargin,
+            y: Layout.shadowMargin,
+            width: Layout.width,
+            height: bodyHeight
+        )
+        bodyWindowRect = surface.frame.union(
+            NSRect(
+                x: surface.frame.minX,
+                y: surface.frame.maxY,
+                width: surface.frame.width,
+                height: Layout.bridgeHeight
+            )
+        )
+        root.liveRegion = bodyWindowRect
+        root.addSubview(surface)
+        panel.contentView = root
+    }
+
+    deinit {
+        // Every release path goes through `dismiss()`, which invalidates this.
+        // Belt and braces: a repeating timer the run loop still owns would
+        // otherwise outlive the object it was polling on behalf of.
+        pointerTimer?.invalidate()
+    }
+
+    private func show() {
+        guard let host = anchor?.window else { return }
+        host.addChildWindow(panel, ordered: .above)
+        panel.orderFront(nil)
+        surface.refreshGlassAfterWindowAttach()
+        surface.present()
+        startPointerTracking()
+    }
+
+    // MARK: - Dismissal
+
+    func dismiss(animated: Bool = true) {
+        guard !isDismissing else { return }
+        isDismissing = true
+        if UpdateNotesPopover.current === self { UpdateNotesPopover.current = nil }
+        onDismiss?()
+        onDismiss = nil
+        pointerTimer?.invalidate()
+        pointerTimer = nil
+        guard animated, !surface.reducesMotion else {
+            close()
+            return
+        }
+        // Nobody watches an exit: a plain fade, faster than the arrival.
+        NSAnimationContext.runAnimationGroup { context in
+            context.duration = Motion.quick
+            context.timingFunction = Motion.timing(.easeOut)
+            panel.animator().alphaValue = 0
+        } completionHandler: { [weak self] in
+            MainActor.assumeIsolated { self?.close() }
+        }
+    }
+
+    private func close() {
+        panel.parent?.removeChildWindow(panel)
+        panel.orderOut(nil)
+        panel.contentView = nil
+    }
+
+    /// The union the pointer must stay inside: the pill, the bridge, the body.
+    private var liveScreenRegion: NSRect? {
+        guard let anchor, let host = anchor.window else { return nil }
+        let anchorOnScreen = host.convertToScreen(anchor.convert(anchor.bounds, to: nil))
+        return anchorOnScreen.union(panel.convertToScreen(bodyWindowRect))
+    }
+
+    private func startPointerTracking() {
+        pointerTimer?.invalidate()
+        let timer = Timer.scheduledTimer(
+            withTimeInterval: Self.pointerPollInterval, repeats: true
+        ) { [weak self] _ in
+            MainActor.assumeIsolated { self?.checkPointer() }
+        }
+        // The pour and any document scrolling both run in tracking modes; a
+        // default-mode-only timer would stop testing the pointer mid-gesture.
+        RunLoop.main.add(timer, forMode: .common)
+        pointerTimer = timer
+    }
+
+    private func checkPointer() {
+        guard let host = anchor?.window, host.isVisible, NSApp.isActive else {
+            dismiss()
+            return
+        }
+        guard let region = liveScreenRegion else {
+            dismiss()
+            return
+        }
+        if region.contains(NSEvent.mouseLocation) {
+            outsideSince = nil
+            return
+        }
+        let since = outsideSince ?? Date()
+        outsideSince = since
+        if Date().timeIntervalSince(since) >= Self.dismissGrace { dismiss() }
+    }
+}
+
+// MARK: - Root view
+
+/// Passes every click outside the body straight through to the document.  The
+/// window is much larger than what it paints — it carries a bridge strip and
+/// shadow room — and none of that margin may swallow a click.
+private final class UpdateNotesRootView: NSView {
+    var liveRegion: NSRect = .zero
+    private let liveInset: CGFloat
+
+    init(liveInset: CGFloat) {
+        self.liveInset = liveInset
+        super.init(frame: .zero)
+    }
+
+    required init?(coder: NSCoder) { fatalError("not supported") }
+
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        guard liveRegion.contains(point) else { return nil }
+        return super.hitTest(point)
+    }
+}
+
+// MARK: - Surface (the pour)
+
+/// The glass body, and the one piece of motion in this file.
+///
+/// It arrives as a *pour*, not a fade: the first visible sliver is already
+/// real material at `Motion.floatingSurfaceSliverOpacity`, full presence
+/// lands inside the first quarter of the travel, and the rest of the arrival
+/// is the body unfurling downward under a reveal mask.  Glass faded up from
+/// zero has nothing to refract and reads as a grey rectangle resolving, which
+/// is the whole reason those two constants exist.
+@MainActor
+private final class UpdateNotesSurface: Motion.SpringSurfaceView {
+    /// The height that is visible the instant the panel appears.
+    private static let sliverHeight: CGFloat = 20
+
+    let reducesMotion: Bool
+
+    private let glass: ChromeGlass
+    private let revealMask = CAShapeLayer()
+    private var reveal: Motion.SpringScalar
+    private var revealTarget: CGFloat = 0
+
+    init(content: NSView, sheet: StyleSheet) {
+        reducesMotion = sheet.reduceMotion
+        glass = ChromeGlass(
+            styleSheet: sheet,
+            cornerRadius: PanelMetrics.surfaceRadius,
+            tint: .panel
+        )
+        // A hover surface is quicker than a summoned one: the reader is
+        // holding still and waiting for it, so `deliberate` reads as lag.
+        reveal = Motion.SpringScalar(
+            value: 0, perceptualDuration: Motion.springStandard, bounce: 0.06
+        )
+        super.init(frame: .zero)
+
+        wantsLayer = true
+        revealMask.fillColor = NSColor.black.cgColor
+        revealMask.actions = ["path": NSNull(), "frame": NSNull()]
+        layer?.mask = revealMask
+
+        glass.autoresizingMask = [.width, .height]
+        addSubview(glass)
+        content.translatesAutoresizingMaskIntoConstraints = false
+        glass.contentView.addSubview(content)
+        NSLayoutConstraint.activate([
+            content.leadingAnchor.constraint(equalTo: glass.contentView.leadingAnchor),
+            content.trailingAnchor.constraint(equalTo: glass.contentView.trailingAnchor),
+            content.topAnchor.constraint(equalTo: glass.contentView.topAnchor),
+            content.bottomAnchor.constraint(equalTo: glass.contentView.bottomAnchor),
+        ])
+
+        setAccessibilityRole(.group)
+    }
+
+    required init?(coder: NSCoder) { fatalError("not supported") }
+
+    func refreshGlassAfterWindowAttach() {
+        glass.frame = bounds
+        glass.layoutSubtreeIfNeeded()
+        applyReveal()
+    }
+
+    func present() {
+        revealTarget = 1
+        guard !reducesMotion else {
+            reveal.snap(to: 1)
+            applyReveal()
+            return
+        }
+        reveal.snap(to: 0)
+        applyReveal()
+        // `snap` sets the target as well as the value, so the pour has to be
+        // retargeted after it or the spring is born already settled.
+        reveal.target(1)
+        armSprings()
+    }
+
+    override func layout() {
+        super.layout()
+        glass.frame = bounds
+        applyReveal()
+    }
+
+    override func springTick(dt: CGFloat) -> Bool {
+        reveal.advance(dt: dt)
+    }
+
+    override func springApply() { applyReveal() }
+
+    override func springsSettleImmediately() {
+        reveal.snap(to: revealTarget)
+        applyReveal()
+    }
+
+    private func applyReveal() {
+        let full = bounds.height
+        guard full > 1, bounds.width > 1 else { return }
+        let sliver = min(Self.sliverHeight, full)
+        let fraction = min(max(reveal.value, 0), 1)
+        let height = sliver + (full - sliver) * fraction
+        // The body unfurls downward, so the revealed rect hangs from the top.
+        let rect = CGRect(x: 0, y: full - height, width: bounds.width, height: height)
+        let radius = min(PanelMetrics.surfaceRadius, height / 2)
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        revealMask.path = CGPath(
+            roundedRect: rect, cornerWidth: radius, cornerHeight: radius, transform: nil
+        )
+        CATransaction.commit()
+
+        let presence = min(1, fraction / max(Motion.floatingSurfacePresenceFraction, 0.001))
+        alphaValue = Motion.floatingSurfaceSliverOpacity
+            + (1 - Motion.floatingSurfaceSliverOpacity) * presence
+    }
+}
+
+// MARK: - Content
+
+/// Version, what it changes, and a way out to the full notes.
+///
+/// The notes are already in hand: the release pipeline runs `generate_appcast`
+/// with `--embed-release-notes`, so the appcast `<description>` carries the
+/// Markdown and `UpdateMetadata.itemDescription` has it the moment the update
+/// is found.  This panel costs no network request of its own.
+@MainActor
+private final class UpdateNotesContentView: NSView {
+    private let stack = NSStackView()
+    private let notesScroll = NSScrollView()
+    private let metadata: UpdateMetadata
+    private let sheet: StyleSheet
+    private var notesHeight: NSLayoutConstraint!
+
+    init(metadata: UpdateMetadata, isReady: Bool, sheet: StyleSheet) {
+        self.metadata = metadata
+        self.sheet = sheet
+        super.init(frame: .zero)
+        translatesAutoresizingMaskIntoConstraints = false
+
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        stack.orientation = .vertical
+        stack.alignment = .leading
+        stack.spacing = 8
+        addSubview(stack)
+        NSLayoutConstraint.activate([
+            stack.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 14),
+            stack.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -14),
+            stack.topAnchor.constraint(equalTo: topAnchor, constant: 12),
+            stack.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -12),
+        ])
+
+        // Header: the version this installs into, and how far away it is.
+        let header = NSStackView()
+        header.orientation = .horizontal
+        header.alignment = .firstBaseline
+        header.spacing = 8
+        let title = NSTextField(labelWithString: "Downright \(metadata.displayVersionString)")
+        title.font = PanelFont.title
+        title.textColor = sheet.text
+        let status = NSTextField(labelWithString: Self.statusText(metadata, isReady: isReady))
+        status.font = PanelFont.secondary
+        status.textColor = sheet.textFaint
+        status.setContentHuggingPriority(.required, for: .horizontal)
+        header.distribution = .fill
+        title.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        title.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        title.lineBreakMode = .byTruncatingTail
+        header.addArrangedSubview(title)
+        header.addArrangedSubview(status)
+        stack.addArrangedSubview(header)
+        header.widthAnchor.constraint(equalTo: stack.widthAnchor).isActive = true
+
+        let rule = NSBox()
+        rule.boxType = .separator
+        stack.addArrangedSubview(rule)
+        rule.widthAnchor.constraint(equalTo: stack.widthAnchor).isActive = true
+
+        notesScroll.translatesAutoresizingMaskIntoConstraints = false
+        notesScroll.hasVerticalScroller = true
+        notesScroll.drawsBackground = false
+        notesScroll.borderType = .noBorder
+        notesScroll.autohidesScrollers = true
+        notesScroll.scrollerStyle = .overlay
+        stack.addArrangedSubview(notesScroll)
+        notesScroll.widthAnchor.constraint(equalTo: stack.widthAnchor).isActive = true
+        notesHeight = notesScroll.heightAnchor.constraint(
+            equalToConstant: UpdateNotesPopover.Layout.notesMinimumHeight
+        )
+        notesHeight.isActive = true
+
+        // The footer is the honest half of "capped": the panel shows an
+        // opening, and says plainly where the rest of it lives.
+        if let infoURL = metadata.infoURL, infoURL.scheme == "https" {
+            let link = UpdateNotesLinkButton(title: "Full notes", url: infoURL, sheet: sheet)
+            stack.addArrangedSubview(link)
+        }
+    }
+
+    required init?(coder: NSCoder) { fatalError("not supported") }
+
+    /// Lays the notes out at the real width, then reports the height the panel
+    /// should take: as tall as the notes need, inside the cap.
+    func preferredHeight(width: CGFloat) -> CGFloat {
+        let notesWidth = width - 28
+        let summary = UpdateNotesSummary.summary(from: metadata.itemDescription)
+        if summary.isEmpty {
+            let empty = NSTextField(wrappingLabelWithString: "No release notes for this build.")
+            empty.font = PanelFont.row
+            empty.textColor = sheet.textFaint
+            empty.preferredMaxLayoutWidth = notesWidth
+            notesScroll.documentView = empty
+            empty.frame = NSRect(
+                x: 0, y: 0, width: notesWidth, height: empty.fittingSize.height
+            )
+            notesHeight.constant = UpdateNotesPopover.Layout.notesMinimumHeight
+        } else {
+            let cap = UpdateNotesPopover.Layout.notesMaximumHeight
+            // The factory lays out at a zero width; it is re-run below at the
+            // real one so every measurement reflects the shown width.
+            // Drop whole lines until the notes fit, rather than letting the
+            // scroll view clip the last one. A hover panel that has to be
+            // scrolled to finish a sentence is worse than one that stops
+            // cleanly and says where the rest is — which the footer does.
+            var text = summary
+            var measured = Self.measure(text, width: notesWidth, sheet: sheet)
+            var guardCount = 0
+            while measured > cap, guardCount < 12,
+                  let shorter = UpdateNotesSummary.droppingLastLine(text) {
+                text = shorter
+                measured = Self.measure(text, width: notesWidth, sheet: sheet)
+                guardCount += 1
+            }
+            // A fresh view for the one that is shown: the measuring views were
+            // re-laid out repeatedly, and reusing one leaves the discarded
+            // candidates' fragments drawn beneath the final text.
+            let textView = UpdateNotesView.markdownTextView(for: text, sheet: sheet)
+            textView.frame = NSRect(x: 0, y: 0, width: notesWidth, height: max(measured, 1))
+            textView.update(document: MarkdownParser.parse(text), dirty: .wholesale)
+            notesScroll.documentView = textView
+            notesHeight.constant = min(
+                max(measured, UpdateNotesPopover.Layout.notesMinimumHeight), cap
+            )
+        }
+        widthAnchor.constraint(equalToConstant: width).isActive = true
+        layoutSubtreeIfNeeded()
+        return ceil(fittingSize.height)
+    }
+
+    /// Lays `text` out at `width` and reports the height it needs.
+    private static func measure(_ text: String, width: CGFloat, sheet: StyleSheet) -> CGFloat {
+        let textView = UpdateNotesView.markdownTextView(for: text, sheet: sheet)
+        textView.frame = NSRect(x: 0, y: 0, width: width, height: 1)
+        textView.update(document: MarkdownParser.parse(text), dirty: .wholesale)
+        guard let layoutManager = textView.textLayoutManager else {
+            return UpdateNotesPopover.Layout.notesMaximumHeight
+        }
+        layoutManager.ensureLayout(for: layoutManager.documentRange)
+        return ceil(layoutManager.usageBoundsForTextContainer.height) + 12
+    }
+
+    private static func statusText(_ metadata: UpdateMetadata, isReady: Bool) -> String {
+        if isReady { return "Ready to install" }
+        guard metadata.contentLength > 0 else { return "" }
+        return ByteCountFormatter.string(
+            fromByteCount: Int64(metadata.contentLength), countStyle: .file
+        )
+    }
+
+}
+
+/// Trims the embedded release notes to what a hover can honestly show.
+///
+/// The panel disappears when the pointer leaves it, so it is the wrong
+/// surface for a wall of text: it stops early and lets the "Full notes" link
+/// carry the rest.  The leading `#` title is dropped because the panel header
+/// above it already names the version it would repeat.
+enum UpdateNotesSummary {
+    static func summary(from markdown: String?) -> String {
+        guard let markdown else { return "" }
+        let maximumLines = 10
+        let maximumCharacters = 700
+        var kept: [String] = []
+        var characters = 0
+        var truncated = false
+        var seenContent = false
+        for line in markdown.components(separatedBy: .newlines) {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if !seenContent {
+                if trimmed.isEmpty { continue }
+                if trimmed.hasPrefix("# ") { seenContent = true; continue }
+                seenContent = true
+            }
+            if kept.count >= maximumLines || characters + trimmed.count > maximumCharacters {
+                truncated = !trimmed.isEmpty
+                break
+            }
+            kept.append(line)
+            characters += trimmed.count
+        }
+        while let last = kept.last, last.trimmingCharacters(in: .whitespaces).isEmpty {
+            kept.removeLast()
+        }
+        guard !kept.isEmpty else { return "" }
+        if truncated { kept.append("") ; kept.append("…") }
+        return kept.joined(separator: "\n")
+    }
+
+    /// Drops one content line, keeping (or adding) the trailing marker that
+    /// says the notes were cut.  `nil` once there is nothing left to drop.
+    static func droppingLastLine(_ text: String) -> String? {
+        var lines = text.components(separatedBy: "\n")
+        func dropTrailingNoise() {
+            while let last = lines.last {
+                let trimmed = last.trimmingCharacters(in: .whitespaces)
+                guard trimmed.isEmpty || trimmed == "…" else { return }
+                lines.removeLast()
+            }
+        }
+        dropTrailingNoise()
+        guard lines.count > 1 else { return nil }
+        lines.removeLast()
+        dropTrailingNoise()
+        guard !lines.isEmpty else { return nil }
+        return lines.joined(separator: "\n") + "\n\n…"
+    }
+}
+
+// MARK: - Footer link
+
+/// A plain text link.  Uses `acceptsFirstMouse` because the panel never
+/// becomes key: the first click on it must be the click that works.
+@MainActor
+private final class UpdateNotesLinkButton: NSButton {
+    private let url: URL
+
+    init(title: String, url: URL, sheet: StyleSheet) {
+        self.url = url
+        super.init(frame: .zero)
+        isBordered = false
+        setButtonType(.momentaryChange)
+        attributedTitle = NSAttributedString(
+            string: "\(title) ↗",
+            attributes: [
+                .font: PanelFont.secondary,
+                .foregroundColor: sheet.link,
+            ]
+        )
+        target = self
+        action = #selector(open)
+        setAccessibilityRole(.link)
+        toolTip = url.absoluteString
+    }
+
+    required init?(coder: NSCoder) { fatalError("not supported") }
+
+    override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
+
+    override func resetCursorRects() {
+        addCursorRect(bounds, cursor: .pointingHand)
+    }
+
+    @objc private func open() {
+        NSWorkspace.shared.open(url)
+        UpdateNotesPopover.dismissCurrent(animated: false)
+    }
+}

--- a/Sources/DownrightApp/Panels/UpdateStatusPill.swift
+++ b/Sources/DownrightApp/Panels/UpdateStatusPill.swift
@@ -7,8 +7,20 @@ import MarkdownRender
 ///
 /// It remains absent (zero width, hidden) when the coordinator is idle, and
 /// appears with a restrained fade/slide for the states the spec surfaces:
-/// "Update 1.1", a progress ring, "Restart to Update", and a warning/retry
+/// "Update Now", a progress ring, "Restart to Update", and a warning/retry
 /// badge.  All motion honors Reduce Motion.
+///
+/// The actionable pill *acts*: one press installs and relaunches, rather than
+/// opening a window to ask the question the label already answered.  What a
+/// press costs is therefore owed to the reader before they make it, which is
+/// what `UpdateNotesPopover` is for — resting on the pill unfurls the release
+/// notes without committing to anything.
+///
+/// One consequence governs the whole control: **the pill must never move or
+/// reshape under the pointer.**  It is a button that restarts the app, so the
+/// target cannot shift while it is being aimed at.  The hover notes are a
+/// separate window hanging below it, and the arrival emphasis is a colour
+/// pass with no geometry in it at all.
 @MainActor
 final class UpdateStatusPill: NSButton {
     enum Presentation {
@@ -47,6 +59,14 @@ final class UpdateStatusPill: NSButton {
     private var stateObserver: NSObjectProtocol?
     private var sheet: StyleSheet
     private var currentModel: UpdatePillModel?
+    /// A single accent pass when an update lands while the reader is here.
+    /// Separate from `feedbackLayer` so an emphasis in flight cannot be
+    /// cancelled by a hover, and a hover cannot inherit the emphasis colour.
+    private let emphasisLayer = CALayer()
+    private var hoverNotesWork: DispatchWorkItem?
+    /// Strong: the panel takes itself down on pointer-exit, so it has to
+    /// survive the method that opened it.
+    private var notesPopover: UpdateNotesPopover?
 
     override var intrinsicContentSize: NSSize {
         guard let currentModel, currentModel != UpdatePillModel.hidden else {
@@ -87,6 +107,10 @@ final class UpdateStatusPill: NSButton {
         feedbackLayer.cornerCurve = .continuous
         feedbackLayer.opacity = 0
         shell.layer?.addSublayer(feedbackLayer)
+        emphasisLayer.cornerRadius = Metrics.cornerRadius
+        emphasisLayer.cornerCurve = .continuous
+        emphasisLayer.opacity = 0
+        shell.layer?.addSublayer(emphasisLayer)
         addSubview(shell)
 
         iconView.translatesAutoresizingMaskIntoConstraints = false
@@ -120,9 +144,9 @@ final class UpdateStatusPill: NSButton {
         target = self
         action = #selector(clicked(_:))
         setAccessibilityRole(.button)
-        setAccessibilityHelp("Open the update panel")
+        setAccessibilityHelp("Downright update status")
         // Pointer users get the same sentence VoiceOver does.
-        toolTip = "Open the update panel"
+        toolTip = "Install the update and relaunch Downright"
 
         NSLayoutConstraint.activate([
             shell.leadingAnchor.constraint(equalTo: leadingAnchor),
@@ -177,7 +201,11 @@ final class UpdateStatusPill: NSButton {
     }
 
     @objc private func clicked(_ sender: Any?) {
-        UpdateCoordinator.shared.showPanel()
+        // The notes were the preview; the click is the decision. Take the
+        // panel down first so the app does not relaunch out from under a
+        // window still animating.
+        dismissNotesPopover(animated: false)
+        UpdateCoordinator.shared.userDidPressUpdateNow()
     }
 
     // MARK: - Pointer feedback
@@ -187,6 +215,7 @@ final class UpdateStatusPill: NSButton {
         CATransaction.begin()
         CATransaction.setDisableActions(true)
         feedbackLayer.frame = shell.bounds
+        emphasisLayer.frame = shell.bounds
         CATransaction.commit()
     }
 
@@ -195,8 +224,82 @@ final class UpdateStatusPill: NSButton {
         refreshTrackingArea(&trackingArea, options: [.mouseEnteredAndExited, .activeInActiveApp, .inVisibleRect])
     }
 
-    override func mouseEntered(with event: NSEvent) { interaction = .hover }
-    override func mouseExited(with event: NSEvent) { interaction = .idle }
+    override func mouseEntered(with event: NSEvent) {
+        interaction = .hover
+        scheduleNotesPopover()
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        interaction = .idle
+        // Only the *pending* presentation is cancelled here. A panel already
+        // on screen dismisses itself once the pointer has left the pill, the
+        // bridge, and its own body — that union is what makes it enterable.
+        hoverNotesWork?.cancel()
+        hoverNotesWork = nil
+    }
+
+    // MARK: - Hover notes
+
+    private func scheduleNotesPopover() {
+        hoverNotesWork?.cancel()
+        hoverNotesWork = nil
+        guard let currentModel, currentModel.offersInstall else { return }
+        guard UpdateCoordinator.shared.pendingUpdate != nil, window != nil else { return }
+        let work = DispatchWorkItem { [weak self] in
+            MainActor.assumeIsolated { self?.presentNotesPopover() }
+        }
+        hoverNotesWork = work
+        DispatchQueue.main.asyncAfter(
+            deadline: .now() + UpdateNotesPopover.hoverInDelay, execute: work
+        )
+    }
+
+    private func presentNotesPopover() {
+        hoverNotesWork = nil
+        guard interaction != .idle, let currentModel, currentModel.offersInstall else { return }
+        let isReady: Bool
+        if case .updateNow(_, let ready) = currentModel { isReady = ready } else { isReady = true }
+        notesPopover = UpdateNotesPopover.present(
+            from: self,
+            metadata: UpdateCoordinator.shared.pendingUpdate,
+            isReady: isReady,
+            sheet: sheet
+        )
+        guard let notesPopover else { return }
+        // The tooltip and the panel answer the same question, and the system
+        // would float the tooltip over the panel a second later. The panel is
+        // the better answer, so it takes the tooltip's place while it is up.
+        toolTip = nil
+        notesPopover.onDismiss = { [weak self] in
+            MainActor.assumeIsolated {
+                self?.notesPopover = nil
+                self?.refreshAppearance()
+            }
+        }
+    }
+
+    private func dismissNotesPopover(animated: Bool) {
+        hoverNotesWork?.cancel()
+        hoverNotesWork = nil
+        notesPopover?.dismiss(animated: animated)
+        notesPopover = nil
+    }
+
+    // MARK: - Arrival
+
+    /// One accent pass, once, when an update lands while the reader is
+    /// actually here.  A pill that was already offering an update when the
+    /// window opened has not just *arrived* and must not pretend it did.
+    private func playArrivalEmphasis() {
+        guard !sheet.reduceMotion else { return }
+        emphasisLayer.backgroundColor = sheet.accent.cgColor
+        let pulse = CAKeyframeAnimation(keyPath: "opacity")
+        pulse.values = [0, sheet.increaseContrast ? 0.5 : 0.34, 0]
+        pulse.keyTimes = [0, 0.34, 1]
+        pulse.duration = Motion.emphasis * 4
+        pulse.timingFunctions = [Motion.timing(.snap), Motion.timing(.easeOut)]
+        emphasisLayer.add(pulse, forKey: "update-arrival")
+    }
 
     override func mouseDown(with event: NSEvent) {
         interaction = .pressed
@@ -232,10 +335,21 @@ final class UpdateStatusPill: NSButton {
     private func refreshFromCoordinator() {
         let model = UpdateCoordinator.shared.pillModel
         let changed = model != currentModel
+        let wasVisible = currentModel != UpdatePillModel.hidden
         currentModel = model
         refreshAppearance()
         guard changed else { return }
         let visible = model != UpdatePillModel.hidden
+        if !(model?.offersInstall ?? false) { dismissNotesPopover(animated: true) }
+        // "Landed while you were sitting here" is the only case that earns
+        // emphasis. A pill built for a window that is opening now, or one
+        // whose app is in the background, has not interrupted anybody — and
+        // the window check is what tells those apart, because a pill built
+        // before it is in a window has no window to have interrupted.
+        if visible, !wasVisible, NSApp.isActive,
+           let window, window.isVisible, window.occlusionState.contains(.visible) {
+            playArrivalEmphasis()
+        }
         // Set in both branches: a hidden control that still reports the last
         // visible state is a stale answer for VoiceOver.
         setAccessibilityLabel(accessibilityLabel(for: model))
@@ -266,12 +380,22 @@ final class UpdateStatusPill: NSButton {
         guard let model = currentModel else { return }
         let contrast = sheet.increaseContrast
         switch model {
-        case .available(let version):
+        case .updateNow(let version, let isReady):
             iconView.image = NSImage(systemSymbolName: "arrow.down.circle.fill", accessibilityDescription: "Update available")
             iconView.contentTintColor = sheet.accent
-            label.textColor = sheet.textSecondary
-            label.stringValue = "Update \(version)"
+            // The button says what pressing it does; the version it installs
+            // is one hover away, and in the tooltip for pointer users who
+            // never rest long enough to see the notes.
+            label.textColor = sheet.text
+            label.stringValue = "Update Now"
             label.isHidden = false
+            toolTip = if version.isEmpty {
+                "Install the update and relaunch Downright"
+            } else if isReady {
+                "Install Downright \(version) and relaunch"
+            } else {
+                "Download and install Downright \(version), then relaunch"
+            }
             progressIndicator.stopAnimation(nil)
             progressIndicator.isHidden = true
             iconView.isHidden = false
@@ -286,6 +410,7 @@ final class UpdateStatusPill: NSButton {
             label.textColor = sheet.text
             label.stringValue = "Restart to Update"
             label.isHidden = false
+            toolTip = "Quit and reopen Downright to finish installing"
             progressIndicator.stopAnimation(nil)
             progressIndicator.isHidden = true
             iconView.isHidden = false
@@ -298,6 +423,7 @@ final class UpdateStatusPill: NSButton {
             label.textColor = sheet.textSecondary
             label.stringValue = title
             label.isHidden = false
+            toolTip = "Show update progress"
             iconView.isHidden = true
             progressIndicator.isHidden = false
             if let fraction {
@@ -341,6 +467,7 @@ final class UpdateStatusPill: NSButton {
 
         case .informational(let version):
             iconView.image = NSImage(systemSymbolName: "info.circle.fill", accessibilityDescription: "Update information")
+            toolTip = "Read about Downright \(version)"
             iconView.contentTintColor = sheet.accent
             label.textColor = sheet.textSecondary
             label.stringValue = "Update \(version)"
@@ -358,7 +485,11 @@ final class UpdateStatusPill: NSButton {
 
     private func accessibilityLabel(for model: UpdatePillModel?) -> String {
         switch model {
-        case .available(let version): return "Update \(version) available"
+        case .updateNow(let version, let isReady):
+            if version.isEmpty { return "Update Now" }
+            return isReady
+                ? "Update Now. Downright \(version) is ready to install"
+                : "Update Now. Downright \(version) is available"
         case .restartToUpdate: return "Update ready. Restart Downright to update"
         case .progress(let title, _): return title
         case .warning: return "Update failed. Open the update panel for details"

--- a/Sources/DownrightApp/Panels/UpdateWindowController.swift
+++ b/Sources/DownrightApp/Panels/UpdateWindowController.swift
@@ -494,7 +494,7 @@ private final class UpdatePanelContent {
 // MARK: - Notes view (release notes through the real renderer)
 
 @MainActor
-private final class UpdateNotesView: NSView {
+final class UpdateNotesView: NSView {
     init(coordinator: UpdateCoordinator, sheet: StyleSheet) {
         super.init(frame: .zero)
 

--- a/Sources/DownrightApp/Panels/VisualDebuggerView.swift
+++ b/Sources/DownrightApp/Panels/VisualDebuggerView.swift
@@ -115,6 +115,10 @@ final class VisualDebuggerView: NSView, PanelSurface {
         copySummary(copyButton)
     }
 
+    /// Where copies land.  Tests inject a named pasteboard so exercising the
+    /// copy path never clobbers the user's real clipboard.
+    var pasteboardForTesting: NSPasteboard = .general
+
     func summaryTextForTesting() -> String { summaryView.string }
 
     override var acceptsFirstResponder: Bool { true }
@@ -132,8 +136,9 @@ final class VisualDebuggerView: NSView, PanelSurface {
     }
 
     @objc private func copySummary(_ sender: Any?) {
-        NSPasteboard.general.clearContents()
-        NSPasteboard.general.setString(model.summary, forType: .string)
+        let pasteboard = pasteboardForTesting
+        pasteboard.clearContents()
+        pasteboard.setString(model.summary, forType: .string)
         delegate?.visualDebugger(self, didCopy: model.summary)
     }
 

--- a/Sources/DownrightApp/Security/DocumentTrust.swift
+++ b/Sources/DownrightApp/Security/DocumentTrust.swift
@@ -71,11 +71,19 @@ struct TrustGrant: Codable, Hashable, Sendable {
     let scope: TrustScope
     let canonicalPath: String
     let effects: Set<TrustEffect>
+    /// For external effects (links, remote assets, automation) the grant is
+    /// pinned to the exact URL the user approved — never to "any URL of this
+    /// effect inside the folder".  `nil` for purely local effects.  Optional
+    /// so grants persisted before this field existed still decode; policy
+    /// treats legacy external-effect grants as unmatched (fail closed), and
+    /// the next prompt re-records them with their URL.
+    let externalURL: String?
 
-    init(scope: TrustScope, canonicalPath: String, effects: Set<TrustEffect>) {
+    init(scope: TrustScope, canonicalPath: String, effects: Set<TrustEffect>, externalURL: String? = nil) {
         self.scope = scope
         self.canonicalPath = canonicalPath
         self.effects = effects
+        self.externalURL = externalURL
     }
 }
 
@@ -95,6 +103,12 @@ struct DocumentTrust: Sendable {
         let target = URL(fileURLWithPath: scopePath)
         let matching = grants.contains { grant in
             guard grant.effects.contains(request.effect) else { return false }
+            // An external grant answers only for the exact URL that was
+            // approved.  Matching "any external effect inside this folder"
+            // would let one approval of, say, a vscode:// link silently
+            // authorize a later shortcuts:// automation URL in any document
+            // under the same root.
+            guard request.target.externalURL == grant.externalURL else { return false }
             let root = URL(fileURLWithPath: grant.canonicalPath)
             switch grant.scope {
             case .file:

--- a/Sources/DownrightApp/Security/TrustStore.swift
+++ b/Sources/DownrightApp/Security/TrustStore.swift
@@ -74,21 +74,28 @@ final class TrustStore {
     }
 
     @discardableResult
-    func grant(scope: TrustScope, path: URL, effects: Set<TrustEffect>) -> Bool {
+    func grant(scope: TrustScope, path: URL, effects: Set<TrustEffect>, externalURL: String? = nil) -> Bool {
         guard let canonical = DocumentTrust.canonicalFilePath(path) else { return false }
         lock.lock()
         defer { lock.unlock() }
         guard !loadFailed else { return false }
         let previous = values
-        let existing = values.first { $0.scope == scope && $0.canonicalPath == canonical.path }
-        values.removeAll { $0.scope == scope && $0.canonicalPath == canonical.path }
+        // External grants are keyed by their approved URL as well, so two
+        // different links at the same path never collapse into one grant.
+        let existing = values.first {
+            $0.scope == scope && $0.canonicalPath == canonical.path && $0.externalURL == externalURL
+        }
+        values.removeAll {
+            $0.scope == scope && $0.canonicalPath == canonical.path && $0.externalURL == externalURL
+        }
         // A new grant extends the effects already allowed for this path rather
         // than replacing them: granting editor-launch after a folder-read must
         // not silently revoke the read the user consented to earlier.
         values.append(TrustGrant(
             scope: scope,
             canonicalPath: canonical.path,
-            effects: effects.union(existing?.effects ?? [])
+            effects: effects.union(existing?.effects ?? []),
+            externalURL: externalURL
         ))
         // Keep mutation and persistence ordered. Unlocking before the save
         // lets concurrent callers write snapshots in reverse order, leaving

--- a/Sources/DownrightApp/Support/Commands.swift
+++ b/Sources/DownrightApp/Support/Commands.swift
@@ -49,8 +49,18 @@ enum Command: String, CaseIterable, Codable {
 
     // Files and export (§9.5)
     case newDocument, open, save, saveAs, revealInFinder, openInEditor, close
+    /// Previews the file the caret is on — a path token, or a link to a local
+    /// file — in the system Quick Look panel, the same affordance Space gives
+    /// in Finder.  Embedded images take the app's own lightbox instead.
+    case quickLook
     case copyAsMarkdown, copyAsRichText, copyAsPlainText, copySection, copySectionLink
     case printDocument, exportHTML, exportPDF, exportSelectionAsImage
+    /// Hands the document to the system share sheet — Mail, Messages, AirDrop,
+    /// Notes.  Two commands rather than one submenu because a share sheet is
+    /// built around the items it was given: the reader chooses the
+    /// representation first and the destination second, and there is no way to
+    /// change the first once the sheet is up.
+    case share, shareAsPDF
     case increaseTextSize, decreaseTextSize, resetTextSize
     case speakDocument, stopSpeaking
 
@@ -149,6 +159,7 @@ enum Command: String, CaseIterable, Codable {
         case .open: return "Open…"
         case .save: return "Save"
         case .saveAs: return "Save As…"
+        case .quickLook: return "Quick Look"
         case .revealInFinder: return "Reveal in Finder"
         case .openInEditor: return "Open in Editor"
         case .close: return "Close"
@@ -161,6 +172,8 @@ enum Command: String, CaseIterable, Codable {
         case .exportHTML: return "Export HTML…"
         case .exportPDF: return "Export PDF…"
         case .exportSelectionAsImage: return "Export Selection as Image…"
+        case .share: return "Share…"
+        case .shareAsPDF: return "Share as PDF…"
         case .increaseTextSize: return "Bigger Text"
         case .decreaseTextSize: return "Smaller Text"
         case .resetTextSize: return "Actual Size"
@@ -194,7 +207,7 @@ enum Command: String, CaseIterable, Codable {
         switch self {
         case .newDocument, .open, .save, .saveAs, .close, .revealInFinder, .openInEditor,
              .printDocument, .exportHTML, .exportPDF, .exportSelectionAsImage, .compareFiles,
-             .versionTimeline:
+             .versionTimeline, .share, .shareAsPDF, .quickLook:
             return .file
         case .copyAsMarkdown, .copyAsRichText, .copyAsPlainText, .copySection, .copySectionLink,
              .find, .findNext, .findPrevious, .findReplace, .findInSiblings, .useSelectionForFind,
@@ -273,6 +286,20 @@ enum Command: String, CaseIterable, Codable {
             return .documentWithFile
         case .useSelectionForFind, .exportSelectionAsImage:
             return .selection
+        case .quickLook:
+            // Not `.selection`: the caret sitting *on* a link is enough, and
+            // requiring a highlighted range would disable the command in the
+            // state it is most often wanted from.
+            return .quickLookTarget
+        case .share, .shareAsPDF:
+            // Deliberately `.document`, not `.documentWithFile`.  A never-saved
+            // buffer still holds something worth sending, and disabling Share
+            // for it would be the one state where the reader most wants it —
+            // notes typed into an Untitled window they have not filed yet.
+            // `DocumentShareSource` covers the gap by writing what is on screen
+            // to a real `.md` before the sheet opens, so AirDrop always carries
+            // a file the receiver can open rather than a nameless text blob.
+            return .document
         case .nextChange, .previousChange, .markChangesReviewed:
             return .changeMarks
         default:
@@ -313,6 +340,8 @@ enum CommandPrecondition: String, CaseIterable {
     case tableAtCaret
     /// Needs at least one live change mark to walk or to retire.
     case changeMarks
+    /// Needs the caret to be on something with a file behind it.
+    case quickLookTarget
 
     func isSatisfied(in context: CommandContext) -> Bool {
         switch self {
@@ -329,6 +358,7 @@ enum CommandPrecondition: String, CaseIterable {
         case .forwardHistory: return context.hasDocument && context.canGoForward
         case .speaking: return context.hasDocument && context.isSpeaking
         case .tableAtCaret: return context.hasDocument && context.caretIsInTable
+        case .quickLookTarget: return context.hasDocument && context.hasQuickLookTarget
         }
     }
 }
@@ -348,6 +378,8 @@ struct CommandContext: Equatable {
     var caretIsInTable: Bool
     /// At least one unexpired change mark is on the page.
     var hasChangeMarks: Bool
+    /// The caret or selection is on a link, path token, or image.
+    var hasQuickLookTarget: Bool
 
     init(
         hasDocument: Bool = false,
@@ -360,7 +392,8 @@ struct CommandContext: Equatable {
         canGoForward: Bool = false,
         isSpeaking: Bool = false,
         caretIsInTable: Bool = false,
-        hasChangeMarks: Bool = false
+        hasChangeMarks: Bool = false,
+        hasQuickLookTarget: Bool = false
     ) {
         self.hasDocument = hasDocument
         self.documentHasFile = documentHasFile
@@ -373,6 +406,7 @@ struct CommandContext: Equatable {
         self.isSpeaking = isSpeaking
         self.caretIsInTable = caretIsInTable
         self.hasChangeMarks = hasChangeMarks
+        self.hasQuickLookTarget = hasQuickLookTarget
     }
 
     /// No document anywhere — what the app menu sees while only the start

--- a/Sources/DownrightApp/Support/Keybindings.swift
+++ b/Sources/DownrightApp/Support/Keybindings.swift
@@ -42,6 +42,13 @@ enum KeybindingDefaults {
         .copySection:         [KeyBinding("c", [.command, .option])],
         .printDocument:       [KeyBinding("p", .command)],
         .exportHTML:          [KeyBinding("e", [.command, .control])],
+        // Share joins Export HTML's ⌃⌘ family — "the same document, sent
+        // somewhere else".  macOS defines no system chord for Share, and ⌘S /
+        // ⇧⌘S are already Save and Save As, so ⌃⌘S is the chord that reads as
+        // a sibling of both without shadowing either.  Share as PDF stays
+        // unbound: it is the rarer half, and spending a fourth modifier on it
+        // would buy a chord nobody can remember.
+        .share:               [KeyBinding("s", [.command, .control])],
 
         // Panels share one ⌥⌘-number family, the way a navigator normally does.
         .documentLens:        [KeyBinding("2", [.command, .option, .shift])],
@@ -76,6 +83,16 @@ enum KeybindingDefaults {
         .save:                [KeyBinding("s", .command)],
         .saveAs:              [KeyBinding("s", [.command, .shift])],
         .close:               [KeyBinding("w", .command)],
+        // ⌘Y is Quick Look everywhere else on the system — Finder, Mail,
+        // Photos — and nothing in Downright had claimed it.  Deliberately a
+        // chord and not the bare Space that Finder also accepts: the document
+        // surface is editable in both of the modes a reader can reach
+        // (`RenderMode.userFacingModes`), so a bare-Space binding in this table
+        // would be a key that types a space today and stops typing one the
+        // first time some future change makes a surface read-only.  Space is
+        // still honoured, but by `MarkdownTextView`, gated on the one fact that
+        // settles it — `isEditable` — read microseconds before the decision.
+        .quickLook:           [KeyBinding("y", .command)],
         .toggleBold:          [KeyBinding("b", .command)],
         .toggleItalic:        [KeyBinding("i", .command)],
         .insertLink:          [KeyBinding("k", [.command, .option])],

--- a/Sources/DownrightApp/Support/Keybindings.swift
+++ b/Sources/DownrightApp/Support/Keybindings.swift
@@ -8,7 +8,7 @@ import AppKit
 /// §7.2 can spend the bare letter keys at all.
 ///
 /// Chords are chosen so nothing shadows a macOS convention: ⌘0 is Actual Size,
-/// ⌘⇧P is Page Setup, ⌥⇧⌘V is Paste and Match Style, ⌃⌘F is Enter Full Screen,
+/// ⌘⇧P is Page Setup, ⌘⇧V is Paste and Match Style, ⌃⌘F is Enter Full Screen,
 /// and ⌘T / ⌘⇧T stay free for the tab chords users reach for reflexively.
 enum KeybindingDefaults {
     /// A command may carry more than one binding: `↓` and `j` both scroll.

--- a/Sources/DownrightApp/Updater/ReleaseWatch.swift
+++ b/Sources/DownrightApp/Updater/ReleaseWatch.swift
@@ -277,29 +277,41 @@ final class ReleaseFeedURLProbe: ReleaseFeedProbe {
 
     private let session: URLSession
 
-    init() {
+    /// `session` is a test seam: production uses the locked-down ephemeral
+    /// configuration; tests inject one backed by a stub URLProtocol.
+    init(session: URLSession = URLSession(configuration: ReleaseFeedURLProbe.makeConfiguration())) {
+        self.session = session
+    }
+
+    nonisolated private static func makeConfiguration() -> URLSessionConfiguration {
         let configuration = URLSessionConfiguration.ephemeral
         configuration.httpCookieAcceptPolicy = .never
         configuration.httpShouldSetCookies = false
         configuration.urlCache = nil
-        // The ETag is the cache; a URL cache on top of it only adds a second
-        // staleness policy that can hold a fresh feed back.
+        // The validators below are the cache; a URL cache on top of them only
+        // adds a second staleness policy that can hold a fresh feed back.
         configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
         configuration.timeoutIntervalForRequest = 15
         configuration.waitsForConnectivity = false
-        session = URLSession(configuration: configuration)
+        return configuration
     }
 
     func probe(feed: URL, validator: String?) async -> ReleaseFeedProbeResult {
         var request = URLRequest(url: feed)
         request.httpMethod = "GET"
         request.cachePolicy = .reloadIgnoringLocalCacheData
-        // An ETag round-trips verbatim. A body hash is ours, not the server's,
-        // so it must never be offered as one.
+        // An ETag round-trips verbatim, and so does a stored document date.
+        // A body hash is ours, not the server's, so it must never be offered
+        // as either.
         if let validator, validator.hasPrefix(Self.etagPrefix) {
             request.setValue(
                 String(validator.dropFirst(Self.etagPrefix.count)),
                 forHTTPHeaderField: "If-None-Match"
+            )
+        } else if let validator, validator.hasPrefix(Self.lastModifiedPrefix) {
+            request.setValue(
+                String(validator.dropFirst(Self.lastModifiedPrefix.count)),
+                forHTTPHeaderField: "If-Modified-Since"
             )
         }
         guard let (data, response) = try? await session.data(for: request),
@@ -316,12 +328,19 @@ final class ReleaseFeedURLProbe: ReleaseFeedProbe {
     }
 
     private static let etagPrefix = "etag:"
+    private static let lastModifiedPrefix = "lastModified:"
 
-    /// Prefer the server's own validator; fall back to hashing the body, which
-    /// keeps the watch working on a host that serves no `ETag` at all.
+    /// Prefer the server's own validator; fall back to the document date,
+    /// which keeps conditional requests working on a host that serves no
+    /// `ETag`; fall back further to hashing the body, which keeps the watch
+    /// working on a host that serves neither.
     private static func validator(for response: HTTPURLResponse, body: Data) -> String {
         if let etag = response.value(forHTTPHeaderField: "ETag"), !etag.isEmpty {
             return etagPrefix + etag
+        }
+        if let lastModified = response.value(forHTTPHeaderField: "Last-Modified"),
+           !lastModified.isEmpty {
+            return lastModifiedPrefix + lastModified
         }
         let digest = SHA256.hash(data: body)
         return "sha256:" + digest.map { String(format: "%02x", $0) }.joined()

--- a/Sources/DownrightApp/Updater/ReleaseWatch.swift
+++ b/Sources/DownrightApp/Updater/ReleaseWatch.swift
@@ -1,0 +1,329 @@
+import AppKit
+import CryptoKit
+import Foundation
+import Network
+
+/// What one conditional probe of the appcast learned.
+enum ReleaseFeedProbeResult: Equatable {
+    /// Byte-identical to the last feed this session saw.
+    case unchanged
+    /// The feed moved.  `validator` is the token to send back next time.
+    case changed(validator: String?)
+    /// The probe could not complete.  Never surfaced: a laptop opened without
+    /// wifi is not an update failure, and `UpdateCoordinator` already refuses
+    /// to raise that alarm for background cycles.
+    case unreachable
+}
+
+/// One conditional GET.  A protocol so the watch's whole schedule can be
+/// tested without a network, a server, or a wall clock.
+@MainActor
+protocol ReleaseFeedProbe: AnyObject {
+    func probe(feed: URL, validator: String?) async -> ReleaseFeedProbeResult
+}
+
+// MARK: - Policy
+
+/// When the watch may probe, and how often.
+///
+/// Pure policy, deliberately kept apart from the timer that obeys it: every
+/// rule here is then a value comparison in a test rather than a wait.
+struct ReleaseWatchPolicy: Equatable {
+    /// Frontmost and in use.  A build that lands while the reader is sitting
+    /// here should be offered while they are still sitting here.
+    static let activeInterval: TimeInterval = 90
+    /// Running, but the reader is in another app.  Still worth knowing before
+    /// they come back; not worth waking the radio on their behalf.
+    static let backgroundInterval: TimeInterval = 15 * 60
+    /// The floor between two probes, however many events coincide.  Wake fires
+    /// activate as well, and a held Cmd-Tab flaps activation several times a
+    /// second; without a floor each of those becomes its own request.
+    static let minimumSpacing: TimeInterval = 20
+
+    var isAppActive = false
+    var isLowPower = false
+    var hasNetwork = true
+
+    /// `nil` means "do not probe at all right now".
+    var interval: TimeInterval? {
+        guard hasNetwork else { return nil }
+        // Low Power Mode is an explicit request to stop doing optional work.
+        // Polling for a build the reader has not asked for is exactly that, so
+        // the background cadence stops entirely and the foreground one drops
+        // to it — Sparkle's own hourly schedule still covers the app.
+        if isLowPower { return isAppActive ? Self.backgroundInterval : nil }
+        return isAppActive ? Self.activeInterval : Self.backgroundInterval
+    }
+}
+
+// MARK: - Watch
+
+/// Notices that the appcast moved, so a build published while the app is open
+/// is offered in about a minute instead of on Sparkle's next scheduled check.
+///
+/// The important line, and the reason this can be as cheap as it is: **the
+/// watch is a trigger, not a trust path.**  It learns exactly one bit — the
+/// feed is not the one we last saw — and hands that to Sparkle.  It never
+/// parses the appcast, never compares versions, never reads an enclosure URL,
+/// and cannot cause an install.  Every signature check, ordering decision, and
+/// download stays inside Sparkle, so shortening the *latency* of an update
+/// leaves the *security model* of one untouched.
+@MainActor
+final class ReleaseWatch {
+    /// Why a probe is happening.  Only `.scheduled` is exempt from the spacing
+    /// floor, because the schedule already spaces itself.
+    private enum ProbeReason {
+        case scheduled
+        case event
+    }
+
+    /// Called when the feed has moved since the baseline.  Never called for
+    /// the probe that establishes the baseline.
+    var onFeedChanged: (() -> Void)?
+
+    /// Test seam: how many probes have completed, and what the last one said.
+    private(set) var completedProbeCount = 0
+    private(set) var lastResult: ReleaseFeedProbeResult?
+    private(set) var hasBaseline = false
+
+    private let feed: URL
+    private let prober: any ReleaseFeedProbe
+    private(set) var policy = ReleaseWatchPolicy()
+
+    private var isRunning = false
+    private var isProbing = false
+    private var validator: String?
+    private var lastProbeDate: Date?
+    private var pending: DispatchWorkItem?
+    /// Tokens are paired with the centre that issued them: the wake
+    /// notification comes from the workspace centre, and handing its token to
+    /// the default centre to remove is a silent no-op that leaks the observer.
+    private var observers: [(NotificationCenter, NSObjectProtocol)] = []
+    private var pathMonitor: NWPathMonitor?
+
+    init(feed: URL, prober: (any ReleaseFeedProbe)? = nil) {
+        self.feed = feed
+        self.prober = prober ?? ReleaseFeedURLProbe()
+    }
+
+    deinit {
+        pending?.cancel()
+        pathMonitor?.cancel()
+        for (center, observer) in observers { center.removeObserver(observer) }
+    }
+
+    // MARK: Lifecycle
+
+    /// Begins watching.  Safe to call twice; the second call is a no-op.
+    func start(observingSystemEvents: Bool = true) {
+        guard !isRunning else { return }
+        isRunning = true
+        policy.isAppActive = NSApp?.isActive ?? false
+        policy.isLowPower = ProcessInfo.processInfo.isLowPowerModeEnabled
+        if observingSystemEvents { observeSystemEvents() }
+        // The first probe establishes the baseline rather than firing, so it
+        // can go out immediately without racing Sparkle's post-launch check.
+        probe(reason: .event)
+    }
+
+    func stop() {
+        isRunning = false
+        pending?.cancel()
+        pending = nil
+        pathMonitor?.cancel()
+        pathMonitor = nil
+        for (center, observer) in observers { center.removeObserver(observer) }
+        observers = []
+    }
+
+    // MARK: Inputs (also the test seam — every one of these is callable directly)
+
+    func applicationDidChangeActivation(isActive: Bool) {
+        guard policy.isAppActive != isActive else { return }
+        policy.isAppActive = isActive
+        // Coming back to the app is the moment a pending build matters most;
+        // leaving it only changes the cadence.
+        if isActive { probe(reason: .event) } else { scheduleNext() }
+    }
+
+    func systemDidWake() {
+        // The feed almost certainly moved across a closed lid, and the
+        // schedule that would have caught it did not fire while asleep.
+        probe(reason: .event)
+    }
+
+    func powerStateDidChange(isLowPower: Bool) {
+        guard policy.isLowPower != isLowPower else { return }
+        policy.isLowPower = isLowPower
+        scheduleNext()
+    }
+
+    func networkAvailabilityDidChange(hasNetwork: Bool) {
+        guard policy.hasNetwork != hasNetwork else { return }
+        policy.hasNetwork = hasNetwork
+        if hasNetwork { probe(reason: .event) } else { scheduleNext() }
+    }
+
+    /// Ignores the spacing floor.  Only for tests and the debug feed override.
+    func probeNow() {
+        lastProbeDate = nil
+        probe(reason: .event)
+    }
+
+    // MARK: Scheduling
+
+    private func scheduleNext() {
+        pending?.cancel()
+        pending = nil
+        guard isRunning, let interval = policy.interval else { return }
+        let work = DispatchWorkItem { [weak self] in
+            MainActor.assumeIsolated { self?.probe(reason: .scheduled) }
+        }
+        pending = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + interval, execute: work)
+    }
+
+    private func probe(reason: ProbeReason) {
+        guard isRunning, policy.interval != nil, !isProbing else { return }
+        if reason == .event, let last = lastProbeDate,
+           Date().timeIntervalSince(last) < ReleaseWatchPolicy.minimumSpacing {
+            // Too soon.  Fall back to the schedule rather than dropping the
+            // event entirely, or a burst of activations can leave no timer.
+            if pending == nil { scheduleNext() }
+            return
+        }
+        isProbing = true
+        lastProbeDate = Date()
+        pending?.cancel()
+        pending = nil
+        let feed = self.feed
+        let validator = self.validator
+        let prober = self.prober
+        Task { @MainActor [weak self] in
+            let result = await prober.probe(feed: feed, validator: validator)
+            self?.probeDidFinish(result)
+        }
+    }
+
+    private func probeDidFinish(_ result: ReleaseFeedProbeResult) {
+        isProbing = false
+        completedProbeCount += 1
+        lastResult = result
+        if case .changed(let newValidator) = result {
+            validator = newValidator
+            if hasBaseline {
+                onFeedChanged?()
+            } else {
+                // Sparkle's own post-launch check already answers "was an
+                // update waiting when you opened the app". Firing here as well
+                // would ask the same feed the same question twice.
+                hasBaseline = true
+            }
+        }
+        scheduleNext()
+    }
+
+    // MARK: System events
+
+    private func observeSystemEvents() {
+        let center = NotificationCenter.default
+        observers.append((center, center.addObserver(
+            forName: NSApplication.didBecomeActiveNotification, object: nil, queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated { self?.applicationDidChangeActivation(isActive: true) }
+        }))
+        observers.append((center, center.addObserver(
+            forName: NSApplication.didResignActiveNotification, object: nil, queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated { self?.applicationDidChangeActivation(isActive: false) }
+        }))
+        observers.append((center, center.addObserver(
+            forName: Notification.Name.NSProcessInfoPowerStateDidChange, object: nil, queue: .main
+        ) { [weak self] _ in
+            let low = ProcessInfo.processInfo.isLowPowerModeEnabled
+            MainActor.assumeIsolated { self?.powerStateDidChange(isLowPower: low) }
+        }))
+        let workspace = NSWorkspace.shared.notificationCenter
+        observers.append((workspace, workspace.addObserver(
+            forName: NSWorkspace.didWakeNotification, object: nil, queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated { self?.systemDidWake() }
+        }))
+
+        let monitor = NWPathMonitor()
+        monitor.pathUpdateHandler = { [weak self] path in
+            let satisfied = path.status == .satisfied
+            Task { @MainActor [weak self] in
+                self?.networkAvailabilityDidChange(hasNetwork: satisfied)
+            }
+        }
+        monitor.start(queue: .main)
+        pathMonitor = monitor
+    }
+}
+
+// MARK: - Production probe
+
+/// One conditional GET against the appcast, and nothing else.
+///
+/// Deliberately the smallest request that can answer the question: no
+/// cookies, no credentials, no cache of its own, no identifiers, and an
+/// unchanged feed answers `304` with an empty body.  It reads the feed only
+/// far enough to know *that* it moved — never what it says.
+final class ReleaseFeedURLProbe: ReleaseFeedProbe {
+    /// A feed larger than this is not one this app publishes; refuse to hash
+    /// an unbounded body just to learn one bit.
+    private static let maximumBodyBytes = 4 * 1024 * 1024
+
+    private let session: URLSession
+
+    init() {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.httpCookieAcceptPolicy = .never
+        configuration.httpShouldSetCookies = false
+        configuration.urlCache = nil
+        // The ETag is the cache; a URL cache on top of it only adds a second
+        // staleness policy that can hold a fresh feed back.
+        configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
+        configuration.timeoutIntervalForRequest = 15
+        configuration.waitsForConnectivity = false
+        session = URLSession(configuration: configuration)
+    }
+
+    func probe(feed: URL, validator: String?) async -> ReleaseFeedProbeResult {
+        var request = URLRequest(url: feed)
+        request.httpMethod = "GET"
+        request.cachePolicy = .reloadIgnoringLocalCacheData
+        // An ETag round-trips verbatim. A body hash is ours, not the server's,
+        // so it must never be offered as one.
+        if let validator, validator.hasPrefix(Self.etagPrefix) {
+            request.setValue(
+                String(validator.dropFirst(Self.etagPrefix.count)),
+                forHTTPHeaderField: "If-None-Match"
+            )
+        }
+        guard let (data, response) = try? await session.data(for: request),
+              let http = response as? HTTPURLResponse
+        else {
+            return .unreachable
+        }
+        if http.statusCode == 304 { return .unchanged }
+        guard (200..<300).contains(http.statusCode) else { return .unreachable }
+        guard data.count <= Self.maximumBodyBytes else { return .unreachable }
+
+        let fresh = Self.validator(for: http, body: data)
+        return fresh == validator ? .unchanged : .changed(validator: fresh)
+    }
+
+    private static let etagPrefix = "etag:"
+
+    /// Prefer the server's own validator; fall back to hashing the body, which
+    /// keeps the watch working on a host that serves no `ETag` at all.
+    private static func validator(for response: HTTPURLResponse, body: Data) -> String {
+        if let etag = response.value(forHTTPHeaderField: "ETag"), !etag.isEmpty {
+            return etagPrefix + etag
+        }
+        let digest = SHA256.hash(data: body)
+        return "sha256:" + digest.map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/Sources/DownrightApp/Updater/UpdateCoordinator.swift
+++ b/Sources/DownrightApp/Updater/UpdateCoordinator.swift
@@ -39,9 +39,19 @@ enum UpdateConfiguration {
 
 /// What the update status pill displays right now.
 enum UpdatePillModel: Equatable {
-    /// "Update 1.1" — an update is available for the user to act on.
-    case available(String)
-    /// "Restart to Update" — downloaded (or ready) and will install on quit.
+    /// "Update Now" — one press installs.  `version` is the build on offer
+    /// (carried in the tooltip, the accessibility label, and the hover notes
+    /// rather than on the button, which says what pressing it *does*).
+    ///
+    /// `isReady` distinguishes an update already downloaded in the background
+    /// — the usual case, because `SUAutomaticallyUpdate` is on, and the press
+    /// is then effectively instant — from one that must be fetched first.  The
+    /// label is the same either way: the difference is how long the press
+    /// takes, not what it means.
+    case updateNow(version: String, isReady: Bool)
+    /// "Restart to Update" — installation has already begun and only a quit
+    /// can finish it.  Distinct from `.updateNow` because pressing here
+    /// retries termination; there is nothing left to install.
     case restartToUpdate
     /// Progress state: label plus an optional 0–1 fraction.
     case progress(String, Double?)
@@ -52,6 +62,15 @@ enum UpdatePillModel: Equatable {
 
     /// Hidden when idle, up to date, or mid-silent-check.
     static let hidden: UpdatePillModel? = nil
+
+    /// Whether pressing this pill starts an install (as opposed to opening a
+    /// window).  The hover notes only appear over a pill that can act.
+    var offersInstall: Bool {
+        switch self {
+        case .updateNow, .restartToUpdate: return true
+        case .progress, .warning, .informational: return false
+        }
+    }
 }
 
 /// The single owner of the updater: `SPUUpdater` lifecycle, the user driver,
@@ -86,6 +105,25 @@ final class UpdateCoordinator: UpdateDriverHost {
     /// that background flows never open the panel while user flows always do.
     private(set) var panelShowCount = 0
 
+    /// Set while a press of "Update Now" is being carried out through a fresh
+    /// Sparkle cycle.  The press already *is* the decision, so the cycle it
+    /// starts must not stop to ask the same question in a window: every prompt
+    /// Sparkle raises while this is set is answered `.install` immediately.
+    /// A failure clears it and does open the panel — a press that could not be
+    /// honoured owes the reader an explanation.
+    private(set) var isExpeditedInstall = false
+
+    /// Test seam: how often the release watch asked Sparkle to look.
+    private(set) var releaseWatchTriggerCount = 0
+
+    /// The update this cycle is about, kept past the phases that stop carrying
+    /// it themselves.  `.downloading`, `.extracting`, and `.readyToRelaunch`
+    /// have no metadata in them, and without this the pill's tooltip, its
+    /// accessibility label, and the hover notes all go blank halfway through
+    /// an install — naming a version at the start and not at the end reads as
+    /// the app having lost track of what it is installing.
+    private(set) var currentCycleUpdate: UpdateMetadata?
+
     var phase: UpdateStateMachine.UpdatePhase { machine.phase }
 
     var isRunning: Bool { engine?.isRunning ?? false }
@@ -97,6 +135,15 @@ final class UpdateCoordinator: UpdateDriverHost {
         set {
             guard let engine else { return }
             engine.automaticallyChecksForUpdates = newValue
+            // The watch is a second automatic check, so it answers to the same
+            // switch. A setting that stopped Sparkle's schedule and left this
+            // one polling would be a narrower promise than the one it makes.
+            if newValue {
+                startReleaseWatch()
+            } else {
+                releaseWatch?.stop()
+                releaseWatch = nil
+            }
             notifyStateChanged()
         }
     }
@@ -129,6 +176,7 @@ final class UpdateCoordinator: UpdateDriverHost {
     private var driver: DownrightUpdateDriver?
     private var panel: UpdateWindowController?
     private var startupFailure: UpdateFailure?
+    private var releaseWatch: ReleaseWatch?
 
     /// Whether this bundle carries the production Sparkle configuration.
     /// Dev/ad-hoc bundles omit `SUFeedURL` (and the whole Sparkle block) from
@@ -187,6 +235,7 @@ final class UpdateCoordinator: UpdateDriverHost {
             try engine.start()
             if startupFailure != nil { machine.reduce(.dismissed) }
             startupFailure = nil
+            startReleaseWatch()
             // MainMenu is built before Sparkle starts. Revalidate its command
             // now that the live updater can answer capability checks; without
             // this notification the menu can remain inert for the whole launch.
@@ -209,14 +258,51 @@ final class UpdateCoordinator: UpdateDriverHost {
     func tearDownForTesting() {
         discardAllCapabilities()
         engine?.onBackgroundDownloadCompleted = nil
+        releaseWatch?.stop()
+        releaseWatch = nil
         machine = UpdateStateMachine()
         downloadedUpdate = nil
+        currentCycleUpdate = nil
         panel = nil
         engine = nil
         driver = nil
         startupFailure = nil
+        isExpeditedInstall = false
         releaseNotes = .none
         notifyStateChanged()
+    }
+
+    // MARK: - Release watch
+
+    /// Starts watching the appcast so a build published while the app is open
+    /// reaches the pill in about a minute rather than on the next scheduled
+    /// check.  Only production bundles get here: `start()` has already refused
+    /// to build an engine for a bundle without the Sparkle configuration.
+    private func startReleaseWatch() {
+        guard releaseWatch == nil else { return }
+        guard engine?.automaticallyChecksForUpdates == true else { return }
+        guard let feedString = Bundle.main.infoDictionary?["SUFeedURL"] as? String,
+              let feed = URL(string: feedString)
+        else {
+            return
+        }
+        let watch = ReleaseWatch(feed: feed)
+        watch.onFeedChanged = { [weak self] in self?.releaseFeedDidChange() }
+        releaseWatch = watch
+        watch.start()
+    }
+
+    /// The appcast moved.  All this does is ask Sparkle to look — the watch
+    /// never parses the feed, so this is the full extent of its authority.
+    ///
+    /// A cycle already in flight is left alone: the reader is watching a
+    /// download or reading a prompt, and restarting underneath them would
+    /// replace what they are looking at with the same answer.
+    func releaseFeedDidChange() {
+        guard let engine, engine.isRunning, engine.automaticallyChecksForUpdates else { return }
+        guard case .idle = machine.phase, downloadedUpdate == nil else { return }
+        releaseWatchTriggerCount += 1
+        engine.checkForUpdatesInBackground()
     }
 
     // MARK: - User actions
@@ -249,6 +335,49 @@ final class UpdateCoordinator: UpdateDriverHost {
     }
 
     // MARK: Update panel actions (routed to the armed capability)
+
+    /// The pill's one press.  Everything the panel's Update button does, minus
+    /// the panel: a reader who clicked a control labelled "Update Now" has
+    /// already answered the question the panel would ask them.
+    ///
+    /// Unsaved work is deliberately *not* handled here.  Sparkle's install
+    /// asks the app to terminate, which runs `applicationShouldTerminate` and
+    /// the one policy this app has for dirty buffers — ask, and cancel the
+    /// quit if the reader cancels.  A second flush here would be a second
+    /// policy for the same moment, and the state machine already carries
+    /// `.waitingForTermination` for the cancelled case.
+    func userDidPressUpdateNow() {
+        switch machine.phase {
+        case .waitingForTermination:
+            // The install is underway; only the quit is outstanding.
+            userDidRetryTermination()
+        case .failed:
+            showPanel()
+        case .downloading, .extracting, .checking:
+            // Already in flight. The panel is where the cancel button lives.
+            showPanel()
+        case .informational(let metadata):
+            userDidRequestLearnMore(metadata)
+        default:
+            if readyReply?.isArmed == true || choiceReply?.isArmed == true {
+                userDidChooseInstall()
+            } else if pendingUpdate != nil, let engine, engine.isRunning {
+                // A background cycle finished without leaving a prompt armed.
+                // Re-entering Sparkle presents the same build for install, and
+                // `isExpeditedInstall` keeps that cycle from opening a window
+                // to ask what the press already answered.
+                //
+                // Straight to the engine rather than through `checkForUpdates`:
+                // that path exists for the *menu*, and gates on the bundle's
+                // updater configuration so it can explain a disabled updater.
+                // A pill only exists when an update is already pending, so a
+                // press can never be the case that alert is for.
+                isExpeditedInstall = true
+                engine.checkForUpdates()
+            }
+        }
+        notifyStateChanged()
+    }
 
     /// Update / Update & Relaunch — "do it now".
     func userDidChooseInstall() {
@@ -406,11 +535,12 @@ final class UpdateCoordinator: UpdateDriverHost {
 
     func driverDidBeginUserCheck(cancellation: @escaping () -> Void) {
         releaseNotes = .none
+        currentCycleUpdate = nil
         currentCycleIsUserInitiated = true
         discard(&checkCancellation)
         checkCancellation = Capability(cancellation)
         machine.reduce(.userInitiatedCheckBegan)
-        showPanel()
+        if !isExpeditedInstall { showPanel() }
         notifyStateChanged()
     }
 
@@ -426,11 +556,18 @@ final class UpdateCoordinator: UpdateDriverHost {
         discard(&readyReply)
         choiceReply = Capability(reply)
         downloadedUpdate = nil
+        currentCycleUpdate = metadata
         currentCycleIsUserInitiated = userInitiated
         machine.reduce(.updateFound(metadata, stage: stage))
-        // A scheduled/automatic presentation stays on the pill; the panel
-        // opens only when the user asked for the update themselves.
-        if userInitiated { showPanel() }
+        if isExpeditedInstall {
+            // The press was the answer. Reply now rather than opening a window
+            // to ask it again; `consume` keeps the exactly-once contract.
+            consume(&choiceReply, value: .install)
+        } else if userInitiated {
+            // A scheduled/automatic presentation stays on the pill; the panel
+            // opens only when the user asked for the update themselves.
+            showPanel()
+        }
         notifyStateChanged()
     }
 
@@ -446,6 +583,8 @@ final class UpdateCoordinator: UpdateDriverHost {
 
     func driverDidFindNoUpdate(userInitiated: Bool, acknowledgement: @escaping () -> Void) {
         releaseNotes = .none
+        isExpeditedInstall = false
+        currentCycleUpdate = nil
         discard(&checkCancellation)
         discard(&choiceReply)
         discard(&readyReply)
@@ -467,6 +606,9 @@ final class UpdateCoordinator: UpdateDriverHost {
 
     func driverDidEncounterError(_ error: Error, acknowledgement: @escaping () -> Void) {
         releaseNotes = .none
+        // A press that could not be honoured owes an explanation, so the
+        // failure path deliberately drops back to the ordinary panel.
+        isExpeditedInstall = false
         let userInitiated = currentCycleIsUserInitiated
         currentCycleIsUserInitiated = false
         discard(&self.acknowledgement)
@@ -492,8 +634,9 @@ final class UpdateCoordinator: UpdateDriverHost {
         discard(&downloadCancellation)
         downloadCancellation = Capability(cancellation)
         machine.reduce(.downloadInitiated)
-        // Automatic background downloads proceed silently on the pill.
-        if currentCycleIsUserInitiated { showPanel() }
+        // Automatic background downloads — and the one a press started —
+        // proceed silently on the pill.
+        if currentCycleIsUserInitiated && !isExpeditedInstall { showPanel() }
         notifyStateChanged()
     }
 
@@ -523,9 +666,13 @@ final class UpdateCoordinator: UpdateDriverHost {
         discard(&readyReply)
         readyReply = Capability(reply)
         machine.reduce(.readyToInstallAndRelaunch)
-        // A background download that became ready stays on the "Restart to
-        // Update" pill; the panel opens when the pill is clicked.
-        if currentCycleIsUserInitiated { showPanel() }
+        if isExpeditedInstall {
+            consume(&readyReply, value: .install)
+        } else if currentCycleIsUserInitiated {
+            // A background download that became ready stays on the pill; the
+            // panel opens when the pill is clicked.
+            showPanel()
+        }
         notifyStateChanged()
     }
 
@@ -533,6 +680,7 @@ final class UpdateCoordinator: UpdateDriverHost {
         discard(&self.retryTermination)
         discard(&downloadCancellation)
         self.retryTermination = Capability(retryTermination)
+        isExpeditedInstall = false
         machine.reduce(.installingUpdate(applicationTerminated: applicationTerminated))
         if !applicationTerminated {
             showPanel()  // give the user Retry / Later for a delayed quit
@@ -545,6 +693,8 @@ final class UpdateCoordinator: UpdateDriverHost {
         self.acknowledgement = Capability(acknowledgement)
         machine.reduce(.updateInstalled(relaunched: relaunched))
         currentCycleIsUserInitiated = false
+        isExpeditedInstall = false
+        currentCycleUpdate = nil
         downloadedUpdate = nil
         userDidAcknowledge()
         closePanel()
@@ -554,6 +704,8 @@ final class UpdateCoordinator: UpdateDriverHost {
     func driverDidDismiss() {
         discardAllCapabilities()
         currentCycleIsUserInitiated = false
+        isExpeditedInstall = false
+        currentCycleUpdate = nil
         machine.reduce(.dismissed)
         downloadedUpdate = nil
         releaseNotes = .none
@@ -588,6 +740,44 @@ final class UpdateCoordinator: UpdateDriverHost {
         notifyStateChanged()
     }
 
+#if DEBUG
+    /// Debug-only: put the pill into its offered state with synthetic
+    /// metadata, so the "Update Now" surface — the arrival emphasis, the
+    /// hover notes, the copy at both `isReady` values — can be exercised
+    /// without waiting out a real ~35-minute release pipeline for every
+    /// adjustment.
+    ///
+    /// It deliberately touches neither Sparkle, the feed, nor the trust
+    /// model: it fills in exactly the `downloadedUpdate` a completed
+    /// background download would leave behind, and nothing else.  Pressing
+    /// the resulting pill in a dev bundle finds no running engine and does
+    /// nothing, which is the correct outcome for a bundle that has no
+    /// updater.  `#if DEBUG` keeps the whole thing out of the Release
+    /// configuration the notarised archive is built with.
+    func presentDemoUpdateForDebugging(version: String = "9.9.9") {
+        downloadedUpdate = UpdateMetadata(
+            versionString: "99999",
+            displayVersionString: version,
+            title: "Downright \(version)",
+            itemDescription: """
+            # Downright \(version)
+
+            - Update Now installs from the titlebar, without a window in the way
+            - Resting on the button unfurls these notes
+            - The appcast is watched while the app is open, so a build lands here in about a minute
+            """,
+            releaseNotesURL: nil,
+            infoURL: URL(string: "https://github.com/ezzy1630/Downright/releases"),
+            contentLength: 18_400_000,
+            isInformationOnly: false,
+            isMajorUpgrade: false,
+            isCritical: false,
+            minimumSystemVersion: nil
+        )
+        notifyStateChanged()
+    }
+#endif
+
     // MARK: - Release notes state
 
     private(set) var releaseNotes: UpdateReleaseNotesState = .none
@@ -598,21 +788,24 @@ final class UpdateCoordinator: UpdateDriverHost {
     var pillModel: UpdatePillModel? {
         switch machine.phase {
         case .idle:
-            return downloadedUpdate != nil ? .restartToUpdate : nil
+            guard let downloadedUpdate else { return nil }
+            return .updateNow(version: downloadedUpdate.displayVersionString, isReady: true)
         case .checking:
             return nil
         case .available(let metadata, let stage):
-            return stage == .downloaded || stage == .installing
-                ? .restartToUpdate
-                : .available(metadata.displayVersionString)
+            return .updateNow(
+                version: metadata.displayVersionString,
+                isReady: stage == .downloaded || stage == .installing
+            )
         case .downloading(let received, let expected):
             let fraction = expected.map { expected in Double(received) / Double(max(1, expected)) }
             return .progress(updateLabel, fraction)
         case .extracting(let progress):
             return .progress("Updating…", progress)
         case .readyToRelaunch:
-            return .restartToUpdate
+            return .updateNow(version: readyVersionString, isReady: true)
         case .waitingForTermination:
+            // The install has begun and the app has to quit to finish it.
             return .restartToUpdate
         case .installing:
             return .hidden  // the app is quitting; nothing to click
@@ -623,6 +816,23 @@ final class UpdateCoordinator: UpdateDriverHost {
         case .failed:
             return .warning
         }
+    }
+
+    /// The update the pill is currently offering, for the hover notes.  Mirrors
+    /// what the panel resolves so both surfaces describe the same build.
+    var pendingUpdate: UpdateMetadata? {
+        switch machine.phase {
+        case .available(let metadata, _), .informational(let metadata):
+            return metadata
+        default:
+            return downloadedUpdate ?? currentCycleUpdate
+        }
+    }
+
+    /// The version to name once extraction has finished and the metadata is no
+    /// longer carried by the phase itself.
+    private var readyVersionString: String {
+        pendingUpdate?.displayVersionString ?? ""
     }
 
     /// Short label for progress states: the target version once known, else

--- a/Sources/MarkdownCore/DocumentIO.swift
+++ b/Sources/MarkdownCore/DocumentIO.swift
@@ -142,6 +142,14 @@ public enum DocumentIO {
             try? FileManager.default.setAttributes([.posixPermissions: permissions], ofItemAtPath: temporary.path)
         }
 
+        // The swap publishes a name, not durability: without flushing the
+        // payload first, a crash or power loss immediately after the swap can
+        // leave the document path holding a truncated or empty generation.
+        // (The directory entry itself is deliberately not synced — losing it
+        // after a crash only rolls the path back to the previous generation,
+        // which is the safe direction.)
+        try syncTemporaryToStableStorage(temporary)
+
         guard renamex_np(temporary.path, url.path, UInt32(RENAME_SWAP)) == 0 else {
             throw posixRenameError(path: url.path)
         }
@@ -200,6 +208,20 @@ public enum DocumentIO {
             code: Int(errno),
             userInfo: [NSFilePathErrorKey: path]
         )
+    }
+
+    /// Flushes a just-written file's contents to stable storage before its
+    /// name is published.  `F_FULLFSYNC` waits for the drive itself to
+    /// acknowledge, which plain `fsync(2)` does not guarantee on macOS;
+    /// filesystems that do not support it fall back to `fsync`, and only a
+    /// failure of both surfaces as a save error.
+    private static func syncTemporaryToStableStorage(_ url: URL) throws {
+        let handle = try FileHandle(forReadingFrom: url)
+        defer { try? handle.close() }
+        if fcntl(handle.fileDescriptor, F_FULLFSYNC) == 0 { return }
+        guard fsync(handle.fileDescriptor) == 0 else {
+            throw posixRenameError(path: url.path)
+        }
     }
 
     /// The exact bytes `write` will place on disk. Callers that coordinate a

--- a/Sources/MarkdownCore/SafeHTML.swift
+++ b/Sources/MarkdownCore/SafeHTML.swift
@@ -258,15 +258,41 @@ public enum SafeHTMLParser {
             return nil
         }
 
+        /// True when the genuine closing fragment appears after `location`.
+        ///
+        /// swift-markdown splits a README-style `<details>` element at blank
+        /// lines, so the partner tag lives in a *later HTML block*. A bare
+        /// substring search over the whole source would let any mention of
+        /// the text satisfy that check — `` `<details>` `` inside a code span,
+        /// or prose naming the element — and hide a stray literal
+        /// `</details>` that was never part of a real element. Genuine
+        /// partners are written as their own HTML block, so require that
+        /// shape: at most three spaces of indent on the line, then the tag.
         private func hasClosingDetails(after location: Int) -> Bool {
             guard location < source.length else { return false }
-            return source.range(
-                of: "</details>",
-                options: [.caseInsensitive],
-                range: NSRange(location: location, length: source.length - location)
-            ).location != NSNotFound
+            var search = NSRange(location: location, length: source.length - location)
+            while search.length > 0 {
+                let match = source.range(
+                    of: "</details>",
+                    options: [.caseInsensitive],
+                    range: search
+                )
+                guard match.location != NSNotFound else { return false }
+                if isHTMLBlockLineStart(match.location) {
+                    return true
+                }
+                search = NSRange(
+                    location: match.location + 1,
+                    length: source.length - (match.location + 1)
+                )
+            }
+            return false
         }
 
+        /// True when a real `<details …>` opening tag appears before
+        /// `location`, written as an HTML block. See `hasClosingDetails` for
+        /// why the search is anchored to the block shape rather than run over
+        /// raw source.
         private func hasOpeningDetails(before location: Int) -> Bool {
             guard location > 0 else { return false }
             var search = NSRange(location: 0, length: location)
@@ -277,17 +303,41 @@ public enum SafeHTMLParser {
                     range: search
                 )
                 guard match.location != NSNotFound else { return false }
+                // The partner must live entirely before this block.
                 guard match.upperBound < location else {
                     search.length = match.location
                     continue
                 }
-                let next = source.character(at: match.upperBound)
-                if next == 0x3E || next == 0x20 || next == 0x09 || next == 0x0A || next == 0x0D {
-                    return true
+                if isHTMLBlockLineStart(match.location) {
+                    let next = source.character(at: match.upperBound)
+                    if next == 0x3E || next == 0x20 || next == 0x09 || next == 0x0A || next == 0x0D {
+                        return true
+                    }
                 }
                 search.length = match.location
             }
             return false
+        }
+
+        /// Whether `location` starts an HTML block line: beginning of source
+        /// or right after a newline, with no more than three leading spaces
+        /// (CommonMark's HTML-block indentation allowance). Tabs fail
+        /// deliberately: real emitters indent blocks with spaces, while code
+        /// fences routinely indent deeper than three.
+        private func isHTMLBlockLineStart(_ location: Int) -> Bool {
+            var index = location
+            var spaces = 0
+            while index > 0 {
+                let previous = source.character(at: index - 1)
+                if previous == 0x20 {
+                    spaces += 1
+                    index -= 1
+                    if spaces > 3 { return false }
+                    continue
+                }
+                return previous == 0x0A || previous == 0x0D
+            }
+            return true
         }
 
         private func index(of character: Character, from start: Int) -> Int? {

--- a/Sources/MarkdownRender/Engine/DecorationEngine.swift
+++ b/Sources/MarkdownRender/Engine/DecorationEngine.swift
@@ -66,6 +66,37 @@ public final class DecorationEngine {
     private var styles: BlockStyleFactory
     private let syntaxCache = SyntaxRunCache()
 
+    // MARK: Source-mode typography (§3.2)
+
+    /// Set for the duration of one `decorate` call whose `.font`, `.ligature`
+    /// and `.paragraphStyle` output is guaranteed to be thrown away before
+    /// anything can read it.
+    ///
+    /// Switching the one text surface into Source is a wholesale pass under the
+    /// Source policy followed — in the same turn, before any layout — by the
+    /// view's whole-document source presentation, which rewrites the font and
+    /// one uniform paragraph style over *every* character.  So the heading
+    /// faces, the list indents, the code row hangs and the per-paragraph styles
+    /// this file computes on that path exist for microseconds and are then
+    /// overwritten.  They are not free to compute: each one is a paragraph walk
+    /// and an attribute run split that the source pass then has to walk back
+    /// over, which is why the switch cost grew with the document rather than
+    /// with what changed.
+    ///
+    /// Everything that is *not* typography still has to be produced here —
+    /// foreground colours, marker highlighting, code syntax runs, links,
+    /// fragments, block identity — because nothing downstream re-establishes
+    /// any of it.  `apply` enforces that split in one place rather than trusting
+    /// each call site to remember it.
+    private var discardsTypography = false
+
+    /// The policy shape Source mode uses: markers styled in place rather than
+    /// hidden, and nothing rendered as an object.  Live and Read both hide
+    /// markers and both render fragments, so this cannot be true for either.
+    private var policyIsSourceShaped: Bool {
+        !policy.rendersFragments && !policy.hidesBlockMarkers && !policy.hidesInlineMarkers
+    }
+
     public init(styleSheet: StyleSheet, highlighter: SyntaxHighlighter = BuiltinSyntaxHighlighter.shared) {
         self.styleSheet = styleSheet
         self.highlighter = highlighter
@@ -95,6 +126,14 @@ public final class DecorationEngine {
         /// the key must carry the task bit or the cache records the wrong
         /// marker column for one of them.
         var task: Bool
+        /// A program recorded during a wholesale Source pass carries no font
+        /// and no paragraph style, because the source presentation was about
+        /// to overwrite both.  Replaying that program anywhere else leaves the
+        /// paragraph with no typography at all, so the two shapes must never
+        /// share an entry — the policy change that ends Source mode already
+        /// drops the cache, but an incremental commit *inside* Source mode does
+        /// not, and that is the one that would have hit a stale entry.
+        var plainTypography: Bool
     }
 
     private var programCache: [ProgramKey: [AttributeOp]] = [:]
@@ -147,6 +186,14 @@ public final class DecorationEngine {
             targets = RangeSet.normalized(dirty.ranges.compactMap { clip(blockBounds(of: $0, in: document), to: full) })
         }
         guard !targets.isEmpty else { return DecorationResult(elapsed: CFAbsoluteTimeGetCurrent() - started) }
+
+        // Only a *wholesale* Source pass earns the shortcut.  An incremental
+        // commit in Source mode re-decorates whole blocks while the source
+        // presentation is re-applied over the narrower ranges the diff
+        // reported, so typography dropped here would not be put back over the
+        // rest of those blocks.
+        discardsTypography = dirty.isWholesale && policyIsSourceShaped
+        defer { discardsTypography = false }
 
         var state = DecorateState(document: document, storage: storage)
         state.documentBase = documentBaseAttributes()
@@ -525,6 +572,7 @@ public final class DecorationEngine {
     // MARK: - Attribute application
 
     private func applyTrailingListSpacing(_ list: MDBlock, state: inout DecorateState) {
+        guard !discardsTypography else { return }
         guard let last = list.children.last, last.range.length > 0 else { return }
         let source = state.storage.string as NSString
         let offset = min(source.length - 1, max(last.range.location, last.range.upperBound - 1))
@@ -551,13 +599,28 @@ public final class DecorationEngine {
     ) {
         guard let clipped = clip(range, to: state.target), clipped.length > 0 else { return }
         guard clipped.upperBound <= state.storage.length else { return }
+        guard !discardsTypography else {
+            // The one place the Source shortcut is enforced, so a call site
+            // that forgets it still cannot write typography that the source
+            // presentation is about to overwrite.  An operation that carried
+            // nothing but a font or a paragraph style disappears entirely
+            // rather than splitting an attribute run for nothing.
+            var surviving = attributes
+            surviving.removeValue(forKey: .font)
+            surviving.removeValue(forKey: .paragraphStyle)
+            guard !surviving.isEmpty else { return }
+            state.storage.addAttributes(surviving, range: clipped)
+            state.attributeRanges += 1
+            return
+        }
         state.storage.addAttributes(attributes, range: clipped)
         state.attributeRanges += 1
     }
 
     private func applyBase(_ block: MDBlock, context: BlockContext, state: inout DecorateState) {
         var attributes = styles.baseAttributes(for: block, context: context)
-        if styleSheet.theme.typography.opticalMargins,
+        if !discardsTypography,
+           styleSheet.theme.typography.opticalMargins,
            context.listDepth == 0,
            case .paragraph = block.content,
            let first = state.document.substring(block.contentRange).first,
@@ -600,6 +663,7 @@ public final class DecorationEngine {
         over block: MDBlock,
         state: inout DecorateState
     ) {
+        guard !discardsTypography else { return }
         let text = state.storage.string as NSString
         let children = block.children
         var cursor = block.range.location
@@ -623,6 +687,7 @@ public final class DecorationEngine {
         attributes: [NSAttributedString.Key: Any],
         state: inout DecorateState
     ) {
+        guard !discardsTypography else { return }
         guard case .heading = block.content,
               let original = attributes[.paragraphStyle] as? NSParagraphStyle else { return }
         let isFirst = state.document.headings.first?.range.location == block.range.location
@@ -672,6 +737,7 @@ public final class DecorationEngine {
         attributes: [NSAttributedString.Key: Any],
         state: inout DecorateState
     ) {
+        guard !discardsTypography else { return }
         guard case .paragraph = block.content,
               state.document.substring(block.contentRange).contains("\n"),
               let original = attributes[.paragraphStyle] as? NSParagraphStyle
@@ -697,6 +763,7 @@ public final class DecorationEngine {
     private func applyCodeRowIndents(
         _ block: MDBlock, context: BlockContext, state: inout DecorateState
     ) {
+        guard !discardsTypography else { return }
         let base = styles.paragraphStyle(for: block, context: context)
         let text = state.storage.string as NSString
         for line in physicalParagraphs(of: block, in: state) {
@@ -757,11 +824,18 @@ public final class DecorationEngine {
 
             switch span.kind {
             case .strong:
+                // The trait still has to propagate into the children even when
+                // the face itself is about to be overwritten: a `**bold _and_
+                // italic**` span resolves its emphasis from both flags.
                 bold = true
-                apply([.font: emphasized(blockFont, bold: true, italic: italic)], to: span.contentRange, state: &state)
+                if !discardsTypography {
+                    apply([.font: emphasized(blockFont, bold: true, italic: italic)], to: span.contentRange, state: &state)
+                }
             case .emphasis:
                 italic = true
-                apply([.font: emphasized(blockFont, bold: bold, italic: true)], to: span.contentRange, state: &state)
+                if !discardsTypography {
+                    apply([.font: emphasized(blockFont, bold: bold, italic: true)], to: span.contentRange, state: &state)
+                }
             case .strikethrough:
                 apply([
                     .strikethroughStyle: NSUnderlineStyle.single.rawValue,
@@ -769,11 +843,17 @@ public final class DecorationEngine {
                     .foregroundColor: styleSheet.textFaint,
                 ], to: span.contentRange, state: &state)
             case .inlineCode:
-                apply([
-                    .font: styleSheet.monoFont(size: blockFont.pointSize * 0.94),
+                var attributes: [NSAttributedString.Key: Any] = [
                     .foregroundColor: styleSheet.text,
                     .drInlineCode: true,
-                ], to: span.contentRange, state: &state)
+                ]
+                // Resolving a resized mono face goes through the font
+                // descriptor, so it is worth not asking for one that is about
+                // to be replaced by the source presentation's own mono.
+                if !discardsTypography {
+                    attributes[.font] = styleSheet.monoFont(size: blockFont.pointSize * 0.94)
+                }
+                apply(attributes, to: span.contentRange, state: &state)
             case .link(let destination, _):
                 applyLink(destination, span: span, state: &state)
             case .autolink(let destination):
@@ -796,20 +876,29 @@ public final class DecorationEngine {
                 // §8.4: the engine marks it; only the app knows whether the
                 // file is there, so `drPathExists` starts optimistic and the
                 // view refines it through the delegate.
-                apply([
+                var attributes: [NSAttributedString.Key: Any] = [
                     .drPathToken: token,
                     .drPathExists: true,
                     .drInlineCode: true,
-                    .font: styleSheet.monoFont(size: blockFont.pointSize * 0.94),
                     .foregroundColor: styleSheet.textSecondary,
-                ], to: span.range, state: &state)
+                ]
+                if !discardsTypography {
+                    attributes[.font] = styleSheet.monoFont(size: blockFont.pointSize * 0.94)
+                }
+                apply(attributes, to: span.range, state: &state)
             case .footnoteReference(let identifier):
-                apply([
+                // The raised baseline survives into Source — only the smaller
+                // face is overwritten — so the offset is still measured from
+                // the block's own font here.
+                var attributes: [NSAttributedString.Key: Any] = [
                     .drReference: identifier,
                     .foregroundColor: styleSheet.accent,
                     .baselineOffset: blockFont.xHeight * 0.42,
-                    .font: blockFont.withSize(blockFont.pointSize * 0.62),
-                ], to: span.range, state: &state)
+                ]
+                if !discardsTypography {
+                    attributes[.font] = blockFont.withSize(blockFont.pointSize * 0.62)
+                }
+                apply(attributes, to: span.range, state: &state)
             case .inlineHTML:
                 apply([.foregroundColor: styleSheet.textFaint], to: span.range, state: &state)
             case .text, .softBreak, .lineBreak:
@@ -857,7 +946,8 @@ public final class DecorationEngine {
             }
             switch annotation.kind {
             case .paragraph(let alignment):
-                guard let alignment, annotation.contentRange.length > 0 else { continue }
+                guard !discardsTypography,
+                      let alignment, annotation.contentRange.length > 0 else { continue }
                 let current = state.storage.attribute(
                         .paragraphStyle,
                         at: annotation.contentRange.location,
@@ -928,7 +1018,7 @@ public final class DecorationEngine {
                     apply([.font: emphasized(bodyFont, bold: true, italic: false)],
                           to: annotation.contentRange, state: &state)
                 }
-                if let alignment, annotation.contentRange.length > 0 {
+                if !discardsTypography, let alignment, annotation.contentRange.length > 0 {
                     let current = state.storage.attribute(
                         .paragraphStyle,
                         at: annotation.contentRange.location,
@@ -1089,7 +1179,8 @@ public final class DecorationEngine {
         guard !Self.containsInlineMath(block.inlines) else { return nil }
         let key = ProgramKey(hash: block.subtreeHash, kind: BlockStyleFactory.kindCode(block.content),
                              listDepth: context.listDepth, quoteDepth: context.quoteDepth,
-                             length: block.range.length, task: context.task)
+                             length: block.range.length, task: context.task,
+                             plainTypography: discardsTypography)
         if let hit = programCache[key] { return hit }
         guard programSeen.contains(key) else {
             programSeen.insert(key)

--- a/Sources/MarkdownRender/Fragments/ImageFragment.swift
+++ b/Sources/MarkdownRender/Fragments/ImageFragment.swift
@@ -7,11 +7,15 @@ import MarkdownCore
 /// make the handoff honest under strict concurrency.
 private final class ImageLoadCompletionBox: @unchecked Sendable {
     weak var view: MarkdownTextView?
-    let sourceRange: NSRange
+    /// The payload reference, not a copied range: an edit that lands while the
+    /// decode is in flight projects the payload's ranges in place, so reading
+    /// `sourceRange` at completion time invalidates where the image lives
+    /// *now* rather than where it lived when the load was scheduled.
+    let payload: FragmentPayload
 
-    init(view: MarkdownTextView?, sourceRange: NSRange) {
+    init(view: MarkdownTextView?, payload: FragmentPayload) {
         self.view = view
-        self.sourceRange = sourceRange
+        self.payload = payload
     }
 }
 
@@ -188,14 +192,14 @@ final class ImageFragment: DownrightFragment {
     /// load share one background read; a failed load is retried on the next
     /// layout pass because the cache still misses.
     private func scheduleAsyncLoad(_ url: URL, dimension: Int) {
-        let box = ImageLoadCompletionBox(view: context?.textView, sourceRange: payload.sourceRange)
+        let box = ImageLoadCompletionBox(view: context?.textView, payload: payload)
         MarkdownFragmentImageCaches.images.loadImageAsync(
             for: url, maxPixelDimension: dimension
         ) { image in
             // A nil result means the file is missing or unreadable; only invalidate
             // layout when an image is successfully loaded to avoid infinite layout loops.
             guard image != nil, let view = box.view else { return }
-            view.invalidateFragments(in: box.sourceRange)
+            view.invalidateFragments(in: box.payload.sourceRange)
         }
     }
 

--- a/Sources/MarkdownRender/RenderContracts.swift
+++ b/Sources/MarkdownRender/RenderContracts.swift
@@ -251,7 +251,10 @@ public final class FragmentPayload: NSObject {
     /// leading cell text disappeared and trailing Markdown markers leaked.
     /// Project the old metadata over the same edit immediately; the fresh parse
     /// remains authoritative when it arrives.
-    func projectSourceRanges(across edit: NSRange, insertedLength: Int) {
+    /// Public because every edit funnel that mutates a decorated storage —
+    /// the view's own and the document layer's — must be able to keep payloads
+    /// aligned with the runs they ride on.
+    public func projectSourceRanges(across edit: NSRange, insertedLength: Int) {
         sourceRange = Self.project(sourceRange, across: edit, insertedLength: insertedLength)
         guard var tableData else { return }
         tableData.delimiterRange = Self.project(

--- a/Sources/MarkdownRender/Theme/ThemeStore.swift
+++ b/Sources/MarkdownRender/Theme/ThemeStore.swift
@@ -31,12 +31,16 @@ public final class ThemeStore {
     private var observers: [ObjectIdentifier: (Theme) -> Void] = [:]
     private var watcher: DirectoryWatcher?
 
-    /// Internal rather than private so tests can save and restore the user's
-    /// real preference around exercising `select(named:)`.
-    static let selectionDefaultsKey = "downright.theme.selected"
+    private static let selectionDefaultsKey = "downright.theme.selected"
 
-    public init() {
-        selectedName = UserDefaults.standard.string(forKey: ThemeStore.selectionDefaultsKey) ?? "Paper Light"
+    private let defaults: UserDefaults
+
+    /// `defaults` exists so a test (or an alternate host) can isolate theme
+    /// selection from the user's real preferences; the default keeps the
+    /// long-standing standard-defaults behaviour.
+    public init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        selectedName = defaults.string(forKey: ThemeStore.selectionDefaultsKey) ?? "Paper Light"
         bundledThemes = ThemeStore.loadBundledThemes()
         rebuild()
         reloadUserThemes()
@@ -47,7 +51,7 @@ public final class ThemeStore {
     public func select(named name: String) {
         guard themes.contains(where: { $0.name == name }), name != selectedName else { return }
         selectedName = name
-        UserDefaults.standard.set(name, forKey: ThemeStore.selectionDefaultsKey)
+        defaults.set(name, forKey: ThemeStore.selectionDefaultsKey)
         bumpAndNotify()
     }
 

--- a/Sources/MarkdownRender/View/DensityGutterView.swift
+++ b/Sources/MarkdownRender/View/DensityGutterView.swift
@@ -149,6 +149,15 @@ public final class DensityGutterView: Motion.SpringSurfaceView {
     static let hoverDismissalSlop: CGFloat = 4
     /// Small bridge only for the physical gap between a mark and its preview.
     static let previewExitDelay: TimeInterval = 0.06
+    /// Floor between two taps of the Taptic engine.
+    ///
+    /// A deliberate scrub crosses a dozen marks in a tenth of a second, and
+    /// the engine renders every request in full rather than coalescing them:
+    /// ungated, the rail hums under the hand instead of ticking, and the one
+    /// tap that means something — the landing punch — is lost in it.  At 50ms
+    /// a slow read of the stack taps mark by mark and a fast sweep thins to a
+    /// rhythm, which is the difference between a detent and a buzz.
+    static let detentInterval: TimeInterval = 0.05
     /// Distance over which mark size / brightness fall off from the pointer.
     static let proximityRadius: CGFloat = 36
     /// Maximum magnetic pull of a mark toward the pointer (points).
@@ -216,6 +225,16 @@ public final class DensityGutterView: Motion.SpringSurfaceView {
     private var pointerIsInOutline = false
     private var lastPointerSample: (y: CGFloat, time: CFTimeInterval)?
     private var pointerVelocityY: CGFloat = 0
+    /// When the rail last tapped, so `detentInterval` can be enforced across
+    /// both the things that ask for one.
+    private var lastHapticTime: CFTimeInterval = -.greatestFiniteMagnitude
+
+    /// Swapped in tests to count taps; production always reaches the performer.
+    /// `.alignment` is the tap the rest of the app uses for a control landing
+    /// on a discrete position, which is exactly what crossing a mark is.
+    var performHapticFeedback: () -> Void = {
+        NSHapticFeedbackManager.defaultPerformer.perform(.alignment, performanceTime: .now)
+    }
     private var previousCurrentFraction: CGFloat?
     private var progressWashLayer: CALayer?
     private var spineLayer: CALayer?
@@ -1258,8 +1277,42 @@ public final class DensityGutterView: Motion.SpringSurfaceView {
         guard let index, index < markSimulations.count else { return }
         markSimulations[index].frame.size.width.kick(Motion.jumpPunchKick)
         markSimulations[index].frame.size.height.kick(Motion.jumpPunchKick * 0.5)
-        NSHapticFeedbackManager.defaultPerformer.perform(.alignment, performanceTime: .now)
+        performRailHaptic()
         armRailDriver()
+    }
+
+    /// Every tap the rail makes goes through here.
+    ///
+    /// Two things ask for one — a detent as the pointer crosses onto a mark,
+    /// and the landing punch when a jump commits — and on mouse-up they can
+    /// both fire for the same mark in the same event.  Two taps that close
+    /// together read as one mushy thud, so the rail keeps a single budget and
+    /// the first asker wins it.  Suppression deliberately leaves the clock
+    /// alone: a detent that loses its slot does not push the next one back.
+    private func performRailHaptic() {
+        // Reduce Motion has already parked every spring in the rail
+        // (`armRailDriver`), which leaves the landing punch a tap with nothing
+        // behind it and the detents a rhythm answering movement the reader
+        // asked not to see.  Read the sheet rather than the workspace: a
+        // reader profile can request a calmer document without the whole
+        // system being set that way.
+        guard !styleSheet.reduceMotion else { return }
+        let now = CACurrentMediaTime()
+        guard now - lastHapticTime >= Self.detentInterval else { return }
+        lastHapticTime = now
+        performHapticFeedback()
+    }
+
+    /// Which hover transitions earn a detent.
+    ///
+    /// Arriving at a mark and crossing between two both do; leaving the stack
+    /// does not.  A tap on the way *out* answers a gesture the reader has
+    /// already abandoned, and because the rail sits against the window edge
+    /// that exit fires on any pointer travel that merely passes the window —
+    /// the one transition guaranteed to happen without intent.
+    static func isDetentCrossing(from previous: Int?, to next: Int?) -> Bool {
+        guard let next else { return false }
+        return next != previous
     }
 
     private func updateHoveredBand(at point: NSPoint?, animated: Bool) {
@@ -1278,6 +1331,13 @@ public final class DensityGutterView: Motion.SpringSurfaceView {
         }
 
         let indexChanged = nextIndex != hoveredBandIndex
+        // Both hover and scrub land here, so the stack ticks under the pointer
+        // the same way whether the button is down or not — the marks are the
+        // rail's detents in either gesture, and hysteresis above has already
+        // decided where one ends and the next begins.
+        if Self.isDetentCrossing(from: hoveredBandIndex, to: nextIndex) {
+            performRailHaptic()
+        }
         hoveredBandIndex = nextIndex
         // The springs *are* the smoothing: retarget on every pointer move and
         // let the display link carry the motion.  With CA, only index changes
@@ -1286,6 +1346,19 @@ public final class DensityGutterView: Motion.SpringSurfaceView {
         if indexChanged || point != nil || pointerLocation != nil {
             updateMarkLayers(animated: animated)
         }
+    }
+
+    /// Drive the hover funnel without a window or a synthesised event, so the
+    /// detent policy can be exercised through the same path hover and scrub
+    /// both take rather than through a reimplementation of it.
+    func driveHoverForTesting(toY y: CGFloat) {
+        updateHoveredBand(at: NSPoint(x: bounds.midX, y: y), animated: false)
+    }
+
+    /// The drawn mark positions, so a test can count the crossings a sweep
+    /// makes against the same stack the rail is hovering.
+    var markPositionsForTesting: [CGFloat] {
+        resolvedStack(height: bounds.height).map(\.y)
     }
 
     /// A mark's hover row is half the gap to its neighbour, so the pointer

--- a/Sources/MarkdownRender/View/MarkdownSmartPaste.swift
+++ b/Sources/MarkdownRender/View/MarkdownSmartPaste.swift
@@ -16,9 +16,8 @@ enum MarkdownPasteMode: Equatable {
     case matchStyle
 }
 
-/// Clipboard payload in the order in which AppKit presents useful flavours.
-/// Keeping this value independent of `NSPasteboard` makes the policy pure and
-/// keeps all source-coordinate mutation in `MarkdownTextView`.
+/// A clipboard payload independent of `NSPasteboard`, keeping flavour policy
+/// pure and all source-coordinate mutation in `MarkdownTextView`.
 enum MarkdownPastePayload: Equatable {
     case markdown(String)
     case url(String)
@@ -30,14 +29,29 @@ enum MarkdownPastePayload: Equatable {
 }
 
 enum MarkdownSmartPaste {
-    /// Reads clipboard flavours in the same order as AppKit's paste action:
-    /// an explicit URL wins over browser HTML, then plain text. The named
-    /// pasteboard seam keeps tests and Quick Look callers off the global board.
-    static func payload(from pasteboard: NSPasteboard) -> MarkdownPastePayload? {
-        let orderedTypes: [NSPasteboard.PasteboardType] = [
-            .downrightMarkdown, .URL, .html, .rtf, .rtfd, .webArchive, .appleWebArchive,
-            .fileURL, .tiff, .png, .string,
+    /// Ordinary paste is conservative: lossless Downright Markdown wins, then
+    /// the producer's visible plain text. Rich conversion belongs to the
+    /// explicit Paste as Markdown command; Match Style also prefers visible
+    /// text and strips formatting from rich-only payloads as a fallback.
+    static func payload(
+        from pasteboard: NSPasteboard,
+        mode: MarkdownPasteMode = .smart
+    ) -> MarkdownPastePayload? {
+        let richTypes: [NSPasteboard.PasteboardType] = [
+            .html, .rtf, .rtfd, .webArchive, .appleWebArchive,
         ]
+        let orderedTypes: [NSPasteboard.PasteboardType]
+        switch mode {
+        case .smart:
+            orderedTypes = [.downrightMarkdown, .string, .URL, .fileURL]
+                + richTypes + [.tiff, .png]
+        case .markdown:
+            orderedTypes = [.downrightMarkdown] + richTypes
+                + [.URL, .fileURL, .string, .tiff, .png]
+        case .matchStyle:
+            orderedTypes = [.string, .downrightMarkdown, .URL, .fileURL]
+                + richTypes + [.tiff, .png]
+        }
         for type in orderedTypes where pasteboard.types?.contains(type) == true {
             if type == .downrightMarkdown {
                 if let markdown = pasteboard.string(forType: type) { return .markdown(markdown) }

--- a/Sources/MarkdownRender/View/MarkdownTextView+Interaction.swift
+++ b/Sources/MarkdownRender/View/MarkdownTextView+Interaction.swift
@@ -1036,7 +1036,7 @@ extension MarkdownTextView {
     private func applyPaste(mode pasteMode: MarkdownPasteMode) {
         guard isEditable else { return }
         let pasteboard = NSPasteboard.general
-        guard let payload = markdownPastePayload(from: pasteboard) else { return }
+        guard let payload = markdownPastePayload(from: pasteboard, mode: pasteMode) else { return }
         if case .image = payload {
             // An unnamed bitmap has no honest Markdown destination until the
             // document owner chooses an asset path. Never replace a selection
@@ -1148,11 +1148,13 @@ extension MarkdownTextView {
         return deletionRange(after: clampedCaret, in: storage)
     }
 
-    /// Read the richest useful clipboard flavour first.  URL is intentionally
-    /// ahead of HTML/string because browser URL copies commonly advertise all
-    /// three and the URL is the user's explicit intent.
-    private func markdownPastePayload(from pasteboard: NSPasteboard) -> MarkdownPastePayload? {
-        MarkdownSmartPaste.payload(from: pasteboard)
+    /// Resolve clipboard flavour according to the invoked command. Ordinary
+    /// paste remains literal; rich conversion is an explicit choice.
+    private func markdownPastePayload(
+        from pasteboard: NSPasteboard,
+        mode: MarkdownPasteMode
+    ) -> MarkdownPastePayload? {
+        MarkdownSmartPaste.payload(from: pasteboard, mode: mode)
     }
 
     /// A hidden marker is deleted whole.  Deleting half of `**` would leave

--- a/Sources/MarkdownRender/View/MarkdownTextView+Interaction.swift
+++ b/Sources/MarkdownRender/View/MarkdownTextView+Interaction.swift
@@ -1403,3 +1403,300 @@ extension MarkdownTextView {
         return image
     }
 }
+
+// MARK: - Dropping files and images onto the document (§7.1)
+
+/// Inserting an image is the single most common thing anyone does in a
+/// Markdown editor, and until now the only surface in Downright that accepted
+/// a drop was the Start window.  Everything below is the render half of
+/// closing that: recognising the drag, resolving where under the pointer it
+/// would land *in source coordinates*, drawing that place, and handing the
+/// pasteboard to the app.  Not one line of it writes a file or invents a path
+/// — see `MarkdownTextViewDelegate` for why that split is load-bearing.
+extension MarkdownTextView {
+
+    /// Everything the document surface is willing to be a drop target for, on
+    /// top of whatever `NSTextView` already claims for text drags.
+    ///
+    /// `.fileURL` covers Finder, Preview, and any app that drags a real file.
+    /// The four image types cover the other half of the story — an image
+    /// dragged straight out of a browser or a preview window arrives as bytes
+    /// with no file behind them at all.  They are `CapturedImage`'s
+    /// passthrough set plus TIFF, which is what AppKit itself hands over when
+    /// the source app offers nothing more specific.
+    ///
+    /// Deliberately *not* here: file promises and `public.url`.  Both mean
+    /// "there will be a file, later, if you ask the network or the source app
+    /// for it", and a drop that silently starts a download is not something
+    /// this app should do without the remote-asset trust prompt the reader
+    /// would normally see first.
+    static let documentDropTypes: [NSPasteboard.PasteboardType] = [
+        .fileURL, .png, .tiff,
+        NSPasteboard.PasteboardType("public.jpeg"),
+        NSPasteboard.PasteboardType("public.heic"),
+    ]
+
+    /// `NSTextView` recomputes its drag registration whenever editability or
+    /// `importsGraphics` changes — which happens on every mode switch, because
+    /// `applyModeChrome` assigns `isEditable` from the mode's policy.  Adding
+    /// our types in the initialiser instead would work exactly once and then
+    /// be silently wiped the first time the reader pressed ⇧⌘E.  Overriding
+    /// the method AppKit calls is the only registration that survives.
+    public override func updateDragTypeRegistration() {
+        super.updateDragTypeRegistration()
+        // Additive, and idempotent: whatever `super` decided to register for
+        // text drags is kept, our types are added exactly once, and — this is
+        // the part that has to be explicit — they are *removed* again when the
+        // surface stops being editable.  A drop is a source mutation, and a
+        // read-only surface accepts none; leaving the types behind from a
+        // previous mode would make Read mode editable through the one door
+        // nobody thought to lock.
+        let ours = MarkdownTextView.documentDropTypes
+        var types = registeredDraggedTypes.filter { !ours.contains($0) }
+        if isEditable { types += ours }
+        // `registerForDraggedTypes([])` is not the same as unregistering —
+        // AppKit treats the empty array as "nothing to add" and leaves the
+        // previous list in place, which is how a surface that had just become
+        // read-only kept advertising itself as a drop target.
+        if types.isEmpty {
+            unregisterDraggedTypes()
+        } else {
+            registerForDraggedTypes(types)
+        }
+    }
+
+    /// The drop point, converted once, the only way it may be converted.
+    ///
+    /// `sourceOffset(at:)` routes through `DisplayMap`, and reusing the raw
+    /// TextKit index instead is the bug this feature is most likely to ship
+    /// with — precisely because it would look right.  The layout map pads
+    /// every hidden marker run out with zero-width joiners so hit testing
+    /// stays aligned, so on most documents the two numbers are equal.  They
+    /// come apart wherever a substitution genuinely changes length inside the
+    /// paragraph being dropped into: a footnote reference is four source
+    /// characters drawn as one superscript, and after three of them the image
+    /// lands nine characters early, in the middle of a word.
+    private func drop(for sender: NSDraggingInfo) -> DocumentDrop {
+        DocumentDrop(
+            pasteboard: sender.draggingPasteboard,
+            sourceOffset: sourceOffset(at: convert(sender.draggingLocation, from: nil))
+        )
+    }
+
+    public override func draggingEntered(_ sender: NSDraggingInfo) -> NSDragOperation {
+        let candidate = drop(for: sender)
+        claimsActiveDrag = isEditable
+            && markdownDelegate?.markdownTextView(self, canAcceptDrop: candidate) == true
+        guard claimsActiveDrag else {
+            setDropInsertionOffset(nil)
+            return super.draggingEntered(sender)
+        }
+        setDropInsertionOffset(candidate.sourceOffset)
+        return .copy
+    }
+
+    public override func draggingUpdated(_ sender: NSDraggingInfo) -> NSDragOperation {
+        // A drag's pasteboard cannot change while it is in flight, so the
+        // claim made on entry stands for the whole drag.  Only the position
+        // is re-resolved, which is what the reader is actually moving.
+        guard claimsActiveDrag else { return super.draggingUpdated(sender) }
+        setDropInsertionOffset(drop(for: sender).sourceOffset)
+        return .copy
+    }
+
+    public override func draggingExited(_ sender: NSDraggingInfo?) {
+        setDropInsertionOffset(nil)
+        guard claimsActiveDrag else {
+            super.draggingExited(sender)
+            return
+        }
+        claimsActiveDrag = false
+    }
+
+    public override func prepareForDragOperation(_ sender: NSDraggingInfo) -> Bool {
+        claimsActiveDrag ? true : super.prepareForDragOperation(sender)
+    }
+
+    public override func performDragOperation(_ sender: NSDraggingInfo) -> Bool {
+        guard claimsActiveDrag else { return super.performDragOperation(sender) }
+        // Resolve the position one last time from the release point rather
+        // than trusting the last `draggingUpdated`: AppKit coalesces drag
+        // updates, and on a fast flick the release can land a line or two
+        // past the last position the caret was drawn at.
+        let released = drop(for: sender)
+        setDropInsertionOffset(nil)
+        claimsActiveDrag = false
+        return markdownDelegate?.markdownTextView(self, didAcceptDrop: released) == true
+    }
+
+    public override func concludeDragOperation(_ sender: NSDraggingInfo?) {
+        setDropInsertionOffset(nil)
+        claimsActiveDrag = false
+        super.concludeDragOperation(sender)
+    }
+
+    /// Moves the drop caret, repainting only the two lines it can have been on.
+    ///
+    /// A full `needsDisplay` here would redraw the whole visible page on every
+    /// `draggingUpdated`, and AppKit sends those continuously while the
+    /// pointer is inside the view even when it has not moved (§12).
+    private func setDropInsertionOffset(_ offset: Int?) {
+        guard offset != dropInsertionOffset else { return }
+        let previous = dropInsertionOffset
+        dropInsertionOffset = offset
+        for candidate in [previous, offset] {
+            guard let candidate, let rect = dropCaretRect(at: candidate) else {
+                needsDisplay = true
+                return
+            }
+            setNeedsDisplay(rect.insetBy(dx: -3, dy: -3))
+        }
+    }
+
+    /// Where the drop caret is drawn for a source offset, in view coordinates.
+    private func dropCaretRect(at sourceOffset: Int) -> NSRect? {
+        let width: CGFloat = 2
+        if let rect = rect(forOffset: sourceOffset) {
+            return NSRect(x: rect.minX - width / 2, y: rect.minY, width: width, height: rect.height)
+        }
+        // The very end of the document has no character to measure, so fall
+        // back to the trailing edge of the last one.  Without this the caret
+        // simply vanishes when the reader aims past the final line, which
+        // reads as "this drop will not work" for the one target that always
+        // does.
+        guard sourceOffset > 0, let rect = rect(forOffset: sourceOffset - 1) else { return nil }
+        return NSRect(x: rect.maxX - width / 2, y: rect.minY, width: width, height: rect.height)
+    }
+
+    /// The insertion indicator, drawn in the accent colour so it reads as the
+    /// same "this is where it goes" mark the caret is, without being mistaken
+    /// for the caret itself — it is twice as wide and it does not blink.
+    func drawDropInsertionCaret(in dirtyRect: NSRect) {
+        guard let offset = dropInsertionOffset, let rect = dropCaretRect(at: offset),
+              rect.intersects(dirtyRect) else { return }
+        styleSheet.accent.setFill()
+        NSBezierPath(roundedRect: rect, xRadius: 1, yRadius: 1).fill()
+    }
+}
+
+// MARK: - Quick Look (§7.1)
+
+/// Two ways into one preview: a force click on a path or a local link, and the
+/// Quick Look command.  Both resolve a `ContextTarget` — the same "what is
+/// under here" table the context menu is built from, so a force click and a
+/// right-click can never disagree about what the reader is pointing at — and
+/// hand it to the app, which owns the panel.
+extension MarkdownTextView {
+
+    /// AppKit turns a force click into `quickLook(with:)` —
+    /// `quickLookWithEvent:` in Objective-C, which is the name everything
+    /// written about this uses.  The pressure stages themselves are
+    /// `NSTextView`'s business and are deliberately left alone: implementing
+    /// `pressureChange(with:)` here would mean taking over the gesture
+    /// recognition that produces this call in the first place, for no gain.
+    /// The event already carries the location, and the only decision to make
+    /// is what is underneath it.
+    ///
+    /// Falling through to `super` is the important half.  A force click on an
+    /// ordinary word is the standard macOS Look Up popover, and `NSTextView`
+    /// gives us that for free as long as we hand back every click that is not
+    /// aimed at something we can preview.
+    public override func quickLook(with event: NSEvent) {
+        let point = convert(event.locationInWindow, from: nil)
+        if let target = quickLookTarget(at: point),
+           markdownDelegate?.markdownTextView(self, wantsQuickLookFor: target) == true {
+            return
+        }
+        super.quickLook(with: event)
+    }
+
+    /// A previewable thing under a point, or nil for anything else.
+    ///
+    /// Narrower than `contextTarget(at:offset:)` on purpose: a heading, a
+    /// table, a code block and a bare word all have context menus but none of
+    /// them is a file, and returning one of those would swallow the force
+    /// click that should have opened the dictionary.
+    ///
+    /// The context menu's own answer is preferred, so a force click and a
+    /// right-click name the same thing whenever they can.  It is only the
+    /// *first* answer, though, because it is gated on `renderedTextContains`,
+    /// which refuses a hit whose glyph rectangle it cannot confirm.  That gate
+    /// exists to stop hover underlining the whitespace after a link, and it is
+    /// the right trade for a pointer drifting across a page — but a force
+    /// click is not a drift.  The reader pressed, deliberately, on one word.
+    /// Falling back to the attribute run at the resolved source offset means
+    /// the gesture answers wherever the source says there is a link or a path,
+    /// and it cannot over-fire: prose carries neither attribute, so Look Up
+    /// still gets every ordinary word.
+    func quickLookTarget(at point: NSPoint) -> ContextTarget? {
+        let offset = sourceOffset(at: point)
+        return previewable(contextTarget(at: point, offset: offset))
+            ?? previewableTarget(atSourceOffset: offset)
+    }
+
+    /// What a Quick Look at the current selection would preview.
+    ///
+    /// Public because the app's Quick Look command needs the same answer the
+    /// force click gets, and the attribute runs that hold links, paths, and
+    /// image fragments live here.  A collapsed selection only counts when the
+    /// surface actually has an insertion point the reader placed: in Read mode
+    /// `sourceSelectedRange` is `{0, 0}` whether or not anyone has touched the
+    /// document, and previewing whatever happens to sit at offset zero because
+    /// a key was pressed is not a feature.
+    public func quickLookTargetAtSelection() -> ContextTarget? {
+        let selection = sourceSelectedRange
+        guard selection.length > 0 || primarySourceCaret != nil else { return nil }
+        // Scanned from the start of the selection so a selection that begins
+        // on a link and runs into the prose after it still previews the link.
+        return previewableTarget(atSourceOffset: selection.location)
+    }
+
+    /// The previewable attribute run at a source offset, geometry not
+    /// consulted.  Shared by the force click's fallback and by the command, so
+    /// "the caret is on a link" means one thing in both.
+    private func previewableTarget(atSourceOffset offset: Int) -> ContextTarget? {
+        if let hit = attribute(.drPathToken, atSourceOffset: offset), let token = hit.value as? PathToken {
+            return ContextTarget(kind: .pathToken(token), sourceRange: hit.range, hitOffset: offset)
+        }
+        if let payload = fragmentPayload(atSourceOffset: offset)?.payload, payload.kind == .image {
+            return ContextTarget(
+                kind: .image(payload.detail), sourceRange: payload.sourceRange, hitOffset: offset
+            )
+        }
+        if let hit = attribute(.drLink, atSourceOffset: offset), let destination = hit.value as? String {
+            return ContextTarget(kind: .link(destination), sourceRange: hit.range, hitOffset: offset)
+        }
+        return nil
+    }
+
+    /// Space, but only where it can never be a character.
+    ///
+    /// Space is the keyboard's most dangerous binding to spend, so it is not
+    /// spent in the command table at all — a table entry is remappable, is
+    /// evaluated against a scope the app computes, and would be one refactor
+    /// away from firing while somebody is typing.  The guard that matters is
+    /// `isEditable`, which is the *same fact* that decides whether this view
+    /// has an insertion point, read straight off the view microseconds before
+    /// the decision.  On an editable surface this method returns false before
+    /// it looks at anything else, and the space becomes a space.
+    ///
+    /// ⌘Y — the chord Finder, Mail and Photos all use — is the trigger the
+    /// reader actually gets in Downright today, because Read mode is no longer
+    /// one of `RenderMode.userFacingModes`.  This path stays because the
+    /// package still ships a read-only surface (§10's Quick Look extension),
+    /// and because "Space previews" should be true the moment a read-only
+    /// document view exists again rather than discovered missing then.
+    func handleQuickLookSpace(_ event: NSEvent) -> Bool {
+        guard !isEditable, event.keyCode == 49,
+              event.modifierFlags.intersection(.deviceIndependentFlagsMask).isEmpty,
+              let target = quickLookTargetAtSelection() else { return false }
+        return markdownDelegate?.markdownTextView(self, wantsQuickLookFor: target) == true
+    }
+
+    private func previewable(_ target: ContextTarget) -> ContextTarget? {
+        switch target.kind {
+        case .pathToken, .image, .link: return target
+        case .heading, .codeBlock, .table, .selection, .plain: return nil
+        }
+    }
+}

--- a/Sources/MarkdownRender/View/MarkdownTextView.swift
+++ b/Sources/MarkdownRender/View/MarkdownTextView.swift
@@ -495,6 +495,20 @@ public final class MarkdownTextView: NSTextView {
     /// wipes attributes on every reflow and an underline that vanishes while
     /// the pointer is still sitting on it reads as a bug (§7.1).
     var hoveredLinkRange: NSRange?
+    /// Where a drag hovering over the surface would land, in *source*
+    /// coordinates, or nil when no drag is over it.
+    ///
+    /// Drawn as a drop caret in `draw(_:)` for the same reason the hovered
+    /// link underline is: a drop indicator written into the storage would be
+    /// wiped by the next decoration pass, and a document being dragged over is
+    /// a document whose fragments are still being materialized.
+    var dropInsertionOffset: Int?
+    /// True between `draggingEntered` and the end of the drag when the host
+    /// claimed the pasteboard.  A drag's payload cannot change once it is in
+    /// flight, so the expensive question — which reaches the filesystem — is
+    /// asked once and the answer held, instead of re-asked on every one of the
+    /// dozens of `draggingUpdated` calls a slow drag across a page produces.
+    var claimsActiveDrag = false
     /// Set while an input method is composing.  Substitutions are suspended in
     /// that paragraph so the hybrid and source spaces coincide and AppKit's own
     /// marked-text machinery stays correct.
@@ -1622,7 +1636,11 @@ public final class MarkdownTextView: NSTextView {
         case .none:
             guard appliedSourceFocus != .none else { return }
             let previous = sourcePresentationRange(for: appliedSourceFocus, in: whole)
-            if let previous { storage.removeAttribute(.drSourceFocus, range: previous) }
+            if let previous {
+                storage.beginEditing()
+                storage.removeAttribute(.drSourceFocus, range: previous)
+                storage.endEditing()
+            }
             appliedSourceFocus = .none
             return
         case .document:
@@ -1653,11 +1671,15 @@ public final class MarkdownTextView: NSTextView {
         }
         guard !applicationRanges.isEmpty else { return }
 
+        // One edit, not thousands.  Every `addAttribute` below posts its own
+        // edit notification otherwise, and on a whole-document switch to
+        // Source that is one notification per paragraph — which is where the
+        // switch was spending most of its time, not in the attributes.
+        storage.beginEditing()
+        defer { storage.endEditing() }
+
         var attributes = styleSheet.monoFontAttributes()
         attributes[.drSourceFocus] = true
-        for range in applicationRanges {
-            storage.addAttributes(attributes, range: range)
-        }
 
         let source = storage.string as NSString
         let paragraphs = RangeSet.normalized(applicationRanges.compactMap { range in
@@ -1666,28 +1688,83 @@ public final class MarkdownTextView: NSTextView {
             let upper = source.paragraphRange(for: NSRange(location: upperOffset, length: 0))
             return lower.union(upper).intersection(target)
         })
+        // Every paragraph in a source region wants the same style. Building a
+        // fresh one each time — twenty `NSTextTab`s among them — is the single
+        // most expensive thing in switching to Source: it dominated a 120 ms
+        // whole-document pass on a two-thousand-line file, and all but four of
+        // those objects were identical. The spacing pair is the only thing
+        // that varies, and only at the two ends of a scoped region, so cache
+        // on exactly that.
+        let lineHeight = styleSheet.lineHeight
+        let characterWidth = styleSheet.averageCharacterWidth
+        let tabStops: [NSTextTab] = stride(from: 4, through: 80, by: 4).map {
+            NSTextTab(textAlignment: .left,
+                      location: CGFloat($0) * characterWidth,
+                      options: [:])
+        }
+        var styleCache: [SourceParagraphSpacing: NSParagraphStyle] = [:]
+        func paragraphStyle(_ spacing: SourceParagraphSpacing) -> NSParagraphStyle {
+            if let cached = styleCache[spacing] { return cached }
+            let style = NSMutableParagraphStyle()
+            style.minimumLineHeight = lineHeight
+            style.maximumLineHeight = lineHeight
+            style.lineBreakMode = .byWordWrapping
+            style.paragraphSpacingBefore = spacing.before
+            style.paragraphSpacing = spacing.after
+            style.tabStops = tabStops
+            style.defaultTabInterval = characterWidth * 4
+            let immutable = style.copy() as! NSParagraphStyle
+            styleCache[spacing] = immutable
+            return immutable
+        }
+
+        // Whole-document Source asks for the same style on every paragraph, so
+        // the font, the ligature setting, the focus mark and that one style can
+        // all go on in a single pass.  Separately, the two used to be a
+        // whole-document `addAttributes` followed by one `addAttribute` per
+        // paragraph — several thousand of them on a large file, each one
+        // re-walking the storage's attribute runs.  Merged, the storage's runs
+        // are rewritten once.
+        //
+        // Only the unscoped pass qualifies: a scoped region's first and last
+        // paragraphs carry the region's own air, so those two genuinely differ
+        // from the rest and the walk below is what finds them.
+        if !scoped {
+            attributes[.paragraphStyle] = paragraphStyle(
+                SourceParagraphSpacing(before: 0, after: 0))
+            for paragraphsRange in paragraphs {
+                storage.addAttributes(attributes, range: paragraphsRange)
+            }
+            return
+        }
+
+        for range in applicationRanges {
+            storage.addAttributes(attributes, range: range)
+        }
+
         for paragraphsRange in paragraphs {
             var cursor = paragraphsRange.location
             while cursor < paragraphsRange.upperBound {
                 let paragraph = source.paragraphRange(for: NSRange(location: cursor, length: 0))
                     .intersection(target) ?? NSRange(location: cursor, length: 0)
                 guard paragraph.length > 0 else { break }
-                let style = NSMutableParagraphStyle()
-                style.minimumLineHeight = styleSheet.lineHeight
-                style.maximumLineHeight = styleSheet.lineHeight
-                style.lineBreakMode = .byWordWrapping
-                style.paragraphSpacingBefore = scoped && cursor == target.location ? 28 : 0
-                style.paragraphSpacing = scoped && paragraph.upperBound >= target.upperBound ? 8 : 0
-                style.tabStops = stride(from: 4, through: 80, by: 4).map {
-                    NSTextTab(textAlignment: .left,
-                              location: CGFloat($0) * styleSheet.averageCharacterWidth,
-                              options: [:])
-                }
-                style.defaultTabInterval = styleSheet.averageCharacterWidth * 4
-                storage.addAttribute(.paragraphStyle, value: style, range: paragraph)
+                let spacing = SourceParagraphSpacing(
+                    before: scoped && cursor == target.location ? 28 : 0,
+                    after: scoped && paragraph.upperBound >= target.upperBound ? 8 : 0
+                )
+                storage.addAttribute(
+                    .paragraphStyle, value: paragraphStyle(spacing), range: paragraph
+                )
                 cursor = paragraph.upperBound
             }
         }
+    }
+
+    /// The only thing that varies between source paragraphs, and only at the
+    /// first and last paragraph of a scoped region.
+    private struct SourceParagraphSpacing: Hashable {
+        let before: CGFloat
+        let after: CGFloat
     }
 
     private func sourcePresentationRange(for focus: SourceFocus, in whole: NSRange) -> NSRange? {
@@ -2619,6 +2696,7 @@ public final class MarkdownTextView: NSTextView {
             return
         }
         if keyEventHandler?(event) == true { return }
+        if handleQuickLookSpace(event) { return }
         super.keyDown(with: event)
     }
 
@@ -3043,6 +3121,13 @@ public final class MarkdownTextView: NSTextView {
 
     public override func scrollWheel(with event: NSEvent) {
         interruptAnimatedScroll()
+        // The host gets first refusal on every scroll event: this surface
+        // only scrolls vertically, so the horizontal axis is free for a
+        // gesture the app owns.  Only a claimed event is withheld, so ordinary
+        // scrolling never waits on the decision.
+        if markdownDelegate?.markdownTextView(self, shouldClaimScrollGesture: event) == true {
+            return
+        }
         super.scrollWheel(with: event)
     }
 
@@ -3146,6 +3231,7 @@ public final class MarkdownTextView: NSTextView {
         drawDeletedChangeMarks(in: dirtyRect)
         drawObjectChangeMarks(in: dirtyRect)
         drawHoveredLinkUnderline(in: dirtyRect)
+        drawDropInsertionCaret(in: dirtyRect)
     }
 
     /// Underlines the link under the pointer.  Drawn after the text so it sits
@@ -3315,6 +3401,13 @@ public final class MarkdownTextView: NSTextView {
 
     private func applyModeChrome() {
         isEditable = mode.policy.showsInsertionPoint
+        // `NSTextView` refreshes its drag registration when editability
+        // *changes*, and the mode this view is constructed in is very often
+        // the one it stays in — so the document's own drop types would never
+        // be registered at all without asking for the refresh explicitly.  It
+        // is idempotent; see `updateDragTypeRegistration` in
+        // `MarkdownTextView+Interaction`.
+        updateDragTypeRegistration()
         isSelectable = true
         insertionPointColor = mode.policy.showsInsertionPoint ? styleSheet.accent : styleSheet.text
         typingAttributes = [

--- a/Sources/MarkdownRender/View/MarkdownTextViewDelegate.swift
+++ b/Sources/MarkdownRender/View/MarkdownTextViewDelegate.swift
@@ -35,6 +35,36 @@ public struct ContextTarget {
     }
 }
 
+/// A drag hovering over — or dropped on — the document surface.
+///
+/// The pasteboard is handed over undecoded on purpose.  Deciding what a
+/// dropped file *means* is a question about a document on disk and a folder
+/// beside it: whether the file is already inside the document's own directory,
+/// whether it has to be copied in, what a portable destination for it looks
+/// like.  This package has neither a document nor a filesystem, so it resolves
+/// the one thing it does own — where in the *source* the pointer is — and
+/// leaves everything else to the app (§10 keeps the Quick Look extension
+/// buildable against exactly that boundary).
+public struct DocumentDrop {
+    public let pasteboard: NSPasteboard
+    /// Source UTF-16 offset under the pointer, already converted out of
+    /// TextKit's hybrid space by `DisplayMap`.
+    ///
+    /// This is the value the whole feature turns on, and it is dangerous
+    /// because it is *usually* equal to the raw TextKit index: the layout map
+    /// pads hidden marker runs out with zero-width joiners on purpose, so hit
+    /// testing stays aligned on an ordinary page.  Where a substitution really
+    /// does change length in the paragraph under the pointer — a footnote
+    /// reference is four source characters drawn as one superscript — the two
+    /// part company, and an insertion made from the wrong one lands mid-word.
+    public let sourceOffset: Int
+
+    public init(pasteboard: NSPasteboard, sourceOffset: Int) {
+        self.pasteboard = pasteboard
+        self.sourceOffset = sourceOffset
+    }
+}
+
 /// Everything the text surface hands back to the app.
 ///
 /// The render package owns no windows, no files, and no editor integrations —
@@ -64,6 +94,31 @@ public protocol MarkdownTextViewDelegate: AnyObject {
     func markdownTextView(_ view: MarkdownTextView, didNavigateTo destination: Int)
     func markdownTextView(_ view: MarkdownTextView, didRequestTextSizeSteps steps: Int)
     func markdownTextViewDidRequestSmartTextZoom(_ view: MarkdownTextView)
+    /// Every scroll event, offered to the host before the scroll view sees
+    /// it.  The document surface has no horizontal axis of its own, so a
+    /// sideways gesture over it is the host's to claim — today the
+    /// Document/Source swipe.  Return `true` to consume the event; a host that
+    /// is still deciding must return `false` so ordinary scrolling never waits
+    /// on it.
+    func markdownTextView(_ view: MarkdownTextView, shouldClaimScrollGesture event: NSEvent) -> Bool
+    /// Asked once when a drag arrives over the surface, and again nowhere
+    /// else: the answer cannot change while one drag is in flight, and this
+    /// question reaches the filesystem.  Returning `true` makes the view take
+    /// the drag over from `NSTextView` — it stops offering to insert the
+    /// pasteboard's text and starts drawing a drop caret instead.
+    func markdownTextView(_ view: MarkdownTextView, canAcceptDrop drop: DocumentDrop) -> Bool
+    /// The drag was released.  The app writes whatever files it needs to and
+    /// makes exactly one undoable source mutation at `drop.sourceOffset`.
+    /// Returning `false` reports the drop as failed, which is what AppKit
+    /// needs in order to animate the item back to where it came from.
+    func markdownTextView(_ view: MarkdownTextView, didAcceptDrop drop: DocumentDrop) -> Bool
+    /// A force click, or the Quick Look command, landed on something.
+    ///
+    /// Return `true` only if the app actually opened a preview.  `false` means
+    /// "not previewable", and the view then falls back to whatever AppKit
+    /// would have done — for a force click that is the standard Look Up
+    /// popover, which must keep working on an ordinary word.
+    func markdownTextView(_ view: MarkdownTextView, wantsQuickLookFor target: ContextTarget) -> Bool
 }
 
 /// Defaults so a host that only cares about links does not have to implement
@@ -85,4 +140,8 @@ public extension MarkdownTextViewDelegate {
     func markdownTextView(_ view: MarkdownTextView, didNavigateTo destination: Int) {}
     func markdownTextView(_ view: MarkdownTextView, didRequestTextSizeSteps steps: Int) {}
     func markdownTextViewDidRequestSmartTextZoom(_ view: MarkdownTextView) {}
+    func markdownTextView(_ view: MarkdownTextView, shouldClaimScrollGesture event: NSEvent) -> Bool { false }
+    func markdownTextView(_ view: MarkdownTextView, canAcceptDrop drop: DocumentDrop) -> Bool { false }
+    func markdownTextView(_ view: MarkdownTextView, didAcceptDrop drop: DocumentDrop) -> Bool { false }
+    func markdownTextView(_ view: MarkdownTextView, wantsQuickLookFor target: ContextTarget) -> Bool { false }
 }

--- a/Sources/drdownright/AgentBridge.swift
+++ b/Sources/drdownright/AgentBridge.swift
@@ -93,9 +93,31 @@ public enum AgentBridge {
 
     /// The shell command a hook runs.  `notify` reads the payload on stdin, so
     /// the hook needs no `jq`, no shell quoting, and no per-tool special casing.
+    ///
+    /// The executable is POSIX single-quoted (with the usual `'\''` escape)
+    /// rather than double-quoted: a double-quoted string still expands `$`,
+    /// backticks, and backslashes when the agent's hook runner shells out, so
+    /// an unusual install path could smuggle command substitution into
+    /// settings.json.
     public static func hookCommand(executable: String = "down") -> String {
-        let quoted = executable.contains(" ") ? "\"\(executable)\"" : executable
+        let quoted = "'" + executable.replacingOccurrences(of: "'", with: "'\\''") + "'"
         return "\(quoted) notify"
+    }
+
+    /// Command strings earlier builds wrote for this executable: the bare
+    /// path and a double-quoted variant.  Recognizing them lets an upgrade
+    /// find its own previous hook instead of appending a duplicate next to it,
+    /// and lets an uninstall remove it instead of leaving debris.
+    private static func legacyHookCommands(executable: String) -> [String] {
+        [executable + " notify", "\"\(executable)\" notify"]
+    }
+
+    /// Every command string that counts as this app's hook for the executable:
+    /// the canonical quoted form plus the pre-quoting legacy forms.
+    private static func ownedHookCommands(executable: String) -> Set<String> {
+        var commands = Set(legacyHookCommands(executable: executable))
+        commands.insert(hookCommand(executable: executable))
+        return commands
     }
 
     /// One `PostToolUse` entry in Claude Code's settings schema.
@@ -113,7 +135,7 @@ public enum AgentBridge {
     /// a user who edits it by hand or checks one into a project must not find
     /// the app disagreeing with reality.
     public static func isHookInstalled(in settings: [String: Any], executable: String = "down") -> Bool {
-        let command = hookCommand(executable: executable)
+        let commands = ownedHookCommands(executable: executable)
         let entries = (settings["hooks"] as? [String: Any])?["PostToolUse"] as? [[String: Any]] ?? []
         return entries.contains { entry in
             // Our hook is identified by its matcher *and* its command.  A
@@ -123,7 +145,7 @@ public enum AgentBridge {
             entry["matcher"] as? String == toolMatcher
                 && (entry["hooks"] as? [[String: Any]] ?? [])
                     .compactMap { $0["command"] as? String }
-                    .contains(command)
+                    .contains { commands.contains($0) }
         }
     }
 
@@ -132,15 +154,56 @@ public enum AgentBridge {
     /// Idempotent, and deliberately additive: a user's `settings.json` is their
     /// own file with their own hooks in it, so this preserves every unrelated
     /// key, appends rather than replaces the `PostToolUse` array, and returns
-    /// the input unchanged when an equivalent hook is already installed.
+    /// the input unchanged when the canonical hook is already installed.  A
+    /// legacy-format entry of ours is migrated in place — replaced by the
+    /// canonical quoted command at the same position — rather than duplicated.
     public static func installingHook(
         into settings: [String: Any],
         executable: String = "down"
     ) -> (settings: [String: Any], changed: Bool) {
-        guard !isHookInstalled(in: settings, executable: executable) else { return (settings, false) }
         var settings = settings
         var hooks = settings["hooks"] as? [String: Any] ?? [:]
         var postToolUse = hooks["PostToolUse"] as? [[String: Any]] ?? []
+
+        let canonical = hookCommand(executable: executable)
+        let legacy = Set(legacyHookCommands(executable: executable))
+        func commands(in entry: [String: Any]) -> [String] {
+            (entry["hooks"] as? [[String: Any]] ?? []).compactMap { $0["command"] as? String }
+        }
+
+        // Canonical already present: nothing to do, even if a legacy entry
+        // somehow sits beside it (that combination means hands edited the
+        // file, and hands win).
+        if postToolUse.contains(where: { entry in
+            entry["matcher"] as? String == toolMatcher && commands(in: entry).contains(canonical)
+        }) {
+            return (settings, false)
+        }
+
+        // A legacy entry of ours: migrate it to the canonical form where it
+        // stands instead of appending a second hook that fires twice.
+        var migrated = false
+        postToolUse = postToolUse.map { entry in
+            guard entry["matcher"] as? String == toolMatcher,
+                  commands(in: entry).contains(where: legacy.contains)
+            else { return entry }
+            migrated = true
+            var updated = entry
+            updated["hooks"] = (entry["hooks"] as? [[String: Any]] ?? []).map { hook -> [String: Any] in
+                guard let command = hook["command"] as? String, legacy.contains(command) else {
+                    return hook
+                }
+                var replacement = hook
+                replacement["command"] = canonical
+                return replacement
+            }
+            return updated
+        }
+        if migrated {
+            hooks["PostToolUse"] = postToolUse
+            settings["hooks"] = hooks
+            return (settings, true)
+        }
 
         postToolUse.append(hookEntry(executable: executable))
         hooks["PostToolUse"] = postToolUse
@@ -159,7 +222,7 @@ public enum AgentBridge {
               let postToolUse = hooks["PostToolUse"] as? [[String: Any]]
         else { return (settings, false) }
 
-        let command = hookCommand(executable: executable)
+        let commands = ownedHookCommands(executable: executable)
         var changed = false
         var remaining: [[String: Any]] = []
         for var entry in postToolUse {
@@ -170,9 +233,12 @@ public enum AgentBridge {
                 remaining.append(entry)
                 continue
             }
-            let commands = entry["hooks"] as? [[String: Any]] ?? []
-            let kept = commands.filter { ($0["command"] as? String) != command }
-            if kept.count != commands.count { changed = true }
+            let hooks = entry["hooks"] as? [[String: Any]] ?? []
+            let kept = hooks.filter { hook in
+                guard let command = hook["command"] as? String else { return true }
+                return !commands.contains(command)
+            }
+            if kept.count != hooks.count { changed = true }
             guard !kept.isEmpty else { continue }
             entry["hooks"] = kept
             remaining.append(entry)

--- a/Sources/drdownright/MarkdownCLI.swift
+++ b/Sources/drdownright/MarkdownCLI.swift
@@ -590,7 +590,7 @@ public enum MarkdownCLI {
         result = result.replacingOccurrences(of: #"\*([^*]+)\*"#, with: "<em>$1</em>", options: .regularExpression)
         result = replacingMatches(in: result, pattern: #"!\[([^\]]*)\]\(([^)]+)\)"#) { captures in
             let alt = captures[0]
-            let source = captures[1]
+            let source = removingURLLineBreaks(captures[1])
             guard imageSourceIsSafe(source) else {
                 return "<span class=\"missing-image\" title=\"\(source)\">\(alt)</span>"
             }
@@ -598,7 +598,7 @@ public enum MarkdownCLI {
         }
         result = replacingMatches(in: result, pattern: #"\[([^\]]+)\]\(([^)]+)\)"#) { captures in
             let label = captures[0]
-            let destination = captures[1]
+            let destination = removingURLLineBreaks(captures[1])
             guard linkDestinationIsSafe(destination) else {
                 return "<span title=\"\(destination)\">\(label)</span>"
             }
@@ -609,12 +609,28 @@ public enum MarkdownCLI {
 
     private static let linkSchemeAllowlist: Set<String> = ["http", "https", "mailto"]
 
+    /// Browsers strip tab, line feed, and carriage return from anywhere inside
+    /// a URL before parsing it, so `java\tscript:` reaches the browser as a
+    /// live `javascript:` scheme no matter how it was analyzed.  Normalizing
+    /// before analysis *and* emission means the safety check sees exactly what
+    /// the browser will act on, and the emitted HTML carries the same text.
+    private static func removingURLLineBreaks(_ value: String) -> String {
+        value.replacingOccurrences(of: "\t", with: "")
+            .replacingOccurrences(of: "\n", with: "")
+            .replacingOccurrences(of: "\r", with: "")
+    }
+
     private static func linkDestinationIsSafe(_ destination: String) -> Bool {
-        let trimmed = destination.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let trimmed = removingURLLineBreaks(destination)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
         guard let colon = trimmed.firstIndex(of: ":") else { return true }
         let prefix = String(trimmed[..<colon])
         if prefix.rangeOfCharacter(from: CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "+-.")).inverted) != nil {
-            return !prefix.contains("javascript") && !prefix.contains("data") && !prefix.contains("vbscript")
+            // A character a URL scheme cannot contain means this parses as a
+            // relative path (browsers never treat it as a scheme), so it is
+            // inert by construction — no fuzzy substring block needed.
+            return true
         }
         return linkSchemeAllowlist.contains(prefix)
     }
@@ -622,7 +638,7 @@ public enum MarkdownCLI {
     private static func imageSourceIsSafe(_ source: String) -> Bool {
         guard !source.hasPrefix("/"),
               !source.hasPrefix("\\"),
-              !hasURLScheme(source)
+              !hasURLScheme(removingURLLineBreaks(source))
         else { return false }
         let decoded = source.removingPercentEncoding ?? source
         let path = decoded

--- a/Tests/DownrightAppTests/AppLayerTests.swift
+++ b/Tests/DownrightAppTests/AppLayerTests.swift
@@ -548,6 +548,52 @@ struct AppLayerTests {
         )
     }
 
+    /// "Open in your editor" never means "run it": execution-capable targets
+    /// linked from a document must be classified so every open path reveals
+    /// them in Finder instead of handing them to LaunchServices.
+    @Test func executableTargetsAreClassifiedForRevealInsteadOfLaunch() throws {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("downright-exec-classify-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        func write(_ name: String, _ bytes: Data, permissions: Int? = nil) throws -> URL {
+            let url = root.appendingPathComponent(name)
+            try bytes.write(to: url)
+            if let permissions {
+                try FileManager.default.setAttributes(
+                    [.posixPermissions: NSNumber(value: permissions)], ofItemAtPath: url.path
+                )
+            }
+            return url
+        }
+
+        // Application bundles and Terminal-run scripts execute on open.
+        let bundle = root.appendingPathComponent("Evil.app", isDirectory: true)
+        try FileManager.default.createDirectory(at: bundle, withIntermediateDirectories: true)
+        #expect(DocumentTypes.executesWhenOpened(bundle))
+        #expect(try DocumentTypes.executesWhenOpened(
+            write("run.tool", Data("#!/bin/sh\necho hi\n".utf8))
+        ))
+        // An executable bit with no extension at all is a raw binary/script.
+        #expect(try DocumentTypes.executesWhenOpened(
+            write("deploy", Data("#!/bin/sh\necho hi\n".utf8), permissions: 0o755)
+        ))
+
+        // Documents — including executable-bit scripts with a document-ish
+        // extension, which open in an editor — do not execute.
+        #expect(try !DocumentTypes.executesWhenOpened(write("notes.md", Data("# hi\n".utf8))))
+        #expect(try !DocumentTypes.executesWhenOpened(
+            write("build.sh", Data("#!/bin/sh\n".utf8), permissions: 0o755)
+        ))
+        #expect(try !DocumentTypes.executesWhenOpened(
+            write("diagram.png", Data("\u{89}PNG".utf8))
+        ))
+        let folder = root.appendingPathComponent("assets", isDirectory: true)
+        try FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true)
+        #expect(!DocumentTypes.executesWhenOpened(folder))
+    }
+
     @Test @MainActor
     func pathResolverWarmsCacheAndReturnsOnMainQueue() async throws {
         let root = URL(fileURLWithPath: NSTemporaryDirectory())

--- a/Tests/DownrightAppTests/AppLayerTests.swift
+++ b/Tests/DownrightAppTests/AppLayerTests.swift
@@ -180,7 +180,7 @@ struct AppLayerTests {
         await store.pruneOneGenerationForTesting()
     }
 
-    @Test func pruneForgetsOldHistoryForMissingDocument() async throws {
+    @Test func pruneKeepsNewestHistoryForMissingDocument() async throws {
         let root = URL(fileURLWithPath: NSTemporaryDirectory())
             .appendingPathComponent("downright-prune-\(UUID().uuidString)", isDirectory: true)
         defer { try? FileManager.default.removeItem(at: root) }
@@ -194,59 +194,10 @@ struct AppLayerTests {
         await store.waitForPendingWrites()
         try ageSnapshotIndex(file, by: 90 * 24 * 60 * 60)
         await runSnapshotPrune(store)
-        #expect(FileManager.default.fileExists(atPath: file.path), "one ENOENT can be an atomic replacement gap")
-        await runSnapshotPrune(store)
-        #expect(!FileManager.default.fileExists(atPath: file.path))
-
-        #expect(
-            store.record(text, for: url, kind: .baseline) != nil,
-            "deleting an abandoned index must atomically invalidate its loaded newest-hash cache"
-        )
-        await store.waitForPendingWrites()
-        #expect(FileManager.default.fileExists(atPath: file.path))
-    }
-
-    @Test func pruneRequiresConsecutiveAbsenceAndForgetsARestoredGap() async throws {
-        let root = URL(fileURLWithPath: NSTemporaryDirectory())
-            .appendingPathComponent("downright-prune-gap-\(UUID().uuidString)", isDirectory: true)
-        defer { try? FileManager.default.removeItem(at: root) }
-        let historyDirectory = root.appendingPathComponent("history", isDirectory: true)
-        let store = SnapshotStore(historyDirectory: historyDirectory)
-        let url = root.appendingPathComponent("temporarily-missing.md")
-        let file = snapshotIndexFile(for: url, historyDirectory: historyDirectory)
-        try writeSnapshotIndex(path: url.path, age: 90 * 24 * 60 * 60, to: file)
-
-        await runSnapshotPrune(store)
-        try Data("restored\n".utf8).write(to: url)
-        await runSnapshotPrune(store)
-        try FileManager.default.removeItem(at: url)
-        await runSnapshotPrune(store)
-        #expect(FileManager.default.fileExists(atPath: file.path), "a restored path resets absence confirmation")
-        await runSnapshotPrune(store)
-        #expect(!FileManager.default.fileExists(atPath: file.path))
-    }
-
-    @Test func pruneKeepsHistoryWhenPathLookupIsUnreadable() async throws {
-        let root = URL(fileURLWithPath: NSTemporaryDirectory())
-            .appendingPathComponent("downright-prune-permission-\(UUID().uuidString)", isDirectory: true)
-        let locked = root.appendingPathComponent("locked", isDirectory: true)
-        try FileManager.default.createDirectory(at: locked, withIntermediateDirectories: true)
-        defer {
-            try? FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: locked.path)
-            try? FileManager.default.removeItem(at: root)
-        }
-        let target = locked.appendingPathComponent("document.md")
-        try Data("private\n".utf8).write(to: target)
-        let historyDirectory = root.appendingPathComponent("history", isDirectory: true)
-        let store = SnapshotStore(historyDirectory: historyDirectory)
-        let file = snapshotIndexFile(for: target, historyDirectory: historyDirectory)
-        try writeSnapshotIndex(path: target.path, age: 90 * 24 * 60 * 60, to: file)
-        try FileManager.default.setAttributes([.posixPermissions: 0], ofItemAtPath: locked.path)
-
-        #expect(SnapshotStore.pathPresence(for: target.path) == .indeterminate)
-        await runSnapshotPrune(store)
         await runSnapshotPrune(store)
         #expect(FileManager.default.fileExists(atPath: file.path))
+        #expect(store.versions(for: url).count == 1, "the newest version survives age pruning")
+        #expect(store.text(for: store.versions(for: url)[0]) == text)
     }
 
     @Test func pruneKeepsObjectsWhenIndexDirectoryCannotBeListed() async throws {
@@ -346,115 +297,23 @@ struct AppLayerTests {
         #expect(attributes[.modificationDate] as? Date == mark)
     }
 
-    @Test func abandonedReadingStateIsCollectedButLiveStateRemains() throws {
+    @Test func readingStatePersistsWhenDocumentIsMissing() throws {
         let root = URL(fileURLWithPath: NSTemporaryDirectory())
             .appendingPathComponent("downright-state-\(UUID().uuidString)", isDirectory: true)
-        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
-        defer { try? FileManager.default.removeItem(at: root) }
-
-        let live = root.appendingPathComponent("live.md")
-        try Data("# Live\n".utf8).write(to: live)
-        let recent = root.appendingPathComponent("recent.md")
-        let stale = root.appendingPathComponent("stale.md")
-        let supportDirectory = root.appendingPathComponent("support", isDirectory: true)
-        let store = DocumentStateStore(supportDirectory: supportDirectory)
-        func stateFile(_ url: URL) -> URL {
-            supportDirectory.appendingPathComponent("state", isDirectory: true)
-                .appendingPathComponent(SnapshotStore.documentKey(for: url) + ".json")
-        }
-        defer {
-            for url in [live, recent, stale] {
-                try? FileManager.default.removeItem(at: stateFile(url))
-            }
-        }
-
-        for url in [live, recent] {
-            var state = DocumentState(path: url.path)
-            state.lastOpened = Date()
-            store.save(state, for: url)
-        }
-        var oldState = DocumentState(path: stale.path)
-        oldState.lastOpened = .distantPast
-        store.save(oldState, for: stale)
-
-        store.pruneAbandonedStates()
-
-        #expect(FileManager.default.fileExists(atPath: stateFile(live).path))
-        #expect(FileManager.default.fileExists(atPath: stateFile(recent).path))
-        #expect(FileManager.default.fileExists(atPath: stateFile(stale).path))
-        store.pruneAbandonedStates()
-        #expect(!FileManager.default.fileExists(atPath: stateFile(stale).path))
-    }
-
-    @Test func readingStatePruneForgetsTransientAbsenceAfterRestore() throws {
-        let root = URL(fileURLWithPath: NSTemporaryDirectory())
-            .appendingPathComponent("downright-state-gap-\(UUID().uuidString)", isDirectory: true)
-        defer { try? FileManager.default.removeItem(at: root) }
-        let support = root.appendingPathComponent("support", isDirectory: true)
-        let store = DocumentStateStore(supportDirectory: support)
-        let document = root.appendingPathComponent("document.md")
-        let stateFile = support.appendingPathComponent("state", isDirectory: true)
-            .appendingPathComponent(SnapshotStore.documentKey(for: document) + ".json")
-        var state = DocumentState(path: document.path)
-        state.lastOpened = .distantPast
-        store.save(state, for: document)
-
-        store.pruneAbandonedStates()
-        try Data("restored\n".utf8).write(to: document)
-        store.pruneAbandonedStates()
-        try FileManager.default.removeItem(at: document)
-        store.pruneAbandonedStates()
-        #expect(FileManager.default.fileExists(atPath: stateFile.path))
-        store.pruneAbandonedStates()
-        #expect(!FileManager.default.fileExists(atPath: stateFile.path))
-    }
-
-    @Test func scheduledReadingStatePruneReachesDelayedConfirmation() async throws {
-        let root = URL(fileURLWithPath: NSTemporaryDirectory())
-            .appendingPathComponent("downright-state-scheduled-\(UUID().uuidString)", isDirectory: true)
-        defer { try? FileManager.default.removeItem(at: root) }
-        let support = root.appendingPathComponent("support", isDirectory: true)
-        let store = DocumentStateStore(
-            supportDirectory: support,
-            abandonedStateConfirmationDelay: 0.05
-        )
-        let document = root.appendingPathComponent("missing.md")
-        let stateFile = support.appendingPathComponent("state", isDirectory: true)
-            .appendingPathComponent(SnapshotStore.documentKey(for: document) + ".json")
-        var state = DocumentState(path: document.path)
-        state.lastOpened = .distantPast
-        store.save(state, for: document)
-
-        store.schedulePruneAbandonedStates()
-        let deadline = Date().addingTimeInterval(1)
-        while FileManager.default.fileExists(atPath: stateFile.path), Date() < deadline {
-            try await Task.sleep(for: .milliseconds(10))
-        }
-        #expect(!FileManager.default.fileExists(atPath: stateFile.path))
-    }
-
-    @Test func freshReadingStateCancelsPendingAbandonment() throws {
-        let root = URL(fileURLWithPath: NSTemporaryDirectory())
-            .appendingPathComponent("downright-state-refresh-\(UUID().uuidString)", isDirectory: true)
         defer { try? FileManager.default.removeItem(at: root) }
         let support = root.appendingPathComponent("support", isDirectory: true)
         let store = DocumentStateStore(supportDirectory: support)
         let document = root.appendingPathComponent("missing.md")
         let stateFile = support.appendingPathComponent("state", isDirectory: true)
             .appendingPathComponent(SnapshotStore.documentKey(for: document) + ".json")
-        var stale = DocumentState(path: document.path)
-        stale.lastOpened = .distantPast
-        store.save(stale, for: document)
-        store.pruneAbandonedStates()
-
-        var fresh = DocumentState(path: document.path)
-        fresh.lastOpened = Date()
-        fresh.selectionLocation = 42
-        store.save(fresh, for: document)
-        store.pruneAbandonedStates()
+        var state = DocumentState(path: document.path)
+        state.lastOpened = .distantPast
+        state.selectionLocation = 42
+        store.save(state, for: document)
 
         #expect(FileManager.default.fileExists(atPath: stateFile.path))
-        #expect(store.state(for: document).selectionLocation == 42)
+        let reopenedStore = DocumentStateStore(supportDirectory: support)
+        #expect(reopenedStore.state(for: document).selectionLocation == 42)
     }
 
     @Test func contentHashIsStable() {

--- a/Tests/DownrightAppTests/AsyncParseTests.swift
+++ b/Tests/DownrightAppTests/AsyncParseTests.swift
@@ -317,8 +317,12 @@ struct AsyncParseTests {
         #expect(document.parsed.text == "three\n")
     }
 
+    /// The architectural P0 invariant: the synchronous edit path never parses.
+    /// The 8 ms budget itself is a release measurement owned by drbench
+    /// (RUN_DRBENCH=1); asserting it here in a debug build only produced flaky
+    /// red runs on loaded machines, so the wall clock stays informational.
     @Test @MainActor
-    func sourceEditPathStaysUnderEightMillisecondsWithoutParsing() {
+    func sourceEditPathNeverParsesSynchronously() {
         let calls = WorkerCallCounter()
         let worker = MarkdownParseWorker { text, previous, revision in
             calls.increment()
@@ -343,8 +347,7 @@ struct AsyncParseTests {
         }
         durations.sort()
         let p95 = durations[94]
-        print("[typing response] p95 \(Double(p95) / 1_000_000) ms (budget 8.0 ms)")
-        #expect(p95 < 8_000_000)
+        print("[typing response] p95 \(Double(p95) / 1_000_000) ms (informational; budget enforced by drbench)")
         #expect(calls.value == 0)
     }
 }

--- a/Tests/DownrightAppTests/AutosaveLifecycleTests.swift
+++ b/Tests/DownrightAppTests/AutosaveLifecycleTests.swift
@@ -1,0 +1,105 @@
+import AppKit
+import Foundation
+import MarkdownCore
+import Testing
+@testable import DownrightApp
+
+/// The save boundary must never write a buffer the user declined to keep, and
+/// implicit saves must stop the moment the document (or the user's consent)
+/// ends.  These tests pin that boundary at both layers: the document refuses
+/// writes after close(), and the window's occlusion path is part of the
+/// autosave feature rather than an unconditional writer.
+@Suite("Autosave and close lifetime", .serialized)
+struct AutosaveLifecycleTests {
+    @Test @MainActor
+    func closedDocumentRefusesImplicitAndExplicitSaves() throws {
+        let fixture = try Fixture(text: "before\n")
+        defer { fixture.remove() }
+        let document = MarkdownDocument()
+        try document.open(fixture.url)
+        #expect(document.replace(
+            NSRange(location: 0, length: document.storage.length),
+            with: "after\n",
+            actionName: "Replace"
+        ))
+        document.close()
+
+        // A straggler implicit save (queued autosave work, occlusion during
+        // teardown) must be a silent no-op, not a resurrection of the buffer.
+        guard case .success = document.saveIfNeeded() else {
+            Issue.record("saving a closed document must not surface an error")
+            return
+        }
+        #expect(try String(contentsOf: fixture.url, encoding: .utf8) == "before\n")
+
+        // Even a direct save call finds no owner to consent to the write.
+        try document.save()
+        #expect(try String(contentsOf: fixture.url, encoding: .utf8) == "before\n")
+    }
+
+    @Test @MainActor
+    func occlusionSaveBelongsToTheAutosaveSetting() throws {
+        let fixture = try Fixture(text: "before\n")
+        defer { fixture.remove() }
+        let original = Preferences.shared.values.autosaveEnabled
+        defer { Preferences.shared.update { $0.autosaveEnabled = original } }
+
+        let controller = DocumentWindowController()
+        defer { controller.close() }
+        try controller.open(fixture.url, mode: .live)
+        #expect(controller.markdownDocument.replace(
+            NSRange(location: 0, length: controller.markdownDocument.storage.length),
+            with: "after\n",
+            actionName: "Replace"
+        ))
+
+        // Default (autosave off): covering or miniaturizing the window must
+        // not commit the buffer — an agent may be editing the same file.
+        Preferences.shared.update { $0.autosaveEnabled = false }
+        controller.windowDidChangeOcclusionState(Notification(
+            name: NSWindow.didChangeOcclusionStateNotification, object: controller.window
+        ))
+        #expect(try String(contentsOf: fixture.url, encoding: .utf8) == "before\n")
+        #expect(controller.markdownDocument.isDirty)
+
+        // With autosave enabled the occlusion save still works.
+        Preferences.shared.update { $0.autosaveEnabled = true }
+        controller.windowDidChangeOcclusionState(Notification(
+            name: NSWindow.didChangeOcclusionStateNotification, object: controller.window
+        ))
+        #expect(try String(contentsOf: fixture.url, encoding: .utf8) == "after\n")
+        #expect(!controller.markdownDocument.isDirty)
+    }
+
+    @Test @MainActor
+    func pathTokenActionsStayInertForMissingPaths() throws {
+        let fixture = try Fixture(text: "see `src/gone.ts:42` and [link](notes.md)\n")
+        defer { fixture.remove() }
+        let controller = DocumentWindowController()
+        defer { controller.close() }
+        try controller.open(fixture.url, mode: .live)
+
+        // The documented contract (§ Workspace and path resolution): missing
+        // paths are clear but never run a command — no editor launch, no
+        // Finder reveal, from activation or from the context menu alike.
+        let missing = PathToken(rawPath: "src/gone.ts", line: 42)
+        #expect(controller.pathResolver?.resolve(missing).exists == false)
+        #expect(!controller.openPathTokenInEditor(missing))
+        #expect(!controller.revealPathTokenInFinder(missing))
+    }
+}
+
+private struct Fixture {
+    let root: URL
+    let url: URL
+
+    init(text: String) throws {
+        root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("downright-autosave-lifetime-\(UUID().uuidString)", isDirectory: true)
+        url = root.appendingPathComponent("note.md")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        try Data(text.utf8).write(to: url)
+    }
+
+    func remove() { try? FileManager.default.removeItem(at: root) }
+}

--- a/Tests/DownrightAppTests/CommandTableTests.swift
+++ b/Tests/DownrightAppTests/CommandTableTests.swift
@@ -114,7 +114,8 @@ struct CommandTableTests {
         walk(MainMenu.build())
 
         #expect(titles["Paste and Match Style"]?.0 == "v")
-        #expect(titles["Paste and Match Style"]?.1 == [.command, .option, .shift])
+        #expect(titles["Paste and Match Style"]?.1 == [.command, .shift])
+        #expect(titles["Paste as Markdown"]?.0 == "")
         #expect(titles["Page Setup…"]?.0 == "p")
         #expect(titles["Page Setup…"]?.1 == [.command, .shift])
         #expect(titles["Enter Full Screen"]?.0 == "f")

--- a/Tests/DownrightAppTests/DocumentDropTests.swift
+++ b/Tests/DownrightAppTests/DocumentDropTests.swift
@@ -1,0 +1,547 @@
+import AppKit
+import Foundation
+import MarkdownCore
+import MarkdownRender
+import Testing
+@testable import DownrightApp
+
+/// Dropping a file on the document, and previewing the one under the caret.
+///
+/// The drop half is mostly about *which path* ends up between the parentheses.
+/// Downright has four separate consumers of a Markdown destination — the
+/// renderer, the Asset Doctor's parser, the diagnostics, and the link
+/// classifier — and they do not agree with each other, so most of these tests
+/// take a reference the drop produced and push it back through the real
+/// parser and the real policy to prove it still names the file that was
+/// dropped.  A reference that merely *looks* right is the failure mode: it
+/// renders as a grey missing-image box a week later, in somebody else's
+/// checkout.
+@Suite(.serialized)
+struct DocumentDropTests {
+
+    private func makeTemporaryDirectory() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("DocumentDropTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory
+    }
+
+    private func pngData(width: Int = 8, height: Int = 8) throws -> Data {
+        let rep = NSBitmapImageRep(
+            bitmapDataPlanes: nil, pixelsWide: width, pixelsHigh: height,
+            bitsPerSample: 8, samplesPerPixel: 4, hasAlpha: true, isPlanar: false,
+            colorSpaceName: .deviceRGB, bytesPerRow: 0, bitsPerPixel: 0
+        )!
+        NSGraphicsContext.saveGraphicsState()
+        NSGraphicsContext.current = NSGraphicsContext(bitmapImageRep: rep)
+        NSColor.systemTeal.setFill()
+        NSRect(x: 0, y: 0, width: width, height: height).fill()
+        NSGraphicsContext.restoreGraphicsState()
+        return try #require(rep.representation(using: .png, properties: [:]))
+    }
+
+    private func pasteboard(files: [URL]) -> NSPasteboard {
+        let board = NSPasteboard(name: NSPasteboard.Name("DocumentDropTests-\(UUID().uuidString)"))
+        board.clearContents()
+        board.writeObjects(files.map { $0 as NSURL })
+        return board
+    }
+
+    private func pasteboard(png: Data) -> NSPasteboard {
+        let board = NSPasteboard(name: NSPasteboard.Name("DocumentDropTests-\(UUID().uuidString)"))
+        board.clearContents()
+        board.setData(png, forType: .png)
+        return board
+    }
+
+    // MARK: - Reading the drag
+
+    @Test func aFileDragIsReadAsFilesEvenWhenItAlsoCarriesPixels() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let file = directory.appendingPathComponent("shot.png")
+        try pngData().write(to: file)
+
+        // Finder and Preview both put an image representation on the
+        // pasteboard alongside the file URL.  Taking the pixels would copy a
+        // file the reader already has, under a name they did not choose.
+        let board = NSPasteboard(name: NSPasteboard.Name("DocumentDropTests-\(UUID().uuidString)"))
+        board.clearContents()
+        board.writeObjects([file as NSURL])
+        board.setData(try pngData(), forType: .png)
+        #expect(DroppedAsset.payload(from: board) == .files([file]))
+    }
+
+    @Test func rawPixelsAreReadWhenThereIsNoFile() throws {
+        let png = try pngData()
+        let payload = try #require(DroppedAsset.payload(from: pasteboard(png: png)))
+        #expect(payload == .imageData(CapturedImage.Payload(data: png, fileExtension: "png")))
+    }
+
+    @Test func aTextDragIsNotAnAssetDrop() {
+        let board = NSPasteboard(name: NSPasteboard.Name("DocumentDropTests-\(UUID().uuidString)"))
+        board.clearContents()
+        board.setString("just some words", forType: .string)
+        #expect(DroppedAsset.payload(from: board) == nil)
+    }
+
+    /// A dragged file that has since been deleted is not a drop target.  The
+    /// reference would be written as a missing asset with no way to tell it
+    /// from a typo.
+    @Test func aVanishedFileIsNotAPayload() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let board = pasteboard(files: [directory.appendingPathComponent("gone.png")])
+        #expect(DroppedAsset.payload(from: board) == nil)
+    }
+
+    // MARK: - Which destination a file gets
+
+    @Test func aFileInsideTheDocumentsFolderIsReferencedWhereItStands() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        try FileManager.default.createDirectory(
+            at: directory.appendingPathComponent("assets"), withIntermediateDirectories: true
+        )
+        let nested = directory.appendingPathComponent("assets/diagram.png")
+        #expect(
+            DroppedAsset.destination(for: nested, relativeTo: directory) == .relative("assets/diagram.png")
+        )
+    }
+
+    /// Percent-encoding is *not* the answer here, and this is the test that
+    /// pins why: `LocalAssetPolicy` — the renderer — treats the destination as
+    /// a literal path and never decodes, so `meeting%20notes.png` would send
+    /// it looking for a file with a `%` in the name.  The angle-bracket form
+    /// is stripped by the parser before either consumer sees it.
+    @Test func aSpaceInTheNameUsesTheAngleBracketFormRatherThanPercentEncoding() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let spaced = directory.appendingPathComponent("meeting notes.png")
+        #expect(
+            DroppedAsset.destination(for: spaced, relativeTo: directory) == .angled("meeting notes.png")
+        )
+        #expect(DroppedAsset.Destination.angled("meeting notes.png").markdownText == "<meeting notes.png>")
+        #expect(!DroppedAsset.Destination.angled("meeting notes.png").markdownText.contains("%"))
+    }
+
+    @Test func aFileOutsideTheFolderHasNoRelativeForm() throws {
+        let directory = try makeTemporaryDirectory()
+        let elsewhere = try makeTemporaryDirectory()
+        defer {
+            try? FileManager.default.removeItem(at: directory)
+            try? FileManager.default.removeItem(at: elsewhere)
+        }
+        let outside = elsewhere.appendingPathComponent("diagram.png")
+        #expect(DroppedAsset.relativePath(of: outside, in: directory) == nil)
+        guard case .absolute = DroppedAsset.destination(for: outside, relativeTo: directory) else {
+            Issue.record("a file outside the folder must not be given a relative destination")
+            return
+        }
+    }
+
+    /// A `..` path is *not* used for a file one directory up.  A traversal is
+    /// not `isSafeRelative`, so an image referenced through one renders only
+    /// behind a trust prompt — which is exactly what copying it in avoids.
+    @Test func aSiblingFolderDoesNotGetATraversalPath() throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let documents = root.appendingPathComponent("docs", isDirectory: true)
+        let images = root.appendingPathComponent("images", isDirectory: true)
+        try FileManager.default.createDirectory(at: documents, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: images, withIntermediateDirectories: true)
+        let asset = images.appendingPathComponent("diagram.png")
+        #expect(DroppedAsset.relativePath(of: asset, in: documents) == nil)
+    }
+
+    /// `/tmp` is a symlink to `/private/tmp`, and a document opened through one
+    /// with an image dragged from the other must not look like two folders.
+    @Test func symlinkedFoldersStillResolveAsTheSameFolder() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let resolved = directory.resolvingSymlinksInPath()
+        let asset = resolved.appendingPathComponent("diagram.png")
+        #expect(DroppedAsset.relativePath(of: asset, in: directory) == "diagram.png")
+    }
+
+    // MARK: - What a drop becomes
+
+    private func plan(
+        _ payload: DroppedAsset.Payload,
+        directory: URL?,
+        base: String = "notes",
+        taken: Set<String> = []
+    ) -> [DroppedAsset.Insertion] {
+        DroppedAsset.plan(
+            for: payload, documentDirectory: directory,
+            documentBaseName: base, isTaken: { taken.contains($0) }
+        )
+    }
+
+    @Test func anImageAlreadyBesideTheDocumentIsNotCopied() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let asset = directory.appendingPathComponent("diagram.png")
+        try pngData().write(to: asset)
+
+        let insertions = plan(.files([asset]), directory: directory)
+        #expect(insertions.count == 1)
+        #expect(insertions[0].write == nil, "a file already in the folder must not be duplicated")
+        #expect(insertions[0].markdown == "![diagram](diagram.png)")
+        #expect(insertions[0].isBlock)
+    }
+
+    @Test func anImageFromOutsideIsCopiedInAndReferencedRelatively() throws {
+        let directory = try makeTemporaryDirectory()
+        let elsewhere = try makeTemporaryDirectory()
+        defer {
+            try? FileManager.default.removeItem(at: directory)
+            try? FileManager.default.removeItem(at: elsewhere)
+        }
+        let asset = elsewhere.appendingPathComponent("Screen Shot 2026.png")
+        try pngData().write(to: asset)
+
+        let insertions = plan(.files([asset]), directory: directory)
+        #expect(insertions[0].write == .init(fileName: "Screen-Shot-2026.png", contents: .copyOf(asset)))
+        // The alt text keeps the name the reader recognises even though the
+        // written file is slugged.
+        #expect(insertions[0].markdown == "![Screen Shot 2026](Screen-Shot-2026.png)")
+    }
+
+    /// A link is a reference, not an embed.  Copying somebody's document into
+    /// this folder because it was linked would duplicate their file behind
+    /// their back.
+    @Test func aMarkdownFileIsLinkedInlineAndNeverCopied() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let sibling = directory.appendingPathComponent("design.md")
+        try "# Design\n".write(to: sibling, atomically: true, encoding: .utf8)
+
+        let insertions = plan(.files([sibling]), directory: directory)
+        #expect(insertions[0].write == nil)
+        #expect(insertions[0].markdown == "[design](design.md)")
+        #expect(!insertions[0].isBlock, "a link lands where the pointer was, inline")
+    }
+
+    @Test func aFileFromOutsideIsLinkedByFileURL() throws {
+        let directory = try makeTemporaryDirectory()
+        let elsewhere = try makeTemporaryDirectory()
+        defer {
+            try? FileManager.default.removeItem(at: directory)
+            try? FileManager.default.removeItem(at: elsewhere)
+        }
+        let sibling = elsewhere.appendingPathComponent("spec.pdf")
+        try Data("%PDF-1.4\n".utf8).write(to: sibling)
+
+        let insertions = plan(.files([sibling]), directory: directory)
+        #expect(insertions[0].write == nil)
+        #expect(insertions[0].markdown.hasPrefix("[spec](file://"))
+        // The classifier the app uses when the reader clicks it has to
+        // recognise the destination, and a bare absolute path does not
+        // classify as a local file — it classifies as *relative* and gets
+        // appended to the document's own folder.
+        let destination = String(
+            insertions[0].markdown.drop(while: { $0 != "(" }).dropFirst().dropLast()
+        )
+        guard case .localFile(let url) = MarkdownLinkDestination.classify(destination) else {
+            Issue.record("a dropped outside file must classify as a local file")
+            return
+        }
+        #expect(url.standardizedFileURL.path == sibling.standardizedFileURL.path)
+    }
+
+    @Test func droppedPixelsAreWrittenBesideTheDocument() throws {
+        let png = try pngData()
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let insertions = plan(
+            .imageData(CapturedImage.Payload(data: png, fileExtension: "png")), directory: directory
+        )
+        #expect(insertions[0].write == .init(fileName: "notes-image.png", contents: .data(png)))
+        #expect(insertions[0].markdown == "![notes-image](notes-image.png)")
+    }
+
+    /// Bytes have nowhere to go without a document folder.  The same answer
+    /// Continuity Camera gives, for the same reason.
+    @Test func droppedPixelsAreRefusedWithoutADocumentFolder() throws {
+        let png = try pngData()
+        #expect(plan(.imageData(CapturedImage.Payload(data: png, fileExtension: "png")),
+                     directory: nil).isEmpty)
+    }
+
+    @Test func twoDropsInARowNeverCollideOnOneName() throws {
+        let directory = try makeTemporaryDirectory()
+        let elsewhere = try makeTemporaryDirectory()
+        defer {
+            try? FileManager.default.removeItem(at: directory)
+            try? FileManager.default.removeItem(at: elsewhere)
+        }
+        let first = elsewhere.appendingPathComponent("shot.png")
+        let second = elsewhere.appendingPathComponent("nested", isDirectory: true)
+        try FileManager.default.createDirectory(at: second, withIntermediateDirectories: true)
+        let secondFile = second.appendingPathComponent("shot.png")
+        try pngData().write(to: first)
+        try pngData().write(to: secondFile)
+
+        // Both are called `shot.png`, and one is already on disk beside the
+        // document — three claims on one name inside a single drop.
+        let insertions = plan(
+            .files([first, secondFile]), directory: directory, taken: ["shot.png"]
+        )
+        #expect(insertions.compactMap { $0.write?.fileName } == ["shot-2.png", "shot-3.png"])
+    }
+
+    // MARK: - The single source edit
+
+    @Test func aSingleLinkStaysInlineAtTheDropPoint() {
+        let insertions = [DroppedAsset.Insertion(write: nil, markdown: "[a](a.md)", isBlock: false)]
+        let edit = DroppedAsset.edit(insertions: insertions, in: "one two three", at: 4)
+        #expect(edit?.replacement == "[a](a.md)")
+        #expect(edit?.origin == 4)
+        #expect(edit?.caret == 4 + 9)
+    }
+
+    @Test func anImagePadsItselfIntoItsOwnParagraph() {
+        let insertions = [DroppedAsset.Insertion(write: nil, markdown: "![a](a.png)", isBlock: true)]
+        let edit = DroppedAsset.edit(insertions: insertions, in: "one two three", at: 4)
+        #expect(edit?.replacement == "\n\n![a](a.png)\n\n")
+    }
+
+    /// Several files at once is a list, not a sentence.
+    @Test func aMultipleFileDropIsLaidOutAsBlocks() {
+        let insertions = [
+            DroppedAsset.Insertion(write: nil, markdown: "[a](a.md)", isBlock: false),
+            DroppedAsset.Insertion(write: nil, markdown: "[b](b.md)", isBlock: false),
+        ]
+        let edit = DroppedAsset.edit(insertions: insertions, in: "", at: 0)
+        #expect(edit?.replacement == "[a](a.md)\n\n[b](b.md)")
+    }
+
+    @Test func nothingToInsertIsNoEdit() {
+        #expect(DroppedAsset.edit(insertions: [], in: "one", at: 0) == nil)
+    }
+
+    // MARK: - The reference has to survive the round trip
+
+    private func diagnostics(_ text: String, documentURL: URL, root: URL) -> [AssetDiagnostic] {
+        let probe = AssetProbe { url in
+            AssetMetadata(
+                exists: FileManager.default.fileExists(atPath: url.path),
+                isDirectory: false,
+                byteSize: (try? Data(contentsOf: url)).map { Int64($0.count) },
+                fileExtension: url.pathExtension
+            )
+        }
+        return AssetDoctor.diagnose(
+            MarkdownParser.parse(text),
+            context: AssetResolutionContext(documentURL: documentURL, workspaceRoot: root),
+            probe: probe
+        )
+    }
+
+    @Test func aDroppedImageResolvesBackToTheFileThatWasDropped() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let documentURL = directory.appendingPathComponent("notes.md")
+        let asset = directory.appendingPathComponent("diagram.png")
+        try pngData().write(to: asset)
+
+        let markdown = plan(.files([asset]), directory: directory)[0].markdown
+        let reference = try #require(AssetDoctor.references(
+            in: MarkdownParser.parse(markdown),
+            context: AssetResolutionContext(documentURL: documentURL, workspaceRoot: directory)
+        ).first)
+        #expect(reference.kind == .relativeLocal)
+        #expect(reference.url?.standardizedFileURL == asset.standardizedFileURL)
+        #expect(try #require(
+            LocalAssetPolicy.request(raw: reference.source, documentURL: documentURL)
+        ).isSafeRelative)
+        #expect(diagnostics(markdown, documentURL: documentURL, root: directory).isEmpty)
+    }
+
+    /// The angle-bracket form has to survive all three: the parser strips the
+    /// brackets, the doctor stays quiet, and the renderer's own resolver finds
+    /// the file with the space still in its name.
+    @Test func anAngleBracketDestinationSurvivesTheParserAndTheRenderer() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let documentURL = directory.appendingPathComponent("notes.md")
+        let asset = directory.appendingPathComponent("meeting notes.png")
+        try pngData().write(to: asset)
+
+        let markdown = plan(.files([asset]), directory: directory)[0].markdown
+        #expect(markdown == "![meeting notes](<meeting notes.png>)")
+        let reference = try #require(AssetDoctor.references(
+            in: MarkdownParser.parse(markdown),
+            context: AssetResolutionContext(documentURL: documentURL, workspaceRoot: directory)
+        ).first)
+        #expect(reference.source == "meeting notes.png")
+        #expect(reference.url?.standardizedFileURL == asset.standardizedFileURL)
+        let request = try #require(
+            LocalAssetPolicy.request(raw: reference.source, documentURL: documentURL)
+        )
+        #expect(request.isSafeRelative)
+        #expect(request.url.lastPathComponent == "meeting notes.png")
+        #expect(diagnostics(markdown, documentURL: documentURL, root: directory).isEmpty)
+    }
+
+    /// A filename holding a bracket would otherwise end the label early and
+    /// leave the rest of the reference as literal prose.
+    @Test func bracketsInAFileNameAreEscapedInTheLabel() {
+        #expect(DroppedAsset.altText(for: "a [draft] plan.md") == "a \\[draft\\] plan")
+        #expect(DroppedAsset.altText(for: ".hidden") == ".hidden")
+        #expect(DroppedAsset.altText(for: "") == "Image")
+    }
+
+    // MARK: - The real window
+
+    @MainActor
+    private func makeController(text: String, at url: URL) throws -> DocumentWindowController {
+        try text.write(to: url, atomically: true, encoding: .utf8)
+        let controller = DocumentWindowController()
+        try controller.open(url, mode: .live)
+        return controller
+    }
+
+    @MainActor
+    private func drop(_ board: NSPasteboard, at offset: Int, on controller: DocumentWindowController) -> Bool {
+        let view = controller.containerTextView
+        return controller.markdownTextView(
+            view, didAcceptDrop: DocumentDrop(pasteboard: board, sourceOffset: offset)
+        )
+    }
+
+    /// End to end, at a source offset the reader chose — not at the caret.
+    @Test @MainActor func droppingAnImageInsertsOneUndoableReferenceAtTheDropPoint() throws {
+        let directory = try makeTemporaryDirectory()
+        let elsewhere = try makeTemporaryDirectory()
+        defer {
+            try? FileManager.default.removeItem(at: directory)
+            try? FileManager.default.removeItem(at: elsewhere)
+        }
+        let url = directory.appendingPathComponent("notes.md")
+        let source = "# Title\n\nFirst paragraph.\n\nSecond paragraph.\n"
+        let controller = try makeController(text: source, at: url)
+        defer { controller.close() }
+        // The caret is somewhere else entirely: the drop must ignore it.
+        controller.containerTextView.setSourceSelectedRanges([NSRange(location: 0, length: 0)])
+
+        let origin = elsewhere.appendingPathComponent("chart.png")
+        let bytes = try pngData()
+        try bytes.write(to: origin)
+
+        let dropOffset = (source as NSString).range(of: "Second paragraph.").location
+        #expect(drop(pasteboard(files: [origin]), at: dropOffset, on: controller))
+
+        let copied = directory.appendingPathComponent("chart.png")
+        #expect(try Data(contentsOf: copied) == bytes)
+        #expect(controller.markdownDocument.text
+            == "# Title\n\nFirst paragraph.\n\n![chart](chart.png)\n\nSecond paragraph.\n")
+        // One boundary, so one Undo puts the document back exactly — and
+        // leaves the copied file alone, which is the less destructive half.
+        controller.markdownDocument.undoManager.undo()
+        #expect(controller.markdownDocument.text == source)
+        #expect(FileManager.default.fileExists(atPath: copied.path))
+    }
+
+    @Test @MainActor func droppingPixelsWritesAFileNamedAfterTheDocument() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let url = directory.appendingPathComponent("meeting notes.md")
+        let controller = try makeController(text: "# Title\n", at: url)
+        defer { controller.close() }
+
+        let bytes = try pngData()
+        #expect(drop(pasteboard(png: bytes), at: 8, on: controller))
+        let written = directory.appendingPathComponent("meeting-notes-image.png")
+        #expect(try Data(contentsOf: written) == bytes)
+        #expect(controller.markdownDocument.text
+            == "# Title\n\n![meeting-notes-image](meeting-notes-image.png)")
+    }
+
+    @Test @MainActor func aNeverSavedWindowTakesFilesButNotLooseImageBytes() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let controller = DocumentWindowController()
+        defer { controller.close() }
+        #expect(controller.markdownDocument.url == nil)
+
+        let view = controller.containerTextView
+        let bytes = try pngData()
+        let pixels = pasteboard(png: bytes)
+        #expect(!controller.markdownTextView(
+            view, canAcceptDrop: DocumentDrop(pasteboard: pixels, sourceOffset: 0)
+        ))
+        let before = controller.markdownDocument.text
+        #expect(!drop(pixels, at: 0, on: controller))
+        #expect(controller.markdownDocument.text == before)
+
+        let file = directory.appendingPathComponent("design.md")
+        try "# Design\n".write(to: file, atomically: true, encoding: .utf8)
+        let board = pasteboard(files: [file])
+        #expect(controller.markdownTextView(
+            view, canAcceptDrop: DocumentDrop(pasteboard: board, sourceOffset: 0)
+        ))
+        #expect(drop(board, at: 0, on: controller))
+        #expect(controller.markdownDocument.text.contains("[design](file://"))
+    }
+
+    /// A dropped `.md` sibling lands inline, and the link the reader then
+    /// clicks has to open the file it names.
+    @Test @MainActor func aDroppedSiblingBecomesALinkThatResolves() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let url = directory.appendingPathComponent("notes.md")
+        let controller = try makeController(text: "See also.\n", at: url)
+        defer { controller.close() }
+        let sibling = directory.appendingPathComponent("design.md")
+        try "# Design\n".write(to: sibling, atomically: true, encoding: .utf8)
+
+        #expect(drop(pasteboard(files: [sibling]), at: 8, on: controller))
+        #expect(controller.markdownDocument.text == "See also[design](design.md).\n")
+
+        guard case .relative(let relative) = MarkdownLinkDestination.classify("design.md") else {
+            Issue.record("a sibling link must classify as relative")
+            return
+        }
+        #expect(FileManager.default.fileExists(
+            atPath: directory.appendingPathComponent(relative).path
+        ))
+    }
+
+    /// Nothing is inserted when a write fails, and the files this drop already
+    /// created are taken back out.  A half-applied drop leaves the reader with
+    /// a reference to a file that was never written.
+    @Test @MainActor func aFailedWriteInsertsNothingAndLeavesNoDebris() throws {
+        let directory = try makeTemporaryDirectory()
+        let elsewhere = try makeTemporaryDirectory()
+        defer {
+            try? FileManager.default.removeItem(at: directory)
+            try? FileManager.default.removeItem(at: elsewhere)
+        }
+        let url = directory.appendingPathComponent("notes.md")
+        let controller = try makeController(text: "# Title\n", at: url)
+        defer { controller.close() }
+
+        let good = elsewhere.appendingPathComponent("one.png")
+        try pngData().write(to: good)
+        // The second source is unreadable, so its copy throws *after* the
+        // first one has already landed — the only interesting failure shape.
+        let doomed = elsewhere.appendingPathComponent("two.png")
+        try pngData().write(to: doomed)
+        try FileManager.default.setAttributes([.posixPermissions: 0], ofItemAtPath: doomed.path)
+        defer {
+            try? FileManager.default.setAttributes(
+                [.posixPermissions: 0o644], ofItemAtPath: doomed.path
+            )
+        }
+        let board = pasteboard(files: [good, doomed])
+
+        let before = controller.markdownDocument.text
+        #expect(!drop(board, at: 8, on: controller))
+        #expect(controller.markdownDocument.text == before)
+        #expect(!FileManager.default.fileExists(
+            atPath: directory.appendingPathComponent("one.png").path
+        ), "the file this drop created must be rolled back with it")
+    }
+}

--- a/Tests/DownrightAppTests/DocumentEditProjectionTests.swift
+++ b/Tests/DownrightAppTests/DocumentEditProjectionTests.swift
@@ -1,0 +1,120 @@
+import AppKit
+import Foundation
+import MarkdownCore
+import MarkdownRender
+import Testing
+@testable import DownrightApp
+
+/// Fragment payloads are reference values riding on NSTextStorage attribute
+/// runs.  Runs move with an edit; payload ranges do not — unless every edit
+/// funnel projects them.  The view's own funnel already did; these tests pin
+/// the document-level funnels (commands, undo/redo, external absorption),
+/// which previously left unchanged blocks below an edit pointing at pre-edit
+/// offsets until some later decoration happened to touch them.
+@Suite("Document edits project fragment payloads", .serialized)
+struct DocumentEditProjectionTests {
+    private let source = """
+    Intro paragraph.
+
+    ```swift
+    let a = 1
+    ```
+
+    Tail paragraph.
+    """
+
+    @Test @MainActor
+    func commandEditsShiftPayloadRangesBelowTheEdit() throws {
+        let fixture = try Fixture(text: source)
+        defer { fixture.remove() }
+        let document = MarkdownDocument()
+        try document.open(fixture.url)
+
+        let view = MarkdownTextView(
+            frame: NSRect(x: 0, y: 0, width: 720, height: 420),
+            storage: document.storage
+        )
+        view.update(document: document.parsed, dirty: .wholesale)
+
+        // Locate the fenced code block's payload in the decorated storage.
+        let fenceLine = (source as NSString).range(of: "```swift")
+        guard fenceLine.location != NSNotFound else {
+            Issue.record("fixture lost its code fence")
+            return
+        }
+        guard let payloadBefore = document.storage.attribute(
+            .drFragment, at: fenceLine.location, effectiveRange: nil
+        ) as? FragmentPayload else {
+            Issue.record("the code block must carry a fragment payload")
+            return
+        }
+
+        // A document-level edit above the fence: two inserted characters.
+        #expect(document.replace(
+            NSRange(location: 0, length: 0),
+            with: "Hi",
+            actionName: "Type"
+        ))
+
+        // The payload must now describe where the block lives *after* the
+        // edit, matching what a fresh parse of the current text says.
+        let reparsed = MarkdownParser.parse(document.text)
+        var expected = NSRange(location: 0, length: 0)
+        reparsed.root.walk { block in
+            if case .codeBlock(.some, true, _) = block.content, expected.length == 0 {
+                expected = block.range
+            }
+        }
+        #expect(expected.length > 0)
+        #expect(payloadBefore.sourceRange.location == fenceLine.location + 2)
+        #expect(payloadBefore.sourceRange.location == expected.location,
+                "projected payload must agree with the fresh parse")
+    }
+
+    @Test @MainActor
+    func undoRedoKeepsPayloadsAligned() throws {
+        let fixture = try Fixture(text: source)
+        defer { fixture.remove() }
+        let document = MarkdownDocument()
+        try document.open(fixture.url)
+
+        let view = MarkdownTextView(
+            frame: NSRect(x: 0, y: 0, width: 720, height: 420),
+            storage: document.storage
+        )
+        view.update(document: document.parsed, dirty: .wholesale)
+
+        let fenceLine = (source as NSString).range(of: "```swift")
+        let payload = document.storage.attribute(
+            .drFragment, at: fenceLine.location, effectiveRange: nil
+        ) as? FragmentPayload
+        let originalLocation = fenceLine.location
+
+        #expect(document.replace(
+            NSRange(location: 0, length: 0), with: "XYZ", actionName: "Type"
+        ))
+        #expect(payload?.sourceRange.location == originalLocation + 3)
+
+        document.undoManager.undo()
+        #expect(payload?.sourceRange.location == originalLocation,
+                "undo is itself an edit through replace() and must project too")
+
+        document.undoManager.redo()
+        #expect(payload?.sourceRange.location == originalLocation + 3)
+    }
+}
+
+private struct Fixture {
+    let root: URL
+    let url: URL
+
+    init(text: String) throws {
+        root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("downright-payload-projection-\(UUID().uuidString)", isDirectory: true)
+        url = root.appendingPathComponent("note.md")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        try Data(text.utf8).write(to: url)
+    }
+
+    func remove() { try? FileManager.default.removeItem(at: root) }
+}

--- a/Tests/DownrightAppTests/DocumentQuickLookTests.swift
+++ b/Tests/DownrightAppTests/DocumentQuickLookTests.swift
@@ -1,0 +1,193 @@
+import AppKit
+import Foundation
+import MarkdownCore
+import MarkdownRender
+import Testing
+@testable import DownrightApp
+
+/// Quick Look, pointed inward.
+///
+/// Downright already ships the extension that lets *Finder* preview a Markdown
+/// file; this is the same affordance aimed at whatever the reader is pointing
+/// at inside a document.  Two things are worth holding still: what each kind of
+/// target routes to, and — much more important — that the key which triggers it
+/// can never be a character.
+@Suite(.serialized)
+struct DocumentQuickLookTests {
+
+    private func makeTemporaryDirectory() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("DocumentQuickLookTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory
+    }
+
+    private func resolve(
+        _ kind: ContextTarget.Kind,
+        documentURL: URL? = nil,
+        resolution: PathResolver.Resolution? = nil
+    ) -> QuickLookRequest? {
+        QuickLookRequest.resolve(
+            ContextTarget(kind: kind, sourceRange: NSRange(location: 0, length: 0)),
+            documentURL: documentURL,
+            pathResolution: { _ in resolution },
+            fileExists: { FileManager.default.fileExists(atPath: $0.path) }
+        )
+    }
+
+    // MARK: - Routing
+
+    /// An embedded image opens in the lightbox, not the system panel.  A click
+    /// on that same image already opens the lightbox (§7.1), and force click
+    /// summoning a second, different image viewer for the same picture would
+    /// be two answers to one question.
+    @Test func anEmbeddedImageGoesToTheAppsOwnLightbox() {
+        #expect(resolve(.image("diagram.png")) == .lightbox(source: "diagram.png"))
+    }
+
+    @Test func aResolvedPathTokenGoesToTheSystemPanel() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let file = directory.appendingPathComponent("session.ts")
+        try "export const x = 1\n".write(to: file, atomically: true, encoding: .utf8)
+
+        let request = resolve(
+            .pathToken(PathToken(rawPath: "src/session.ts")),
+            resolution: .init(url: file, exists: true, isDirectory: false, line: nil)
+        )
+        #expect(request == .panel(file.standardizedFileURL))
+    }
+
+    /// §8.4 draws a path that is not there as missing.  Previewing it would be
+    /// a second, contradictory answer about the same file.
+    @Test func aMissingPathTokenIsNotPreviewable() {
+        #expect(resolve(
+            .pathToken(PathToken(rawPath: "src/gone.ts")),
+            resolution: .init(url: URL(fileURLWithPath: "/nope/gone.ts"), exists: false,
+                              isDirectory: false, line: nil)
+        ) == nil)
+        #expect(resolve(.pathToken(PathToken(rawPath: "src/gone.ts")), resolution: nil) == nil)
+    }
+
+    @Test func aRelativeLinkResolvesAgainstTheDocumentsFolder() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let documentURL = directory.appendingPathComponent("notes.md")
+        let sibling = directory.appendingPathComponent("design.md")
+        try "# Design\n".write(to: sibling, atomically: true, encoding: .utf8)
+
+        #expect(resolve(.link("design.md"), documentURL: documentURL)
+            == .panel(sibling.standardizedFileURL))
+        // Nothing to resolve against, and no guessing.
+        #expect(resolve(.link("design.md"), documentURL: nil) == nil)
+        #expect(resolve(.link("missing.md"), documentURL: documentURL) == nil)
+    }
+
+    @Test func aFileURLLinkIsPreviewedDirectly() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let sibling = directory.appendingPathComponent("spec.pdf")
+        try Data("%PDF-1.4\n".utf8).write(to: sibling)
+        #expect(resolve(.link(sibling.absoluteString)) == .panel(sibling.standardizedFileURL))
+    }
+
+    /// Turning a preview gesture into "launch this URL" would route around the
+    /// trust prompt a real click goes through.
+    @Test func webAnchorAndAutomationLinksAreNeverPreviewed() {
+        #expect(resolve(.link("https://example.com")) == nil)
+        #expect(resolve(.link("#a-heading")) == nil)
+        #expect(resolve(.link("x-downright://run")) == nil)
+        #expect(resolve(.link("")) == nil)
+    }
+
+    @Test func targetsWithNoFileBehindThemAreNotPreviewable() {
+        #expect(resolve(.heading(0)) == nil)
+        #expect(resolve(.codeBlock(NSRange(location: 0, length: 4))) == nil)
+        #expect(resolve(.table(NSRange(location: 0, length: 4))) == nil)
+        #expect(resolve(.selection) == nil)
+        #expect(resolve(.plain) == nil)
+    }
+
+    // MARK: - The trigger
+
+    /// The one that matters.  A menu item carrying a bare Space as its key
+    /// equivalent intercepts the space bar before the text view ever sees it,
+    /// and `applyKeyEquivalent` only refuses bindings without ⌘ or ⌃ — so the
+    /// guard has to hold in the table too, not just in the menu builder.
+    @Test @MainActor func noCommandBindsAnUnmodifiedSpace() {
+        for (command, bindings) in KeybindingDefaults.table {
+            for binding in bindings where binding.key == "space" {
+                #expect(
+                    !binding.modifiers.isEmpty,
+                    "\(command.rawValue) binds a bare Space, which is a character in Live and Source"
+                )
+            }
+        }
+    }
+
+    @Test @MainActor func quickLookIsAFileMenuCommandOnTheStandardChord() {
+        _ = NSApplication.shared
+        #expect(Command.quickLook.title == "Quick Look")
+        #expect(Command.quickLook.menu == .file)
+        #expect(KeybindingDefaults.table[.quickLook] == [KeyBinding("y", .command)])
+
+        var found: NSMenuItem?
+        func walk(_ menu: NSMenu) {
+            for item in menu.items {
+                if MainMenu.command(for: item) == .quickLook { found = item }
+                if let submenu = item.submenu { walk(submenu) }
+            }
+        }
+        walk(MainMenu.build())
+        #expect(found?.keyEquivalent == "y")
+        #expect(found?.keyEquivalentModifierMask == [.command])
+    }
+
+    /// Enabled only when there is something to preview, so the menu never
+    /// offers a command that would be a no-op.
+    @Test func quickLookIsOfferedOnlyWithATargetUnderTheCaret() {
+        #expect(!Command.quickLook.isEnabled(in: CommandContext(hasDocument: true)))
+        #expect(Command.quickLook.isEnabled(
+            in: CommandContext(hasDocument: true, hasQuickLookTarget: true)
+        ))
+        #expect(!Command.quickLook.isEnabled(
+            in: CommandContext(hasDocument: false, hasQuickLookTarget: true)
+        ))
+    }
+
+    // MARK: - The real window
+
+    @MainActor
+    private func makeController(text: String, at url: URL) throws -> DocumentWindowController {
+        try text.write(to: url, atomically: true, encoding: .utf8)
+        let controller = DocumentWindowController()
+        try controller.open(url, mode: .live)
+        return controller
+    }
+
+    @Test @MainActor func theCommandFollowsTheCaretAndReportsWhenThereIsNothingToShow() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let url = directory.appendingPathComponent("notes.md")
+        let source = "See [the design](design.md) here.\n"
+        let controller = try makeController(text: source, at: url)
+        defer { controller.close() }
+
+        let ns = source as NSString
+        controller.containerTextView.setSourceSelectedRanges([
+            NSRange(location: ns.range(of: "here").location, length: 0),
+        ])
+        #expect(!controller.hasQuickLookTarget)
+        #expect(!controller.commandContext.hasQuickLookTarget)
+        // Reports failure rather than swallowing the key, so a trigger that
+        // resolves to nothing can still fall through to what it would
+        // otherwise have done.
+        #expect(!controller.quickLookAtSelection())
+
+        controller.containerTextView.setSourceSelectedRanges([
+            NSRange(location: ns.range(of: "the design").location + 2, length: 0),
+        ])
+        #expect(controller.hasQuickLookTarget)
+        #expect(controller.commandContext.hasQuickLookTarget)
+    }
+}

--- a/Tests/DownrightAppTests/FileWatcherTests.swift
+++ b/Tests/DownrightAppTests/FileWatcherTests.swift
@@ -177,6 +177,99 @@ struct FileWatcherTests {
         try await Task.sleep(nanoseconds: 350_000_000)
     }
 
+    /// A save on a slow volume can stay in flight far longer than any fixed
+    /// suppression window. Suppression is a state now, so the observation
+    /// made while the write is still unacknowledged — and the acknowledged
+    /// bytes themselves — must both stay silent, and only genuine later
+    /// external activity may deliver.
+    @Test("a write still unacknowledged past the old clock window stays suppressed")
+    func slowVolumeSaveIsNotAPhantomExternalChange() async throws {
+        let fixture = try Fixture(contents: "before")
+        defer { fixture.remove() }
+        let events = EventCollector()
+        let watcher = FileWatcher(url: fixture.url) { events.append($0) }
+        defer { watcher.stop() }
+
+        let own = Data("own bytes written slowly".utf8)
+        watcher.suppressOwnWrite(for: 0.05)
+        try fixture.atomicReplace(own)
+
+        // Outlive the caller's whole interval and the legacy 0.6 s window.
+        try await Task.sleep(nanoseconds: 700_000_000)
+        watcher.checkNowForTesting()
+        try await settle()
+        #expect(events.count == 0, "an in-flight own write must not arrive as an external change")
+
+        watcher.acknowledgeOwnWrite(contents: own)
+        watcher.checkNowForTesting()
+        try await settle()
+        #expect(events.count == 0, "the acknowledged bytes stay silent too")
+
+        let external = Data("genuinely external".utf8)
+        try fixture.atomicReplace(external)
+        watcher.checkNowForTesting()
+        try await expectEventCount(events, 1)
+        #expect(events.count == 1)
+        #expect(events.isChanged(at: 0))
+    }
+
+    /// If an acknowledgement is somehow lost, the watchdog fails open instead
+    /// of leaving the watcher deaf forever.
+    @Test("a lost acknowledgement trips the watchdog back to detection")
+    func lostAcknowledgementFailsOpen() async throws {
+        let fixture = try Fixture(contents: "before")
+        defer { fixture.remove() }
+        let events = EventCollector()
+        let watcher = FileWatcher(url: fixture.url) { events.append($0) }
+        defer { watcher.stop() }
+
+        let own = Data("unacknowledged bytes".utf8)
+        watcher.suppressOwnWrite(for: 5)
+        try fixture.atomicReplace(own)
+        watcher.tripSuppressionWatchdogForTesting()
+
+        watcher.checkNowForTesting()
+        try await expectEventCount(events, 1)
+        #expect(events.isChanged(at: 0), "fail-open surfaces the unacknowledged write as change")
+
+        // And the watcher keeps detecting afterwards.
+        try fixture.atomicReplace(Data("later".utf8))
+        watcher.checkNowForTesting()
+        try await expectEventCount(events, 2)
+    }
+
+    /// Directory watches honor the same own-write suppression: the owner
+    /// writing sidecars into the watched folder must not wake an idempotent
+    /// rescan, and detection resumes once suppression ends.
+    @Test("directory watch skips deliveries while own-write suppression is open")
+    func directoryWatchRespectsOwnWriteSuppression() async throws {
+        let directory = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("downright-dirwatch-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let sibling = directory.appendingPathComponent("sibling.md")
+        try Data("first\n".utf8).write(to: sibling)
+
+        let events = EventCollector()
+        let watcher = FileWatcher(
+            url: directory,
+            watchesDirectory: true,
+            fileExtensions: ["md"]
+        ) { events.append($0) }
+        defer { watcher.stop() }
+
+        watcher.suppressOwnWrite(for: 5)
+        try Data("second\n".utf8).write(to: sibling)
+        watcher.deliverDirectoryEventForTesting(paths: [sibling.path])
+        try await settle()
+        #expect(events.count == 0, "our own write into the folder stays silent")
+
+        watcher.cancelOwnWriteSuppression()
+        watcher.deliverDirectoryEventForTesting(paths: [sibling.path])
+        try await expectEventCount(events, 1)
+        #expect(events.isChanged(at: 0))
+    }
+
     private func expectEventCount(_ events: EventCollector, _ count: Int) async throws {
         for _ in 0..<100 {
             if events.count >= count { return }

--- a/Tests/DownrightAppTests/HistorySwipeTests.swift
+++ b/Tests/DownrightAppTests/HistorySwipeTests.swift
@@ -1,0 +1,479 @@
+import AppKit
+import MarkdownRender
+import Testing
+@testable import DownrightApp
+
+@Suite(.serialized)
+@MainActor
+struct HistorySwipeTests {
+
+    // MARK: - Fixtures
+
+    private func scroll(
+        deltaX: CGFloat = 0,
+        deltaY: CGFloat = 0,
+        phase: CGScrollPhase? = .changed,
+        momentum: CGMomentumScrollPhase = CGMomentumScrollPhase.none,
+        precise: Bool = true,
+        modifiers: NSEvent.ModifierFlags = .shift,
+        at seconds: TimeInterval = 0
+    ) throws -> NSEvent {
+        try SyntheticScroll.event(
+            deltaX: deltaX, deltaY: deltaY, phase: phase, momentum: momentum,
+            precise: precise, modifiers: modifiers, at: seconds
+        )
+    }
+
+    private func sizedController(reduceMotion: Bool) -> DocumentWindowController {
+        let controller = DocumentWindowController()
+        controller.window?.setFrame(NSRect(x: 0, y: 0, width: 900, height: 700), display: false)
+        controller.window?.layoutIfNeeded()
+        controller.primaryContainer.layoutSubtreeIfNeeded()
+        // Always overridden, in both directions: a runner that inherits the
+        // machine's Reduce Motion setting would otherwise silently run the
+        // wrong state machine.
+        controller.activeStyleSheet = StyleSheet(
+            theme: controller.activeStyleSheet.theme,
+            appearance: controller.window?.effectiveAppearance ?? NSAppearance.currentDrawing(),
+            reduceMotionOverride: reduceMotion
+        )
+        return controller
+    }
+
+    /// A coordinator over real panes with the trip recorded rather than taken.
+    private final class Recorder {
+        var moves: [HistorySwipePolicy.Direction] = []
+        var haptics = 0
+        var canGoBack = true
+        var canGoForward = true
+    }
+
+    private func swipe(
+        over controller: DocumentWindowController,
+        recording recorder: Recorder
+    ) -> HistorySwipeCoordinator {
+        HistorySwipeCoordinator(host: HistorySwipeCoordinator.Host(
+            panes: { controller.documentPanes },
+            styleSheet: { controller.activeStyleSheet },
+            canMove: { direction in
+                switch direction {
+                case .back: return recorder.canGoBack
+                case .forward: return recorder.canGoForward
+                }
+            },
+            move: { recorder.moves.append($0) },
+            performHapticFeedback: { recorder.haptics += 1 }
+        ))
+    }
+
+    // MARK: - Policy
+
+    @Test
+    func onlyExactlyShiftSpellsThisGesture() {
+        #expect(HistorySwipePolicy.isSpelledCorrectly([.shift]))
+        // Nothing held is the Document↔Source swipe; ⇧⌘ is not a gesture at
+        // all and must not half-start this one.
+        #expect(!HistorySwipePolicy.isSpelledCorrectly([]))
+        #expect(!HistorySwipePolicy.isSpelledCorrectly([.shift, .command]))
+        #expect(!HistorySwipePolicy.isSpelledCorrectly([.command]))
+        #expect(!HistorySwipePolicy.isSpelledCorrectly([.option]))
+    }
+
+    @Test
+    func theSwipeIsClaimedOnlyWhenItIsDecidedlySideways() {
+        #expect(HistorySwipePolicy.claim(horizontal: 6, vertical: 2) == .undecided)
+        #expect(HistorySwipePolicy.claim(horizontal: 13, vertical: 0) == .undecided)
+        #expect(HistorySwipePolicy.claim(horizontal: 14, vertical: 0) == .swipe)
+        #expect(HistorySwipePolicy.claim(horizontal: -40, vertical: 10) == .swipe)
+        // A diagonal is a scroll. This one is stricter than the presentation
+        // swipe's, because ⇧ is held for plenty of reasons that are not this.
+        #expect(HistorySwipePolicy.claim(horizontal: 30, vertical: 25) == .scroll)
+        #expect(HistorySwipePolicy.claim(horizontal: 0, vertical: -20) == .scroll)
+        #expect(HistorySwipePolicy.claim(horizontal: 8, vertical: 9) == .undecided)
+    }
+
+    @Test
+    func theContentFollowsTheFingersAndBackIsWhatWasOnTheLeft() {
+        // Safari's direction exactly: push the page right, uncovering what
+        // sits to its left, and you go back.
+        #expect(HistorySwipePolicy.direction(translation: 40) == .back)
+        #expect(HistorySwipePolicy.direction(translation: -40) == .forward)
+        #expect(HistorySwipePolicy.direction(translation: 0) == nil)
+    }
+
+    @Test
+    func commitDistanceStaysReachableAtEveryPaneWidth() {
+        #expect(HistorySwipePolicy.commitDistance(paneWidth: 120)
+            == HistorySwipePolicy.minimumCommitDistance)
+        #expect(HistorySwipePolicy.commitDistance(paneWidth: 2400)
+            == HistorySwipePolicy.maximumCommitDistance)
+        #expect(HistorySwipePolicy.commitDistance(paneWidth: 400) == 80)
+        // A trip is cheaper to undo than a presentation switch, so it asks for
+        // a little less travel.
+        #expect(HistorySwipePolicy.commitDistance(paneWidth: 900)
+            < PresentationSwipePolicy.commitDistance(paneWidth: 900))
+    }
+
+    @Test
+    func aShortSwipeCommitsOnlyWhenItIsStillTravelling() {
+        let width: CGFloat = 900
+        let distance = HistorySwipePolicy.commitDistance(paneWidth: width)
+
+        #expect(HistorySwipePolicy.shouldCommit(
+            translation: distance, velocity: 0, paneWidth: width))
+        #expect(!HistorySwipePolicy.shouldCommit(
+            translation: distance - 1, velocity: 0, paneWidth: width))
+        #expect(HistorySwipePolicy.shouldCommit(
+            translation: 20, velocity: 600, paneWidth: width))
+        // Pulled back at the last moment: however fast the hand was moving,
+        // reversing means "put it back".
+        #expect(!HistorySwipePolicy.shouldCommit(
+            translation: 20, velocity: -600, paneWidth: width))
+        #expect(!HistorySwipePolicy.shouldCommit(
+            translation: 0, velocity: 900, paneWidth: width))
+    }
+
+    @Test
+    func thePageGivesAgainstTheFingersAndNeverArrives() {
+        let limit = HistorySwipePolicy.maximumGive
+        #expect(HistorySwipePolicy.give(0) == 0)
+        #expect(HistorySwipePolicy.give(8) > 1)
+        #expect(HistorySwipePolicy.give(-40) < 0)
+        #expect(abs(HistorySwipePolicy.give(40)) < abs(HistorySwipePolicy.give(140)))
+        #expect(abs(HistorySwipePolicy.give(10_000)) < limit)
+        #expect(abs(HistorySwipePolicy.give(10_000)) > limit * 0.99)
+    }
+
+    // MARK: - Coordinator
+
+    @Test
+    func swipingRightGoesBackAndSwipingLeftGoesForward() throws {
+        let controller = sizedController(reduceMotion: true)
+        defer { controller.close() }
+        let recorder = Recorder()
+        let gesture = swipe(over: controller, recording: recorder)
+
+        #expect(!gesture.handle(try scroll(phase: .began, at: 0)))
+        // Still ambiguous, so the scroll view keeps this one.
+        #expect(!gesture.handle(try scroll(deltaX: 8, at: 0.008)))
+        // Past the intent threshold: the swipe takes over.
+        #expect(gesture.handle(try scroll(deltaX: 10, at: 0.016)))
+        #expect(gesture.isTracking)
+        #expect(gesture.trackedDirectionForTesting == .back)
+
+        for step in 3...12 {
+            #expect(gesture.handle(try scroll(deltaX: 24, at: TimeInterval(step) * 0.008)))
+        }
+        #expect(gesture.handle(try scroll(phase: .ended, at: 0.12)))
+        #expect(recorder.moves == [.back])
+        #expect(!gesture.isTracking)
+
+        _ = gesture.handle(try scroll(phase: .began, at: 1))
+        for step in 1...12 {
+            #expect(gesture.handle(try scroll(deltaX: -24, at: 1 + TimeInterval(step) * 0.008)))
+        }
+        #expect(gesture.handle(try scroll(phase: .ended, at: 1.12)))
+        #expect(recorder.moves == [.back, .forward])
+    }
+
+    @Test
+    func withoutShiftTheGestureIsNotEvenConsidered() throws {
+        let controller = sizedController(reduceMotion: true)
+        defer { controller.close() }
+        let recorder = Recorder()
+        let gesture = swipe(over: controller, recording: recorder)
+
+        #expect(!gesture.handle(try scroll(phase: .began, modifiers: [], at: 0)))
+        for step in 1...12 {
+            let event = try scroll(deltaX: 24, modifiers: [], at: TimeInterval(step) * 0.008)
+            #expect(!gesture.handle(event))
+        }
+        #expect(!gesture.handle(try scroll(phase: .ended, modifiers: [], at: 0.12)))
+        #expect(recorder.moves.isEmpty)
+        #expect(!gesture.isTracking)
+    }
+
+    @Test
+    func aSwipeIntoAnEmptyStackNeverCatches() throws {
+        let controller = sizedController(reduceMotion: true)
+        defer { controller.close() }
+        let recorder = Recorder()
+        recorder.canGoBack = false
+        let gesture = swipe(over: controller, recording: recorder)
+
+        _ = gesture.handle(try scroll(phase: .began, at: 0))
+        // A page that gives and then does nothing reads as a bug, so the
+        // gesture is handed straight back and the surface just scrolls.
+        for step in 1...12 {
+            #expect(!gesture.handle(try scroll(deltaX: 24, at: TimeInterval(step) * 0.008)))
+        }
+        #expect(!gesture.handle(try scroll(phase: .ended, at: 0.12)))
+        #expect(recorder.moves.isEmpty)
+        #expect(!gesture.isTracking)
+
+        // …and the other way is still open, so the reader is not locked out of
+        // the direction that does have somewhere to go.
+        _ = gesture.handle(try scroll(phase: .began, at: 1))
+        for step in 1...12 {
+            #expect(gesture.handle(try scroll(deltaX: -24, at: 1 + TimeInterval(step) * 0.008)))
+        }
+        #expect(gesture.handle(try scroll(phase: .ended, at: 1.12)))
+        #expect(recorder.moves == [.forward])
+    }
+
+    @Test
+    func readingWithShiftHeldIsStillJustReading() throws {
+        let controller = sizedController(reduceMotion: true)
+        defer { controller.close() }
+        let recorder = Recorder()
+        let gesture = swipe(over: controller, recording: recorder)
+
+        #expect(!gesture.handle(try scroll(phase: .began, at: 0)))
+        for step in 1...12 {
+            let event = try scroll(deltaX: -1, deltaY: -30, at: TimeInterval(step) * 0.008)
+            #expect(!gesture.handle(event))
+        }
+        #expect(!gesture.handle(try scroll(phase: .ended, at: 0.12)))
+        #expect(recorder.moves.isEmpty)
+    }
+
+    @Test
+    func aWheelIsLeftAlone() throws {
+        let controller = sizedController(reduceMotion: true)
+        defer { controller.close() }
+        let recorder = Recorder()
+        let gesture = swipe(over: controller, recording: recorder)
+
+        // ⇧-wheel is a single unphased notch: no travel to measure and no
+        // release to commit on. Back and Forward stay on the keyboard there.
+        for tick in 0...10 {
+            let event = try scroll(
+                deltaX: -10, phase: nil, precise: false, at: TimeInterval(tick) * 0.03
+            )
+            #expect(!gesture.handle(event))
+        }
+        #expect(recorder.moves.isEmpty)
+    }
+
+    @Test
+    func aFlickCommitsAndASlowNudgeDoesNot() throws {
+        let controller = sizedController(reduceMotion: true)
+        defer { controller.close() }
+        let recorder = Recorder()
+        let gesture = swipe(over: controller, recording: recorder)
+
+        // Short, fast, still going: the flick.
+        _ = gesture.handle(try scroll(phase: .began, at: 0))
+        #expect(gesture.handle(try scroll(deltaX: 16, at: 0.008)))
+        #expect(gesture.handle(try scroll(deltaX: 20, at: 0.016)))
+        #expect(gesture.handle(try scroll(phase: .ended, at: 0.02)))
+        #expect(recorder.moves == [.back])
+
+        // The same distance, released slowly: the reader thought better of it.
+        _ = gesture.handle(try scroll(phase: .began, at: 1))
+        #expect(gesture.handle(try scroll(deltaX: 16, at: 1.008)))
+        #expect(gesture.handle(try scroll(deltaX: 4, at: 1.5)))
+        #expect(gesture.handle(try scroll(phase: .ended, at: 2)))
+        #expect(recorder.moves == [.back])
+    }
+
+    @Test
+    func theCoastAfterAFlickIsSwallowedAndBuysNothing() throws {
+        let controller = sizedController(reduceMotion: true)
+        defer { controller.close() }
+        let recorder = Recorder()
+        let gesture = swipe(over: controller, recording: recorder)
+
+        _ = gesture.handle(try scroll(phase: .began, at: 0))
+        #expect(gesture.handle(try scroll(deltaX: 16, at: 0.008)))
+        #expect(gesture.handle(try scroll(deltaX: 20, at: 0.016)))
+        #expect(gesture.handle(try scroll(phase: .ended, at: 0.02)))
+        #expect(recorder.moves == [.back])
+
+        // Hundreds of points of coast, all of it belonging to a gesture that
+        // has already been answered. It must not travel again, and it must not
+        // fall through and scroll the document under the trip either.
+        for tick in 1...30 {
+            let event = try scroll(
+                deltaX: 60, phase: nil, momentum: .continuous,
+                at: 0.02 + TimeInterval(tick) * 0.008
+            )
+            #expect(gesture.handle(event))
+        }
+        #expect(recorder.moves == [.back])
+        let tail = try scroll(phase: nil, momentum: .end, at: 0.3)
+        #expect(gesture.handle(tail))
+        // With the coast over, the next scroll belongs to the scroll view.
+        #expect(!gesture.handle(try scroll(
+            deltaY: -20, phase: nil, momentum: .continuous, at: 0.31)))
+        #expect(recorder.moves == [.back])
+    }
+
+    @Test
+    func theCommitPointIsADetentTheHandCanFeelExactlyOncePerCrossing() throws {
+        let controller = sizedController(reduceMotion: true)
+        defer { controller.close() }
+        let recorder = Recorder()
+        let gesture = swipe(over: controller, recording: recorder)
+        let distance = HistorySwipePolicy.commitDistance(
+            paneWidth: controller.primaryContainer.bounds.width
+        )
+
+        _ = gesture.handle(try scroll(phase: .began, at: 0))
+        #expect(gesture.handle(try scroll(deltaX: 20, at: 0.008)))
+        #expect(recorder.haptics == 0)
+        #expect(gesture.handle(try scroll(deltaX: distance, at: 0.016)))
+        #expect(recorder.haptics == 1)
+        // Further out is still the same side of the line.
+        #expect(gesture.handle(try scroll(deltaX: 200, at: 0.024)))
+        #expect(recorder.haptics == 1)
+        // Back under it re-arms, so hovering at the threshold feels like a
+        // line rather than a burst.
+        #expect(gesture.handle(try scroll(deltaX: -300, at: 0.032)))
+        #expect(recorder.haptics == 1)
+        #expect(gesture.handle(try scroll(deltaX: 300, at: 0.04)))
+        #expect(recorder.haptics == 2)
+    }
+
+    // MARK: - The give
+
+    @Test
+    func thePageTravelsUnderTheFingersAndIsHandedBackBeforeTheTrip() throws {
+        let controller = sizedController(reduceMotion: false)
+        defer { controller.close() }
+        let recorder = Recorder()
+        let gesture = swipe(over: controller, recording: recorder)
+        let paneSubviews = controller.primaryContainer.subviews.count
+
+        _ = gesture.handle(try scroll(phase: .began, at: 0))
+        #expect(gesture.handle(try scroll(deltaX: 40, at: 0.008)))
+        let scrollLayer = try #require(controller.primaryContainer.scrollView.layer)
+        #expect(scrollLayer.transform.m41 > 0)
+        #expect(controller.primaryContainer.layer?.masksToBounds == true)
+        // Nothing was rendered to get here: the whole gesture so far is one
+        // layer translation, and the destination is not visited until release.
+        #expect(controller.primaryContainer.subviews.count == paneSubviews)
+        #expect(recorder.moves.isEmpty)
+
+        for step in 2...10 {
+            #expect(gesture.handle(try scroll(deltaX: 24, at: TimeInterval(step) * 0.008)))
+        }
+        #expect(gesture.handle(try scroll(phase: .ended, at: 0.1)))
+        // The destination scroll animates from the pane's resting frame, so
+        // the give is surrendered before the trip, not after.
+        #expect(scrollLayer.transform.m41 == 0)
+        #expect(recorder.moves == [.back])
+        #expect(!gesture.isTracking)
+        #expect(!gesture.isSettling)
+    }
+
+    @Test
+    func reduceMotionTakesTheTripWithoutMovingThePage() throws {
+        let controller = sizedController(reduceMotion: true)
+        defer { controller.close() }
+        let recorder = Recorder()
+        let gesture = swipe(over: controller, recording: recorder)
+
+        _ = gesture.handle(try scroll(phase: .began, at: 0))
+        #expect(gesture.handle(try scroll(deltaX: 40, at: 0.008)))
+        #expect(gesture.isTracking)
+        // No give was taken, so there is no transform and no spring to run —
+        // and the gesture still does its job.
+        #expect((controller.primaryContainer.scrollView.layer?.transform.m41 ?? 0) == 0)
+        for step in 2...10 {
+            #expect(gesture.handle(try scroll(deltaX: 24, at: TimeInterval(step) * 0.008)))
+        }
+        #expect(gesture.handle(try scroll(phase: .ended, at: 0.1)))
+        #expect(recorder.moves == [.back])
+        #expect(!gesture.isSettling)
+    }
+
+    @Test
+    func aSwipeInSplitViewCarriesBothPanes() throws {
+        let controller = sizedController(reduceMotion: false)
+        defer {
+            controller.historySwipe.cancelInFlight()
+            controller.close()
+        }
+        controller.toggleSplitView()
+        controller.window?.layoutIfNeeded()
+        let split = try #require(controller.splitContainer)
+        #expect(controller.documentPanes.count == 2)
+        let recorder = Recorder()
+        let gesture = swipe(over: controller, recording: recorder)
+
+        _ = gesture.handle(try scroll(phase: .began, at: 0))
+        #expect(gesture.handle(try scroll(deltaX: 40, at: 0.008)))
+        // Where the reader is in the document is the window's, not one pane's,
+        // so both surfaces travel.
+        #expect((controller.primaryContainer.scrollView.layer?.transform.m41 ?? 0) > 0)
+        #expect((split.scrollView.layer?.transform.m41 ?? 0) > 0)
+
+        gesture.cancelInFlight()
+        #expect(controller.primaryContainer.scrollView.layer?.transform.m41 == 0)
+        #expect(split.scrollView.layer?.transform.m41 == 0)
+    }
+
+    @Test
+    func aResizeMidSwipeGroundsItRatherThanHoldingAStaleTransform() throws {
+        let controller = sizedController(reduceMotion: false)
+        defer { controller.close() }
+        controller.recordJump(to: 40, label: "Test")
+        #expect(controller.jumpHistory.canGoBack)
+
+        _ = controller.historySwipe.handle(try scroll(phase: .began, at: 0))
+        #expect(controller.historySwipe.handle(try scroll(deltaX: 40, at: 0.008)))
+        #expect(controller.historySwipe.isTracking)
+
+        controller.windowDidResize(Notification(name: NSWindow.didResizeNotification))
+        #expect(controller.primaryContainer.scrollView.layer?.transform.m41 == 0)
+        #expect(!controller.historySwipe.isTracking)
+        #expect(!controller.historySwipe.isSettling)
+        // Grounded, not committed: the reader never released.
+        #expect(controller.jumpHistory.canGoBack)
+    }
+
+    // MARK: - Wired into the window
+
+    @Test
+    func shiftSwipingRightMovesBackThroughRealJumpHistory() throws {
+        let controller = sizedController(reduceMotion: true)
+        defer { controller.close() }
+        controller.recordJump(to: 40, label: "Heading")
+        #expect(controller.jumpHistory.canGoBack)
+        #expect(!controller.jumpHistory.canGoForward)
+
+        _ = controller.documentScrollGestures.handle(try scroll(phase: .began, at: 0))
+        for step in 1...12 {
+            let event = try scroll(deltaX: 24, at: TimeInterval(step) * 0.008)
+            #expect(controller.documentScrollGestures.handle(event))
+        }
+        #expect(controller.documentScrollGestures.handle(try scroll(phase: .ended, at: 0.12)))
+
+        #expect(!controller.jumpHistory.canGoBack)
+        #expect(controller.jumpHistory.canGoForward)
+        // The Document↔Source swipe shares this axis and must not have fired.
+        #expect(controller.presentationSegment == 0)
+    }
+
+    @Test
+    func shiftSwipingWithNoHistoryChangesNothingAtAll() throws {
+        let controller = sizedController(reduceMotion: true)
+        defer { controller.close() }
+        #expect(!controller.jumpHistory.canGoBack)
+
+        _ = controller.documentScrollGestures.handle(try scroll(phase: .began, at: 0))
+        for step in 1...12 {
+            let event = try scroll(deltaX: -24, at: TimeInterval(step) * 0.008)
+            // Nowhere to go forward to either, so nothing claims it — and in
+            // particular the bare swipe underneath must not, or ⇧ would switch
+            // presentation whenever history was empty.
+            #expect(!controller.documentScrollGestures.handle(event))
+        }
+        _ = controller.documentScrollGestures.handle(try scroll(phase: .ended, at: 0.12))
+
+        #expect(controller.presentationSegment == 0)
+        #expect(!controller.presentationSwipe.isTracking)
+        #expect(!controller.historySwipe.isTracking)
+    }
+}

--- a/Tests/DownrightAppTests/PresentationDragTests.swift
+++ b/Tests/DownrightAppTests/PresentationDragTests.swift
@@ -1,0 +1,197 @@
+import AppKit
+import MarkdownRender
+import Testing
+@testable import DownrightApp
+
+/// The live Document↔Source drag, and the budget that decides whether the
+/// reader gets it.
+///
+/// The budget is the load-bearing part. Dragging the next presentation in
+/// requires rendering it first, and that rebuild scales with document length —
+/// so a swipe that always dragged would stall for a fifth of a second on a
+/// long file at the exact moment it caught. These tests pin the choice, not
+/// just the mechanism.
+@Suite(.serialized)
+@MainActor
+struct PresentationDragTests {
+    private func corpus(lines: Int) -> String {
+        var out = "# Drag corpus\n\n"
+        for index in 0..<lines {
+            out += index % 4 == 0 ? "## Section \(index)\n\n" : "Paragraph \(index) of prose.\n\n"
+        }
+        return out
+    }
+
+    /// A real controller over a document of a known length, since the budget's
+    /// whole input is how long the document is.
+    private func controller(lines: Int, reduceMotion: Bool = false) throws -> DocumentWindowController {
+        let directory = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("drag-\(lines)-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let file = directory.appendingPathComponent("corpus.md")
+        try corpus(lines: lines).write(to: file, atomically: true, encoding: .utf8)
+
+        let controller = DocumentWindowController()
+        controller.window?.setFrame(NSRect(x: 0, y: 0, width: 1020, height: 728), display: false)
+        try controller.open(file, mode: .live)
+        controller.window?.layoutIfNeeded()
+        controller.primaryContainer.layoutSubtreeIfNeeded()
+        controller.activeStyleSheet = StyleSheet(
+            theme: controller.activeStyleSheet.theme,
+            appearance: controller.window?.effectiveAppearance ?? NSAppearance.currentDrawing(),
+            reduceMotionOverride: reduceMotion
+        )
+        return controller
+    }
+
+    private func swipeLeft(
+        _ controller: DocumentWindowController,
+        steps: Int = 10,
+        perStep: CGFloat = -24
+    ) throws {
+        let swipe = controller.presentationSwipe
+        _ = swipe.handle(try SyntheticScroll.event(phase: .began, at: 0))
+        for step in 1...steps {
+            _ = swipe.handle(try SyntheticScroll.event(
+                deltaX: perStep, at: TimeInterval(step) * 0.008))
+        }
+    }
+
+    // MARK: - Budget
+
+    @Test
+    func budgetGrantsTheDragOnlyWhileTheSwitchFitsInsideAFewFrames() {
+        PresentationSwitchBudget.resetCalibrationForTesting()
+        defer { PresentationSwitchBudget.resetCalibrationForTesting() }
+
+        #expect(PresentationSwitchBudget.allowsDrag(lines: 100))
+        #expect(PresentationSwitchBudget.allowsDrag(lines: 1_000))
+        // Measured: past roughly twelve hundred lines of file, rendering
+        // Source stops fitting inside the engagement budget.
+        #expect(!PresentationSwitchBudget.allowsDrag(lines: 2_000))
+        #expect(!PresentationSwitchBudget.allowsDrag(lines: 9_000))
+        #expect(PresentationSwitchBudget.estimatedCost(lines: 0)
+            == PresentationSwitchBudget.fixedCost)
+    }
+
+    @Test
+    func budgetRecalibratesFromWhatTheSwitchActuallyCost() {
+        PresentationSwitchBudget.resetCalibrationForTesting()
+        defer { PresentationSwitchBudget.resetCalibrationForTesting() }
+        let before = PresentationSwitchBudget.millisecondsPerLine
+
+        // A machine four times slower than the seeded constant.
+        for _ in 0..<12 {
+            PresentationSwitchBudget.record(cost: 0.272 * 1_000, lines: 1_000)
+        }
+        #expect(PresentationSwitchBudget.millisecondsPerLine > before * 2)
+        // …and now refuses documents it would previously have accepted.
+        #expect(!PresentationSwitchBudget.allowsDrag(lines: 1_000))
+
+        // Nonsense never moves the estimate: a short document's cost is mostly
+        // fixed overhead, so dividing it by the line count describes nothing.
+        let calibrated = PresentationSwitchBudget.millisecondsPerLine
+        PresentationSwitchBudget.record(cost: 9_999, lines: 10)
+        PresentationSwitchBudget.record(cost: -5, lines: 5_000)
+        PresentationSwitchBudget.record(cost: .infinity, lines: 5_000)
+        #expect(PresentationSwitchBudget.millisecondsPerLine == calibrated)
+    }
+
+    // MARK: - Choosing
+
+    @Test
+    func aShortDocumentGetsTheRealDragAndSwitchesBehindIt() throws {
+        PresentationSwitchBudget.resetCalibrationForTesting()
+        defer { PresentationSwitchBudget.resetCalibrationForTesting() }
+        let controller = try controller(lines: 120)
+        defer { controller.presentationSwipe.cancelInFlight(); controller.close() }
+
+        try swipeLeft(controller)
+        #expect(controller.presentationSwipe.isTracking)
+        // The drag renders what it is pulling in, so by the time the fingers
+        // have moved the live surface is already Source — hidden behind a
+        // still of the page being left.
+        #expect(controller.presentationSegment == 1)
+        let scrollLayer = try #require(controller.primaryContainer.scrollView.layer)
+        #expect(scrollLayer.transform.m41 != 0)
+    }
+
+    @Test
+    func aLongDocumentGetsTheGiveAndIsNotRebuiltMidGesture() throws {
+        PresentationSwitchBudget.resetCalibrationForTesting()
+        defer { PresentationSwitchBudget.resetCalibrationForTesting() }
+        let controller = try controller(lines: 3_000)
+        defer { controller.presentationSwipe.cancelInFlight(); controller.close() }
+
+        try swipeLeft(controller)
+        #expect(controller.presentationSwipe.isTracking)
+        // Nothing was rendered: the give promises less precisely so that it can
+        // always answer.
+        #expect(controller.presentationSegment == 0)
+    }
+
+    @Test
+    func reduceMotionTakesNeitherAndSwitchesOnRelease() throws {
+        PresentationSwitchBudget.resetCalibrationForTesting()
+        defer { PresentationSwitchBudget.resetCalibrationForTesting() }
+        let controller = try controller(lines: 120, reduceMotion: true)
+        defer { controller.close() }
+
+        try swipeLeft(controller)
+        #expect(controller.presentationSegment == 0)
+        _ = controller.presentationSwipe.handle(
+            try SyntheticScroll.event(phase: .ended, at: 0.2))
+        #expect(controller.presentationSegment == 1)
+    }
+
+    // MARK: - Finishing
+
+    @Test
+    func abandoningADragPutsTheModeBack() throws {
+        PresentationSwitchBudget.resetCalibrationForTesting()
+        defer { PresentationSwitchBudget.resetCalibrationForTesting() }
+        let controller = try controller(lines: 120)
+        defer { controller.close() }
+
+        // Far enough to engage, nowhere near far enough to commit.
+        let swipe = controller.presentationSwipe
+        _ = swipe.handle(try SyntheticScroll.event(phase: .began, at: 0))
+        _ = swipe.handle(try SyntheticScroll.event(deltaX: -16, at: 0.008))
+        #expect(controller.presentationSegment == 1)
+
+        swipe.cancelInFlight()
+        #expect(controller.presentationSegment == 0)
+        #expect(controller.primaryContainer.scrollView.layer?.transform.m41 == 0)
+        #expect(!swipe.isTracking)
+    }
+
+    @Test
+    func aResizeMidDragGroundsItAndRestoresTheMode() throws {
+        PresentationSwitchBudget.resetCalibrationForTesting()
+        defer { PresentationSwitchBudget.resetCalibrationForTesting() }
+        let controller = try controller(lines: 120)
+        defer { controller.close() }
+
+        try swipeLeft(controller, steps: 2, perStep: -20)
+        #expect(controller.presentationSegment == 1)
+
+        controller.windowDidResize(Notification(name: NSWindow.didResizeNotification))
+        #expect(controller.presentationSegment == 0)
+        #expect(!controller.presentationSwipe.isTracking)
+        #expect(!controller.presentationSwipe.isSettling)
+    }
+
+    @Test
+    func swipingTowardTheModeYouAreInNeverEngagesEitherTrack() throws {
+        PresentationSwitchBudget.resetCalibrationForTesting()
+        defer { PresentationSwitchBudget.resetCalibrationForTesting() }
+        let controller = try controller(lines: 120)
+        defer { controller.close() }
+
+        let swipe = controller.presentationSwipe
+        _ = swipe.handle(try SyntheticScroll.event(phase: .began, at: 0))
+        #expect(!swipe.handle(try SyntheticScroll.event(deltaX: 40, at: 0.008)))
+        #expect(!swipe.isTracking)
+        #expect(controller.presentationSegment == 0)
+    }
+}

--- a/Tests/DownrightAppTests/PresentationSwipeBudgetTests.swift
+++ b/Tests/DownrightAppTests/PresentationSwipeBudgetTests.swift
@@ -1,0 +1,107 @@
+import AppKit
+import MarkdownRender
+import Testing
+@testable import DownrightApp
+
+/// The two-finger swipe must cost nothing while it is happening.
+///
+/// This is a budget rather than a curiosity because the obvious design fails
+/// it badly.  Dragging the Source presentation in under the fingers was built
+/// and measured first: Source has to be rendered before it can be dragged, and
+/// that rebuild is ~400 ms on a two-thousand-line document — a dead trackpad
+/// at the moment the gesture catches, plus the same again to undo an abandoned
+/// swipe.  The shipped gesture renders nothing at all; it translates one layer
+/// and switches on release.  These numbers are what keeps it that way.
+@Suite(.serialized)
+@MainActor
+struct PresentationSwipeBudgetTests {
+    /// Generous against the measured cost — engagement and abandonment are
+    /// hundredths of a millisecond in release, and a frame is 8 ms even at
+    /// 120 Hz with room to spare.  A budget this loose still fails instantly
+    /// if anything starts rendering inside the gesture again.
+    private static let engagementBudget: Double = 8
+    private static let trackingFrameBudget: Double = 1
+
+    private func corpus(lines: Int) -> String {
+        var out = "# Renderer handoff\n\n"
+        for index in 0..<lines {
+            switch index % 8 {
+            case 0: out += "## Section \(index)\n\n"
+            case 1: out += "Body text with `inline code`, **bold**, *italic* and a [link](https://example.com) in line \(index).\n\n"
+            case 2: out += "- list item \(index) with trailing prose to make the line wrap at a realistic measure\n"
+            case 3: out += "- [ ] task item \(index)\n\n"
+            case 4: out += "```swift\nlet value\(index) = compute(\(index))\n```\n\n"
+            case 5: out += "> quoted line \(index)\n\n"
+            case 6: out += "| a | b |\n|---|---|\n| \(index) | \(index * 2) |\n\n"
+            default: out += "Plain paragraph \(index).\n\n"
+            }
+        }
+        return out
+    }
+
+    private func elapsed(_ body: () -> Void) -> Double {
+        let start = DispatchTime.now().uptimeNanoseconds
+        body()
+        return Double(DispatchTime.now().uptimeNanoseconds - start) / 1_000_000
+    }
+
+    private func scroll(_ deltaX: CGFloat, phase: CGScrollPhase, at seconds: Double) throws -> NSEvent {
+        let raw = try #require(CGEvent(
+            scrollWheelEvent2Source: nil, units: .pixel,
+            wheelCount: 2, wheel1: 0, wheel2: 0, wheel3: 0
+        ))
+        raw.setIntegerValueField(.scrollWheelEventIsContinuous, value: 1)
+        raw.setDoubleValueField(.scrollWheelEventPointDeltaAxis2, value: Double(deltaX))
+        raw.setIntegerValueField(.scrollWheelEventScrollPhase, value: Int64(phase.rawValue))
+        raw.timestamp = UInt64(seconds * 1_000_000_000)
+        return try #require(NSEvent(cgEvent: raw))
+    }
+
+    @Test
+    func swipingAndAbandoningALargeDocumentRendersNothing() throws {
+        let lines = 2_000
+        let directory = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("swipe-budget-\(ProcessInfo.processInfo.processIdentifier)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let file = directory.appendingPathComponent("corpus.md")
+        try corpus(lines: lines).write(to: file, atomically: true, encoding: .utf8)
+
+        let controller = DocumentWindowController()
+        defer { controller.close() }
+        controller.window?.setFrame(NSRect(x: 0, y: 0, width: 1020, height: 728), display: false)
+        try controller.open(file, mode: .live)
+        controller.window?.layoutIfNeeded()
+        controller.primaryContainer.layoutSubtreeIfNeeded()
+        controller.primaryContainer.textView.prepareForDisplay()
+
+        let swipe = controller.presentationSwipe
+        _ = swipe.handle(try scroll(0, phase: .began, at: 0))
+
+        // Engagement: the frame the gesture is claimed on. This is where the
+        // rejected design spent half a second.
+        let engage = elapsed { _ = swipe.handle(try! self.scroll(-20, phase: .changed, at: 0.008)) }
+        #expect(swipe.isTracking)
+
+        let frames = 100
+        let tracking = elapsed {
+            for step in 2...(frames + 1) {
+                _ = swipe.handle(try! self.scroll(-0.2, phase: .changed, at: Double(step) * 0.008))
+            }
+        }
+
+        // Released short and slow: the reader thought better of it.
+        let abandon = elapsed { _ = swipe.handle(try! self.scroll(0, phase: .ended, at: 4)) }
+        swipe.cancelInFlight()
+
+        #expect(engage < Self.engagementBudget,
+                "engaging the swipe took \(engage) ms — something is rendering inside the gesture")
+        #expect(tracking / Double(frames) < Self.trackingFrameBudget,
+                "tracking cost \(tracking / Double(frames)) ms per frame")
+        #expect(abandon < Self.engagementBudget,
+                "abandoning the swipe took \(abandon) ms — an abandoned swipe must undo nothing")
+        // The whole point: an abandoned swipe leaves the document exactly as
+        // it found it, having built nothing to throw away.
+        #expect(controller.presentationSegment == 0)
+    }
+}

--- a/Tests/DownrightAppTests/PresentationSwipeTests.swift
+++ b/Tests/DownrightAppTests/PresentationSwipeTests.swift
@@ -1,0 +1,419 @@
+import AppKit
+import MarkdownRender
+import Testing
+@testable import DownrightApp
+
+@Suite(.serialized)
+@MainActor
+struct PresentationSwipeTests {
+
+    // MARK: - Synthetic trackpad events
+
+    /// A continuous scroll event with real phases, so the coordinator is
+    /// exercised through the same `NSEvent` decoding the trackpad drives.
+    private func scroll(
+        deltaX: CGFloat = 0,
+        deltaY: CGFloat = 0,
+        phase: CGScrollPhase? = .changed,
+        momentum: CGMomentumScrollPhase = CGMomentumScrollPhase.none,
+        precise: Bool = true,
+        at seconds: TimeInterval = 0
+    ) throws -> NSEvent {
+        let event = try #require(CGEvent(
+            scrollWheelEvent2Source: nil,
+            units: .pixel,
+            wheelCount: 2,
+            wheel1: 0,
+            wheel2: 0,
+            wheel3: 0
+        ))
+        event.setIntegerValueField(.scrollWheelEventIsContinuous, value: precise ? 1 : 0)
+        event.setDoubleValueField(.scrollWheelEventPointDeltaAxis1, value: Double(deltaY))
+        event.setDoubleValueField(.scrollWheelEventPointDeltaAxis2, value: Double(deltaX))
+        if let phase {
+            event.setIntegerValueField(.scrollWheelEventScrollPhase, value: Int64(phase.rawValue))
+        }
+        event.setIntegerValueField(
+            .scrollWheelEventMomentumPhase, value: Int64(momentum.rawValue)
+        )
+        event.timestamp = UInt64(max(0, seconds) * 1_000_000_000)
+        return try #require(NSEvent(cgEvent: event))
+    }
+
+    private func sizedController(reduceMotion: Bool) -> DocumentWindowController {
+        let controller = DocumentWindowController()
+        controller.window?.setFrame(NSRect(x: 0, y: 0, width: 900, height: 700), display: false)
+        controller.window?.layoutIfNeeded()
+        controller.primaryContainer.layoutSubtreeIfNeeded()
+        // Always overridden, in both directions: a runner that inherits the
+        // machine's Reduce Motion setting would otherwise silently run the
+        // wrong state machine.
+        controller.activeStyleSheet = StyleSheet(
+            theme: controller.activeStyleSheet.theme,
+            appearance: controller.window?.effectiveAppearance ?? NSAppearance.currentDrawing(),
+            reduceMotionOverride: reduceMotion
+        )
+        return controller
+    }
+
+    @Test
+    func syntheticScrollEventsCarryTrackpadPhasesAndPreciseDeltas() throws {
+        let event = try scroll(deltaX: -20, deltaY: 3, phase: .began, at: 1)
+        #expect(event.hasPreciseScrollingDeltas)
+        #expect(event.phase == .began)
+        #expect(event.momentumPhase.isEmpty)
+        #expect(abs(event.scrollingDeltaX - -20) < 0.001)
+        #expect(abs(event.scrollingDeltaY - 3) < 0.001)
+
+        let ended = try scroll(phase: .ended)
+        #expect(ended.phase == .ended)
+
+        let coasting = try scroll(deltaX: -8, phase: nil, momentum: .continuous)
+        #expect(!coasting.momentumPhase.isEmpty)
+    }
+
+    // MARK: - Policy
+
+    @Test
+    func swipeIsClaimedOnlyWhenItIsDecidedlySideways() {
+        // Nothing has happened yet: the scroll view keeps the event, so
+        // vertical scrolling never waits on this decision.
+        #expect(PresentationSwipePolicy.claim(horizontal: 4, vertical: 2) == .undecided)
+        #expect(PresentationSwipePolicy.claim(horizontal: -11, vertical: 0) == .undecided)
+        // Sideways and past the threshold.
+        #expect(PresentationSwipePolicy.claim(horizontal: -12, vertical: 0) == .swipe)
+        #expect(PresentationSwipePolicy.claim(horizontal: 30, vertical: 20) == .swipe)
+        // A diagonal is a scroll: sideways travel that has not clearly beaten
+        // the vertical is the far commoner intent, and once the page has moved
+        // that far the gesture stops being re-litigated.
+        #expect(PresentationSwipePolicy.claim(horizontal: 30, vertical: 25) == .scroll)
+        #expect(PresentationSwipePolicy.claim(horizontal: 10, vertical: 40) == .scroll)
+        #expect(PresentationSwipePolicy.claim(horizontal: 0, vertical: -12) == .scroll)
+        // Below both thresholds nothing has been decided yet either way.
+        #expect(PresentationSwipePolicy.claim(horizontal: 9, vertical: 8) == .undecided)
+    }
+
+    @Test
+    func contentFollowsTheFingersOntoTheRail() {
+        // Pushing the page left uncovers Source, which sits right on the rail.
+        #expect(PresentationSwipePolicy.targetSegment(translation: -40) == 1)
+        #expect(PresentationSwipePolicy.targetSegment(translation: 40) == 0)
+        #expect(PresentationSwipePolicy.targetSegment(translation: 0) == nil)
+    }
+
+    @Test
+    func commitDistanceStaysReachableAtEveryPaneWidth() {
+        // A narrow split pane must not switch on a twitch…
+        #expect(PresentationSwipePolicy.commitDistance(paneWidth: 120)
+            == PresentationSwipePolicy.minimumCommitDistance)
+        // …and a wide window must not ask for a swipe past the trackpad.
+        #expect(PresentationSwipePolicy.commitDistance(paneWidth: 2400)
+            == PresentationSwipePolicy.maximumCommitDistance)
+        #expect(PresentationSwipePolicy.commitDistance(paneWidth: 400) == 100)
+    }
+
+    @Test
+    func railFillsExactlyWhereReleasingWouldCommit() {
+        let width: CGFloat = 900
+        let distance = PresentationSwipePolicy.commitDistance(paneWidth: width)
+        #expect(PresentationSwipePolicy.railProgress(translation: 0, paneWidth: width) == 0)
+        #expect(abs(
+            PresentationSwipePolicy.railProgress(translation: -distance / 2, paneWidth: width) - 0.5
+        ) < 0.001)
+        #expect(PresentationSwipePolicy.railProgress(translation: -distance, paneWidth: width) == 1)
+        // Past the commit point the bar has nowhere further to go.
+        #expect(PresentationSwipePolicy.railProgress(
+            translation: -width, paneWidth: width) == 1)
+    }
+
+    @Test
+    func railPositionRunsFromTheModeYouAreInTowardTheOneYouAreHeadingFor() {
+        #expect(PresentationSwipePolicy.railPosition(progress: 0, origin: 0, target: 1) == 0)
+        #expect(PresentationSwipePolicy.railPosition(progress: 0.5, origin: 0, target: 1) == 0.5)
+        #expect(PresentationSwipePolicy.railPosition(progress: 1, origin: 0, target: 1) == 1)
+        // Coming back the other way the bar travels toward Document.
+        #expect(PresentationSwipePolicy.railPosition(progress: 0.25, origin: 1, target: 0) == 0.75)
+        #expect(PresentationSwipePolicy.railPosition(progress: 4, origin: 1, target: 0) == 0)
+    }
+
+    @Test
+    func aShortSwipeCommitsOnlyWhenItIsStillTravelling() {
+        let width: CGFloat = 900
+        let distance = PresentationSwipePolicy.commitDistance(paneWidth: width)
+
+        #expect(PresentationSwipePolicy.shouldCommit(
+            translation: -distance, velocity: 0, paneWidth: width))
+        #expect(!PresentationSwipePolicy.shouldCommit(
+            translation: -distance + 1, velocity: 0, paneWidth: width))
+        // The flick: short, but leaving fast in the direction it was going.
+        #expect(PresentationSwipePolicy.shouldCommit(
+            translation: -20, velocity: -600, paneWidth: width))
+        // Pulled back at the last moment. However fast the hand was moving,
+        // reversing means "put it back".
+        #expect(!PresentationSwipePolicy.shouldCommit(
+            translation: -20, velocity: 600, paneWidth: width))
+        #expect(!PresentationSwipePolicy.shouldCommit(
+            translation: 0, velocity: -900, paneWidth: width))
+    }
+
+    @Test
+    func thePageGivesAgainstTheFingersAndNeverArrives() {
+        let limit = PresentationSwipePolicy.maximumGive
+        #expect(PresentationSwipePolicy.give(0) == 0)
+        // It answers immediately…
+        #expect(PresentationSwipePolicy.give(-8) < -1)
+        // …keeps its sign…
+        #expect(PresentationSwipePolicy.give(40) > 0)
+        #expect(PresentationSwipePolicy.give(-40) < 0)
+        // …grows monotonically…
+        #expect(abs(PresentationSwipePolicy.give(-40)) < abs(PresentationSwipePolicy.give(-140)))
+        // …and asymptotes rather than hitting a wall the hand can feel.
+        #expect(abs(PresentationSwipePolicy.give(-10_000)) < limit)
+        #expect(abs(PresentationSwipePolicy.give(-10_000)) > limit * 0.99)
+    }
+
+    // MARK: - Rail
+
+    @Test
+    func railTracksTheSwipeAndLandsWithoutSwitchingTwice() {
+        var changes: [Int] = []
+        var haptics = 0
+        let control = ToolbarPresentationControl(
+            onChange: { changes.append($0) },
+            performHapticFeedback: { haptics += 1 }
+        )
+        control.frame = NSRect(x: 0, y: 0, width: 184, height: 34)
+        control.layoutSubtreeIfNeeded()
+        let documentCenter = control.selectedSegmentCenterForTesting
+
+        control.trackSwipe(position: 0.25)
+        #expect(control.selectionIndicatorFrameForTesting.midX > documentCenter)
+        #expect(control.selectedSegment == 0)
+        #expect(haptics == 0)
+
+        control.trackSwipe(position: 1)
+        #expect(haptics == 1)
+        // The document has already switched behind the transition; the rail
+        // must not switch it a second time on the way past.
+        #expect(changes.isEmpty)
+
+        control.settleSwipe(at: 1)
+        #expect(control.selectedSegment == 1)
+        #expect(changes.isEmpty)
+        #expect(abs(
+            control.selectionIndicatorFrameForTesting.midX
+                - control.selectedSegmentCenterForTesting
+        ) < 0.01)
+    }
+
+    @Test
+    func railReturnsToWhereItStartedWhenTheSwipeIsAbandoned() {
+        let control = ToolbarPresentationControl(onChange: { _ in })
+        control.frame = NSRect(x: 0, y: 0, width: 184, height: 34)
+        control.layoutSubtreeIfNeeded()
+        let documentCenter = control.selectedSegmentCenterForTesting
+
+        control.trackSwipe(position: 0.8)
+        #expect(control.selectionIndicatorFrameForTesting.midX > documentCenter)
+
+        control.settleSwipe(at: 0)
+        #expect(control.selectedSegment == 0)
+        #expect(abs(control.selectionIndicatorFrameForTesting.midX - documentCenter) < 0.01)
+    }
+
+    // MARK: - Coordinator
+
+    @Test
+    func scrollingThePageIsNeverTakenForASwipe() throws {
+        let controller = sizedController(reduceMotion: true)
+        defer { controller.close() }
+
+        #expect(!controller.presentationSwipe.handle(try scroll(phase: .began, at: 0)))
+        for step in 1...12 {
+            let event = try scroll(deltaX: -1, deltaY: -30, at: TimeInterval(step) * 0.008)
+            #expect(!controller.presentationSwipe.handle(event))
+        }
+        #expect(!controller.presentationSwipe.handle(try scroll(phase: .ended, at: 0.2)))
+        #expect(controller.presentationSegment == 0)
+        #expect(!controller.presentationSwipe.isTracking)
+    }
+
+    @Test
+    func aWheelWithoutPreciseDeltasIsLeftToTheScrollView() throws {
+        let controller = sizedController(reduceMotion: true)
+        defer { controller.close() }
+
+        let event = try scroll(deltaX: -80, phase: .changed, precise: false)
+        #expect(!controller.presentationSwipe.handle(event))
+        #expect(controller.presentationSegment == 0)
+    }
+
+    @Test
+    func swipingLeftClaimsTheGestureAndLandsOnSource() throws {
+        let controller = sizedController(reduceMotion: true)
+        defer { controller.close() }
+        let rail = try #require(controller.toolbarPresentationControl)
+
+        #expect(!controller.presentationSwipe.handle(try scroll(phase: .began, at: 0)))
+        // Still ambiguous, so the scroll view keeps this one.
+        #expect(!controller.presentationSwipe.handle(try scroll(deltaX: -6, at: 0.008)))
+        // Past the intent threshold: the swipe takes over.
+        #expect(controller.presentationSwipe.handle(try scroll(deltaX: -10, at: 0.016)))
+        #expect(controller.presentationSwipe.isTracking)
+        #expect(rail.selectionIndicatorFrameForTesting.midX
+            > rail.selectedSegmentCenterForTesting)
+
+        for step in 3...12 {
+            let event = try scroll(deltaX: -20, at: TimeInterval(step) * 0.008)
+            #expect(controller.presentationSwipe.handle(event))
+        }
+        #expect(controller.presentationSwipe.handle(try scroll(phase: .ended, at: 0.12)))
+        #expect(controller.presentationSegment == 1)
+        #expect(rail.selectedSegment == 1)
+        #expect(!controller.presentationSwipe.isTracking)
+    }
+
+    @Test
+    func abandonedSwipeLeavesTheDocumentWhereItWas() throws {
+        let controller = sizedController(reduceMotion: true)
+        defer { controller.close() }
+        let rail = try #require(controller.toolbarPresentationControl)
+
+        _ = controller.presentationSwipe.handle(try scroll(phase: .began, at: 0))
+        #expect(controller.presentationSwipe.handle(try scroll(deltaX: -16, at: 0.008)))
+        // Barely moved and released slowly: not enough to commit.
+        #expect(controller.presentationSwipe.handle(try scroll(deltaX: -4, at: 0.4)))
+        #expect(controller.presentationSwipe.handle(try scroll(phase: .ended, at: 0.8)))
+
+        #expect(controller.presentationSegment == 0)
+        // The rail is back on Document. Where the indicator has physically
+        // reached is the spring's business and is covered on a windowless
+        // control above, which settles rather than flies.
+        #expect(rail.selectedSegment == 0)
+        #expect(!controller.presentationSwipe.isTracking)
+    }
+
+    @Test
+    func swipingTowardTheModeYouAreAlreadyInIsNotClaimed() throws {
+        let controller = sizedController(reduceMotion: true)
+        defer { controller.close() }
+
+        _ = controller.presentationSwipe.handle(try scroll(phase: .began, at: 0))
+        // Document is already showing, and nothing sits to the left of it.
+        #expect(!controller.presentationSwipe.handle(try scroll(deltaX: 40, at: 0.008)))
+        #expect(!controller.presentationSwipe.isTracking)
+        #expect(controller.presentationSegment == 0)
+    }
+
+    @Test
+    func swipingBackFromSourceReturnsToTheDocument() throws {
+        let controller = sizedController(reduceMotion: true)
+        defer { controller.close() }
+        controller.changePresentation(to: 1)
+        #expect(controller.presentationSegment == 1)
+
+        _ = controller.presentationSwipe.handle(try scroll(phase: .began, at: 0))
+        for step in 1...10 {
+            let event = try scroll(deltaX: 24, at: TimeInterval(step) * 0.008)
+            #expect(controller.presentationSwipe.handle(event))
+        }
+        #expect(controller.presentationSwipe.handle(try scroll(phase: .ended, at: 0.1)))
+        #expect(controller.presentationSegment == 0)
+    }
+
+    @Test
+    func theGivePathRendersNothingUntilTheFingersLift() throws {
+        // Priced out of the drag on purpose. This is the path a long document
+        // takes, and its whole promise is that it builds nothing — so the test
+        // must not depend on how long the fixture happens to be.
+        PresentationSwitchBudget.resetCalibrationForTesting(millisecondsPerLine: 100)
+        defer { PresentationSwitchBudget.resetCalibrationForTesting() }
+
+        let controller = sizedController(reduceMotion: false)
+        defer {
+            controller.presentationSwipe.cancelInFlight()
+            controller.close()
+        }
+        let paneSubviews = controller.primaryContainer.subviews.count
+
+        _ = controller.presentationSwipe.handle(try scroll(phase: .began, at: 0))
+        #expect(controller.presentationSwipe.handle(try scroll(deltaX: -40, at: 0.008)))
+        // The gesture asks for the backing store itself, so the layer only
+        // exists once a swipe has actually caught.
+        let scrollLayer = try #require(controller.primaryContainer.scrollView.layer)
+
+        // Mid-gesture the document has not been rebuilt and no surface has
+        // been added: the whole transition so far is one layer translation.
+        #expect(controller.presentationSegment == 0)
+        #expect(controller.primaryContainer.subviews.count == paneSubviews)
+        #expect(scrollLayer.transform.m41 < 0)
+        // …and it leans, rather than travelling: the give never promises the
+        // page is really going anywhere.
+        #expect(abs(scrollLayer.transform.m41) <= PresentationSwipePolicy.maximumGive)
+        #expect(controller.primaryContainer.layer?.masksToBounds == true)
+
+        controller.presentationSwipe.cancelInFlight()
+        #expect(controller.presentationSegment == 0)
+        #expect(scrollLayer.transform.m41 == 0)
+    }
+
+    @Test
+    func theGivePutsThePageBackBeforeTheSwitchDraws() throws {
+        PresentationSwitchBudget.resetCalibrationForTesting(millisecondsPerLine: 100)
+        defer { PresentationSwitchBudget.resetCalibrationForTesting() }
+        let controller = sizedController(reduceMotion: false)
+        defer { controller.close() }
+        _ = controller.presentationSwipe.handle(try scroll(phase: .began, at: 0))
+        for step in 1...10 {
+            _ = controller.presentationSwipe.handle(
+                try scroll(deltaX: -20, at: TimeInterval(step) * 0.008))
+        }
+        let scrollLayer = try #require(controller.primaryContainer.scrollView.layer)
+        #expect(scrollLayer.transform.m41 < 0)
+        #expect(controller.presentationSwipe.handle(try scroll(phase: .ended, at: 0.1)))
+
+        // The mode change animates from the pane's resting frame, so the give
+        // has to be surrendered before it runs, not after.
+        #expect(scrollLayer.transform.m41 == 0)
+        #expect(controller.presentationSegment == 1)
+        #expect(!controller.presentationSwipe.isTracking)
+        #expect(!controller.presentationSwipe.isSettling)
+    }
+
+    @Test
+    func aSwipeInSplitViewCarriesBothPanes() throws {
+        let controller = sizedController(reduceMotion: true)
+        defer { controller.close() }
+        controller.toggleSplitView()
+        controller.window?.layoutIfNeeded()
+        let split = try #require(controller.splitContainer)
+        #expect(controller.documentPanes.count == 2)
+
+        _ = controller.presentationSwipe.handle(try scroll(phase: .began, at: 0))
+        for step in 1...10 {
+            let event = try scroll(deltaX: -24, at: TimeInterval(step) * 0.008)
+            #expect(controller.presentationSwipe.handle(event))
+        }
+        #expect(controller.presentationSwipe.handle(try scroll(phase: .ended, at: 0.1)))
+
+        // The mode is the window's, not one pane's: both surfaces land in it.
+        #expect(controller.primaryContainer.textView.sourceFocus != .none)
+        #expect(split.textView.sourceFocus != .none)
+    }
+
+    @Test
+    func aResizeMidSwipeGroundsItRatherThanFlyingStaleStills() throws {
+        let controller = sizedController(reduceMotion: false)
+        defer { controller.close() }
+
+        _ = controller.presentationSwipe.handle(try scroll(phase: .began, at: 0))
+        #expect(controller.presentationSwipe.handle(try scroll(deltaX: -40, at: 0.008)))
+        #expect(controller.presentationSwipe.isTracking)
+
+        controller.windowDidResize(Notification(name: NSWindow.didResizeNotification))
+        #expect(controller.presentationSegment == 0)
+        #expect(controller.primaryContainer.scrollView.layer?.transform.m41 == 0)
+        #expect(!controller.presentationSwipe.isTracking)
+        #expect(!controller.presentationSwipe.isSettling)
+    }
+}

--- a/Tests/DownrightAppTests/ReleaseWatchProbeTests.swift
+++ b/Tests/DownrightAppTests/ReleaseWatchProbeTests.swift
@@ -1,0 +1,111 @@
+import Foundation
+import Testing
+@testable import DownrightApp
+
+/// The production probe's conditional-GET contract: validators round-trip as
+/// the matching conditional header, the server's own validators are preferred
+/// over ours, and an unchanged feed answers with no body to hash.
+@Suite(.serialized)
+@MainActor
+struct ReleaseFeedURLProbeTests {
+    private final class StubURLProtocol: URLProtocol {
+        nonisolated(unsafe) static var handler: ((URLRequest) -> (HTTPURLResponse, Data))?
+        nonisolated(unsafe) static var seenRequests: [URLRequest] = []
+
+        override class func canInit(with request: URLRequest) -> Bool { true }
+        override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+        override func startLoading() {
+            Self.seenRequests.append(request)
+            guard let handler = Self.handler else {
+                client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+                return
+            }
+            let (response, data) = handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        }
+
+        override func stopLoading() {}
+    }
+
+    private func makeProbe() -> ReleaseFeedURLProbe {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [StubURLProtocol.self]
+        StubURLProtocol.seenRequests = []
+        return ReleaseFeedURLProbe(session: URLSession(configuration: configuration))
+    }
+
+    private static func response(
+        status: Int, headers: [String: String] = [:], url: URL
+    ) -> HTTPURLResponse {
+        HTTPURLResponse(url: url, statusCode: status, httpVersion: "HTTP/1.1", headerFields: headers)!
+    }
+
+    @Test("A Last-Modified validator is stored and sent back as If-Modified-Since")
+    func lastModifiedRoundTrips() async throws {
+        let feed = URL(string: "https://feeds.example/appcast.xml")!
+        let date = "Wed, 21 Oct 2026 07:28:00 GMT"
+        StubURLProtocol.handler = { request in
+            (Self.response(status: 200, headers: ["Last-Modified": date], url: request.url!), Data("feed".utf8))
+        }
+        let probe = makeProbe()
+
+        guard case .changed(let validator?) = await probe.probe(feed: feed, validator: nil) else {
+            Issue.record("a first probe must report a change")
+            return
+        }
+        #expect(validator == "lastModified:\(date)")
+
+        // The next probe carries the date and a 304 answers without a body.
+        StubURLProtocol.handler = { request in
+            #expect(request.value(forHTTPHeaderField: "If-Modified-Since") == date)
+            return (Self.response(status: 304, url: request.url!), Data())
+        }
+        let second = await probe.probe(feed: feed, validator: validator)
+        #expect(second == .unchanged)
+    }
+
+    @Test("The server ETag is preferred over the document date")
+    func etagWinsOverLastModified() async throws {
+        let feed = URL(string: "https://feeds.example/appcast.xml")!
+        StubURLProtocol.handler = { request in
+            (Self.response(
+                status: 200,
+                headers: ["ETag": "\"v2\"", "Last-Modified": "Wed, 21 Oct 2026 07:28:00 GMT"],
+                url: request.url!
+            ), Data("feed".utf8))
+        }
+        let probe = makeProbe()
+
+        guard case .changed(let validator?) = await probe.probe(feed: feed, validator: nil) else {
+            Issue.record("a first probe must report a change")
+            return
+        }
+        #expect(validator == "etag:\"v2\"")
+    }
+
+    @Test("A body-hash validator is never offered back as a conditional header")
+    func bodyHashStaysLocal() async throws {
+        let feed = URL(string: "https://feeds.example/appcast.xml")!
+        StubURLProtocol.handler = { request in
+            (Self.response(status: 200, url: request.url!), Data("feed".utf8))
+        }
+        let probe = makeProbe()
+
+        guard case .changed(let validator?) = await probe.probe(feed: feed, validator: nil) else {
+            Issue.record("a first probe must report a change")
+            return
+        }
+        #expect(validator.hasPrefix("sha256:"))
+
+        StubURLProtocol.handler = { request in
+            #expect(request.value(forHTTPHeaderField: "If-None-Match") == nil)
+            #expect(request.value(forHTTPHeaderField: "If-Modified-Since") == nil)
+            return (Self.response(status: 200, url: request.url!), Data("feed".utf8))
+        }
+        let second = await probe.probe(feed: feed, validator: validator)
+        #expect(second == .unchanged)
+    }
+}

--- a/Tests/DownrightAppTests/ScrollGestureChainTests.swift
+++ b/Tests/DownrightAppTests/ScrollGestureChainTests.swift
@@ -1,0 +1,83 @@
+import AppKit
+import Testing
+@testable import DownrightApp
+
+@Suite(.serialized)
+@MainActor
+struct ScrollGestureChainTests {
+
+    private final class Stub: ScrollGestureHandler {
+        var claims = false
+        var owns = false
+        private(set) var seen = 0
+
+        var isClaimingGesture: Bool { owns }
+
+        func handle(_ event: NSEvent) -> Bool {
+            seen += 1
+            return claims
+        }
+    }
+
+    private func event() throws -> NSEvent {
+        try SyntheticScroll.event(deltaY: -12)
+    }
+
+    @Test
+    func theFirstHandlerToClaimEndsTheChain() throws {
+        let first = Stub()
+        let second = Stub()
+        let third = Stub()
+        second.claims = true
+        let chain = ScrollGestureChain([first, second, third])
+
+        #expect(chain.handle(try event()))
+        #expect(first.seen == 1)
+        #expect(second.seen == 1)
+        // Two gestures acting on one event is a page that scrolls and zooms at
+        // the same time; the one behind the winner never hears about it.
+        #expect(third.seen == 0)
+    }
+
+    @Test
+    func handlersThatDeclineStillSeeEveryEvent() throws {
+        let first = Stub()
+        let second = Stub()
+        let chain = ScrollGestureChain([first, second])
+
+        // Both swipes spend the first few events deciding, and they can only
+        // decide by accumulating travel — so declining must not cost them the
+        // events they are declining.
+        #expect(!chain.handle(try event()))
+        #expect(!chain.handle(try event()))
+        #expect(first.seen == 2)
+        #expect(second.seen == 2)
+    }
+
+    @Test
+    func aGestureThatHasAlreadyCaughtKeepsTheRestOfIt() throws {
+        let first = Stub()
+        let second = Stub()
+        first.claims = true
+        second.owns = true
+        let chain = ScrollGestureChain([first, second])
+
+        // The swipe on screen owns the fingers.  Polling from the top here is
+        // how a modifier pressed halfway through a swipe would hand the events
+        // to a zoom and leave a translated pane nobody owns.
+        #expect(!chain.handle(try event()))
+        #expect(first.seen == 0)
+        #expect(second.seen == 1)
+
+        second.owns = false
+        #expect(chain.handle(try event()))
+        #expect(first.seen == 1)
+        #expect(second.seen == 1)
+    }
+
+    @Test
+    func anEventNobodyWantsGoesStraightBackToTheScrollView() throws {
+        let chain = ScrollGestureChain([Stub(), Stub()])
+        #expect(!chain.handle(try event()))
+    }
+}

--- a/Tests/DownrightAppTests/ScrollZoomTests.swift
+++ b/Tests/DownrightAppTests/ScrollZoomTests.swift
@@ -1,0 +1,458 @@
+import AppKit
+import MarkdownCore
+import MarkdownRender
+import Testing
+@testable import DownrightApp
+
+@Suite(.serialized)
+@MainActor
+struct ScrollZoomTests {
+
+    // MARK: - Synthetic events
+
+    private func scroll(
+        deltaY: CGFloat = 0,
+        deltaX: CGFloat = 0,
+        phase: CGScrollPhase? = .changed,
+        momentum: CGMomentumScrollPhase = CGMomentumScrollPhase.none,
+        precise: Bool = true,
+        modifiers: NSEvent.ModifierFlags = [],
+        at seconds: TimeInterval = 0
+    ) throws -> NSEvent {
+        try SyntheticScroll.event(
+            deltaX: deltaX, deltaY: deltaY, phase: phase, momentum: momentum,
+            precise: precise, modifiers: modifiers, at: seconds
+        )
+    }
+
+    /// A coordinator with everything it touches recorded rather than done.
+    private final class Recorder {
+        var textSteps: [Int] = []
+        var detailSteps: [Int] = []
+        var haptics = 0
+
+        var host: ScrollZoomCoordinator.Host {
+            ScrollZoomCoordinator.Host(
+                stepTextSize: { [self] in textSteps.append($0) },
+                stepDetail: { [self] in detailSteps.append($0) },
+                performHapticFeedback: { [self] in haptics += 1 }
+            )
+        }
+    }
+
+    @Test
+    func syntheticEventsCarryModifiersAndBothDeltaKinds() throws {
+        let trackpad = try scroll(deltaY: -18, modifiers: .command, at: 1)
+        #expect(trackpad.hasPreciseScrollingDeltas)
+        #expect(trackpad.modifierFlags.contains(.command))
+        #expect(!trackpad.modifierFlags.contains(.option))
+        #expect(abs(trackpad.scrollingDeltaY - -18) < 0.001)
+
+        // A wheel reports lines, and the coarse path only works if the event
+        // really carries them.
+        let wheel = try scroll(deltaY: 3, phase: nil, precise: false, modifiers: .option)
+        #expect(!wheel.hasPreciseScrollingDeltas)
+        #expect(wheel.modifierFlags.contains(.option))
+        #expect(abs(wheel.scrollingDeltaY - 3) < 0.001)
+
+        // Nothing held means nothing held, whatever the machine running the
+        // test has its hands on.
+        let bare = try scroll(deltaY: 4)
+        #expect(ScrollGestureModifiers.held(in: bare).isEmpty)
+
+        // Time is a real input here — the wheel's gesture boundary and every
+        // flick are read out of it — so the synthesized clock has to survive
+        // the round trip through `CGEvent`.
+        let later = try scroll(deltaY: 4, at: 2)
+        #expect(abs((later.timestamp - bare.timestamp) - 2) < 0.001)
+    }
+
+    // MARK: - Policy
+
+    @Test
+    func onlyExactlyCommandOrExactlyOptionIsAZoom() {
+        #expect(ScrollZoomPolicy.intent(for: [.command]) == .textSize)
+        #expect(ScrollZoomPolicy.intent(for: [.option]) == .structuralDetail)
+        #expect(ScrollZoomPolicy.intent(for: []) == nil)
+        // ⇧⌘ is jump history's business plus a stray finger; a zoom that
+        // answered to any superset would fire underneath it.
+        #expect(ScrollZoomPolicy.intent(for: [.command, .shift]) == nil)
+        #expect(ScrollZoomPolicy.intent(for: [.option, .control]) == nil)
+        #expect(ScrollZoomPolicy.intent(for: [.control]) == nil)
+        #expect(ScrollZoomPolicy.intent(for: [.shift]) == nil)
+    }
+
+    @Test
+    func capsLockAndFnRideAlongWithoutCancellingAZoom() throws {
+        let event = try scroll(deltaY: -10, modifiers: [.command, .capsLock, .function])
+        #expect(ScrollZoomPolicy.intent(for: ScrollGestureModifiers.held(in: event)) == .textSize)
+    }
+
+    @Test
+    func aWheelsAccelerationIsThrownAwayAndATrackpadsPointsAreNot() {
+        // Points are what the fingers actually travelled.
+        #expect(ScrollZoomPolicy.contribution(deltaY: 37.5, precise: true) == 37.5)
+        #expect(ScrollZoomPolicy.contribution(deltaY: -37.5, precise: true) == -37.5)
+        // Lines arrive with macOS's acceleration curve baked in, and that
+        // curve turns one flick of the wheel into the whole scale.
+        #expect(ScrollZoomPolicy.contribution(deltaY: 12, precise: false) == 1)
+        #expect(ScrollZoomPolicy.contribution(deltaY: -12, precise: false) == -1)
+        #expect(ScrollZoomPolicy.contribution(deltaY: 1, precise: false) == 1)
+        #expect(ScrollZoomPolicy.contribution(deltaY: 0, precise: false) == 0)
+    }
+
+    @Test
+    func detailAsksForMoreTravelThanTextSize() {
+        #expect(ScrollZoomPolicy.stepThreshold(.structuralDetail, precise: true)
+            > ScrollZoomPolicy.stepThreshold(.textSize, precise: true))
+        // A wheel's notch is the detent, for both scales.
+        #expect(ScrollZoomPolicy.stepThreshold(.textSize, precise: false)
+            == ScrollZoomPolicy.wheelStepLines)
+        #expect(ScrollZoomPolicy.stepThreshold(.structuralDetail, precise: false)
+            == ScrollZoomPolicy.wheelStepLines)
+    }
+
+    @Test
+    func textSizeRampsAndStructuralDetailDoesNot() {
+        #expect(ScrollZoomPolicy.allowsFurtherSteps(.textSize, spent: 0))
+        #expect(ScrollZoomPolicy.allowsFurtherSteps(.textSize, spent: 9))
+        #expect(ScrollZoomPolicy.allowsFurtherSteps(.structuralDetail, spent: 0))
+        #expect(!ScrollZoomPolicy.allowsFurtherSteps(.structuralDetail, spent: 1))
+        #expect(!ScrollZoomPolicy.allowsFurtherSteps(.structuralDetail, spent: -1))
+    }
+
+    @Test
+    func stepsAreEarnedByTravelAndCappedByWhatTheGestureHasLeft() {
+        let text = ScrollZoomPolicy.textSizeStepPoints
+        #expect(ScrollZoomPolicy.steps(
+            .textSize, accumulated: text - 0.01, spent: 0, precise: true) == 0)
+        #expect(ScrollZoomPolicy.steps(
+            .textSize, accumulated: text, spent: 0, precise: true) == 1)
+        // A ramp is allowed to be a ramp.
+        #expect(ScrollZoomPolicy.steps(
+            .textSize, accumulated: text * 3.5, spent: 4, precise: true) == 3)
+        #expect(ScrollZoomPolicy.steps(
+            .textSize, accumulated: -text * 2, spent: 0, precise: true) == -2)
+
+        let detail = ScrollZoomPolicy.detailStepPoints
+        #expect(ScrollZoomPolicy.steps(
+            .structuralDetail, accumulated: detail - 0.01, spent: 0, precise: true) == 0)
+        #expect(ScrollZoomPolicy.steps(
+            .structuralDetail, accumulated: detail, spent: 0, precise: true) == 1)
+        // Five levels per flick is the failure this whole detent exists for:
+        // one event that crosses the line five times still buys one step.
+        #expect(ScrollZoomPolicy.steps(
+            .structuralDetail, accumulated: detail * 5, spent: 0, precise: true) == 1)
+        #expect(ScrollZoomPolicy.steps(
+            .structuralDetail, accumulated: -detail * 5, spent: 0, precise: true) == -1)
+        // …and once it is spent the gesture is over as far as detail goes.
+        #expect(ScrollZoomPolicy.steps(
+            .structuralDetail, accumulated: detail * 5, spent: 1, precise: true) == 0)
+    }
+
+    @Test
+    func aWheelsGestureIsTheQuietAroundIt() {
+        #expect(!ScrollZoomPolicy.startsNewWheelGesture(since: 0))
+        // A spin: events a couple of frames apart.
+        #expect(!ScrollZoomPolicy.startsNewWheelGesture(since: 0.03))
+        #expect(!ScrollZoomPolicy.startsNewWheelGesture(
+            since: ScrollZoomPolicy.wheelGestureGap - 0.001))
+        // A notch, a look, another notch.
+        #expect(ScrollZoomPolicy.startsNewWheelGesture(
+            since: ScrollZoomPolicy.wheelGestureGap))
+        #expect(ScrollZoomPolicy.startsNewWheelGesture(since: 5))
+    }
+
+    // MARK: - Coordinator: nothing held
+
+    @Test
+    func anUnmodifiedScrollIsNeverClaimedAndNeverZooms() throws {
+        let recorder = Recorder()
+        let zoom = ScrollZoomCoordinator(host: recorder.host)
+
+        #expect(!zoom.handle(try scroll(phase: .began, at: 0)))
+        for step in 1...20 {
+            #expect(!zoom.handle(try scroll(deltaY: -40, at: TimeInterval(step) * 0.008)))
+        }
+        #expect(!zoom.handle(try scroll(phase: .ended, at: 0.2)))
+        #expect(recorder.textSteps.isEmpty)
+        #expect(recorder.detailSteps.isEmpty)
+    }
+
+    // MARK: - Coordinator: ⌘ text size
+
+    @Test
+    func commandScrollBanksTravelAndReleasesWholeSteps() throws {
+        let recorder = Recorder()
+        let zoom = ScrollZoomCoordinator(host: recorder.host)
+        let step = ScrollZoomPolicy.textSizeStepPoints
+
+        #expect(zoom.handle(try scroll(phase: .began, modifiers: .command, at: 0)))
+        // Short of the threshold the event is still swallowed — the page must
+        // not scroll while ⌘ is down — but nothing has been earned yet.
+        #expect(zoom.handle(try scroll(deltaY: step / 2, modifiers: .command, at: 0.008)))
+        #expect(recorder.textSteps.isEmpty)
+
+        #expect(zoom.handle(try scroll(deltaY: step / 2, modifiers: .command, at: 0.016)))
+        #expect(recorder.textSteps == [1])
+        // Only the travel the step cost is spent; the remainder rolls on, so a
+        // steady drag steps at a steady rate instead of stuttering.
+        #expect(abs(zoom.accumulatedTravelForTesting) < 0.001)
+
+        #expect(zoom.handle(try scroll(deltaY: step * 2, modifiers: .command, at: 0.024)))
+        #expect(recorder.textSteps == [1, 2])
+        #expect(recorder.detailSteps.isEmpty)
+        // Sizing text is not a detent; it is a ramp, and a ramp does not tap.
+        #expect(recorder.haptics == 0)
+    }
+
+    @Test
+    func commandScrollTheOtherWayMakesTextSmaller() throws {
+        let recorder = Recorder()
+        let zoom = ScrollZoomCoordinator(host: recorder.host)
+
+        #expect(zoom.handle(try scroll(phase: .began, modifiers: .command, at: 0)))
+        #expect(zoom.handle(try scroll(
+            deltaY: -ScrollZoomPolicy.textSizeStepPoints, modifiers: .command, at: 0.008)))
+        #expect(recorder.textSteps == [-1])
+    }
+
+    @Test
+    func theMomentumTailIsSwallowedButNeverZooms() throws {
+        let recorder = Recorder()
+        let zoom = ScrollZoomCoordinator(host: recorder.host)
+        let step = ScrollZoomPolicy.textSizeStepPoints
+
+        #expect(zoom.handle(try scroll(phase: .began, modifiers: .command, at: 0)))
+        #expect(zoom.handle(try scroll(deltaY: step, modifiers: .command, at: 0.008)))
+        #expect(zoom.handle(try scroll(phase: .ended, modifiers: .command, at: 0.016)))
+        #expect(recorder.textSteps == [1])
+
+        // The coast after the fingers lift. Handing it back would scroll the
+        // page out from under a size the reader just settled on.
+        for tick in 1...20 {
+            let event = try scroll(
+                deltaY: 200, phase: nil, momentum: .continuous,
+                modifiers: .command, at: 0.016 + TimeInterval(tick) * 0.008
+            )
+            #expect(zoom.handle(event))
+        }
+        #expect(recorder.textSteps == [1])
+    }
+
+    @Test
+    func lettingGoOfTheModifierHandsTheRestOfTheGestureBack() throws {
+        let recorder = Recorder()
+        let zoom = ScrollZoomCoordinator(host: recorder.host)
+        let step = ScrollZoomPolicy.textSizeStepPoints
+
+        #expect(zoom.handle(try scroll(phase: .began, modifiers: .command, at: 0)))
+        #expect(zoom.handle(try scroll(deltaY: step, modifiers: .command, at: 0.008)))
+        #expect(recorder.textSteps == [1])
+        // ⌘ up mid-gesture: the rest of it is an ordinary scroll again.
+        #expect(!zoom.handle(try scroll(deltaY: step * 4, at: 0.016)))
+        #expect(recorder.textSteps == [1])
+    }
+
+    // MARK: - Coordinator: ⌥ structural detail
+
+    @Test
+    func optionScrollSpendsExactlyOneLevelPerTrackpadGesture() throws {
+        let recorder = Recorder()
+        let zoom = ScrollZoomCoordinator(host: recorder.host)
+
+        #expect(zoom.handle(try scroll(phase: .began, modifiers: .option, at: 0)))
+        // A hard flick: far more travel than one level's worth, all in one
+        // gesture. Five relayouts of the whole document is the thing this is
+        // here to prevent.
+        for step in 1...20 {
+            let event = try scroll(
+                deltaY: -40, modifiers: .option, at: TimeInterval(step) * 0.008
+            )
+            #expect(zoom.handle(event))
+        }
+        #expect(recorder.detailSteps == [-1])
+        #expect(recorder.haptics == 1)
+        #expect(zoom.handle(try scroll(phase: .ended, modifiers: .option, at: 0.2)))
+
+        // Fingers down again is a new gesture, and buys one more.
+        #expect(zoom.handle(try scroll(phase: .began, modifiers: .option, at: 0.4)))
+        for step in 1...20 {
+            let event = try scroll(
+                deltaY: -40, modifiers: .option, at: 0.4 + TimeInterval(step) * 0.008
+            )
+            #expect(zoom.handle(event))
+        }
+        #expect(recorder.detailSteps == [-1, -1])
+        #expect(recorder.haptics == 2)
+    }
+
+    @Test
+    func aShortOptionNudgeDoesNotMoveTheDetailLevel() throws {
+        let recorder = Recorder()
+        let zoom = ScrollZoomCoordinator(host: recorder.host)
+
+        #expect(zoom.handle(try scroll(phase: .began, modifiers: .option, at: 0)))
+        #expect(zoom.handle(try scroll(
+            deltaY: -(ScrollZoomPolicy.detailStepPoints - 1), modifiers: .option, at: 0.008)))
+        #expect(zoom.handle(try scroll(phase: .ended, modifiers: .option, at: 0.016)))
+        #expect(recorder.detailSteps.isEmpty)
+        // …and the travel that did not earn anything is not banked toward the
+        // next gesture, which would fire early for no visible reason.
+        #expect(zoom.accumulatedTravelForTesting == 0)
+        #expect(zoom.stepsFiredForTesting == 0)
+    }
+
+    @Test
+    func optionScrollUpwardShowsMoreDetail() throws {
+        let recorder = Recorder()
+        let zoom = ScrollZoomCoordinator(host: recorder.host)
+
+        #expect(zoom.handle(try scroll(phase: .began, modifiers: .option, at: 0)))
+        #expect(zoom.handle(try scroll(
+            deltaY: ScrollZoomPolicy.detailStepPoints, modifiers: .option, at: 0.008)))
+        #expect(recorder.detailSteps == [1])
+    }
+
+    // MARK: - Coordinator: the wheel
+
+    @Test
+    func oneWheelNotchIsOneTextSizeStepHoweverHardItIsSpun() throws {
+        let recorder = Recorder()
+        let zoom = ScrollZoomCoordinator(host: recorder.host)
+
+        // A gentle notch.
+        #expect(zoom.handle(try scroll(
+            deltaY: 1, phase: nil, precise: false, modifiers: .command, at: 1)))
+        #expect(recorder.textSteps == [1])
+        // An accelerated one: macOS reports twelve lines, the hand turned one
+        // notch, and one notch is what it gets.
+        #expect(zoom.handle(try scroll(
+            deltaY: 12, phase: nil, precise: false, modifiers: .command, at: 1.03)))
+        #expect(recorder.textSteps == [1, 1])
+        // Text size is a ramp, so a spin keeps ramping.
+        #expect(zoom.handle(try scroll(
+            deltaY: 12, phase: nil, precise: false, modifiers: .command, at: 1.06)))
+        #expect(recorder.textSteps == [1, 1, 1])
+    }
+
+    @Test
+    func aSpinOfTheWheelIsOneStructuralLevelAndADeliberateNotchIsAnother() throws {
+        let recorder = Recorder()
+        let zoom = ScrollZoomCoordinator(host: recorder.host)
+
+        // A spin: notches a frame or two apart, accelerated hard.
+        for tick in 0...9 {
+            let event = try scroll(
+                deltaY: -8, phase: nil, precise: false, modifiers: .option,
+                at: 1 + TimeInterval(tick) * 0.03
+            )
+            #expect(zoom.handle(event))
+        }
+        #expect(recorder.detailSteps == [-1])
+
+        // A pause, then a deliberate notch: the reader looked at the result
+        // and asked for one more.
+        #expect(zoom.handle(try scroll(
+            deltaY: -1, phase: nil, precise: false, modifiers: .option,
+            at: 1 + 9 * 0.03 + ScrollZoomPolicy.wheelGestureGap + 0.05
+        )))
+        #expect(recorder.detailSteps == [-1, -1])
+        #expect(recorder.haptics == 2)
+    }
+
+    @Test
+    func switchingModifierMidStreamStartsTheOtherScaleFromZero() throws {
+        let recorder = Recorder()
+        let zoom = ScrollZoomCoordinator(host: recorder.host)
+
+        #expect(zoom.handle(try scroll(phase: .began, modifiers: .option, at: 0)))
+        #expect(zoom.handle(try scroll(
+            deltaY: -(ScrollZoomPolicy.detailStepPoints - 5), modifiers: .option, at: 0.008)))
+        #expect(recorder.detailSteps.isEmpty)
+
+        // ⌥ up, ⌘ down, same fingers still moving. The travel banked toward a
+        // detail level must not fall through into a text-size step.
+        #expect(zoom.handle(try scroll(deltaY: -5, modifiers: .command, at: 0.016)))
+        #expect(recorder.textSteps.isEmpty)
+        #expect(recorder.detailSteps.isEmpty)
+        #expect(zoom.handle(try scroll(
+            deltaY: -ScrollZoomPolicy.textSizeStepPoints, modifiers: .command, at: 0.024)))
+        #expect(recorder.textSteps == [-1])
+    }
+
+    // MARK: - Wired into the window
+
+    @Test
+    func optionScrollMovesTheDocumentsDetailLevelThroughTheRealCommands() throws {
+        let controller = DocumentWindowController()
+        defer { controller.close() }
+        controller.window?.setFrame(NSRect(x: 0, y: 0, width: 900, height: 700), display: false)
+        controller.window?.layoutIfNeeded()
+        #expect(controller.containerTextView.zoomLevel == .everything)
+
+        _ = controller.documentScrollGestures.handle(
+            try scroll(phase: .began, modifiers: .option, at: 0))
+        for step in 1...10 {
+            let event = try scroll(
+                deltaY: -30, modifiers: .option, at: TimeInterval(step) * 0.008
+            )
+            #expect(controller.documentScrollGestures.handle(event))
+        }
+        _ = controller.documentScrollGestures.handle(
+            try scroll(phase: .ended, modifiers: .option, at: 0.1))
+
+        // One level, not five — and through `.zoomOut`, so the gesture and the
+        // ⌃⌥⌘- chord cannot drift apart about where the scale ends.
+        #expect(controller.containerTextView.zoomLevel == .skeleton)
+        #expect(controller.markdownDocument.state.zoomLevel == .skeleton)
+    }
+
+    @Test
+    func commandScrollMovesTheReadingTextSize() throws {
+        let controller = DocumentWindowController()
+        defer { controller.close() }
+        controller.window?.setFrame(NSRect(x: 0, y: 0, width: 900, height: 700), display: false)
+        controller.window?.layoutIfNeeded()
+
+        // Text size is a preference, so put it back however this ends.
+        let original = Preferences.shared.values.textSizeAdjustment
+        defer { Preferences.shared.update { $0.textSizeAdjustment = original } }
+        Preferences.shared.update { $0.textSizeAdjustment = 0 }
+
+        _ = controller.documentScrollGestures.handle(
+            try scroll(phase: .began, modifiers: .command, at: 0))
+        #expect(controller.documentScrollGestures.handle(try scroll(
+            deltaY: ScrollZoomPolicy.textSizeStepPoints * 2, modifiers: .command, at: 0.008)))
+        _ = controller.documentScrollGestures.handle(
+            try scroll(phase: .ended, modifiers: .command, at: 0.016))
+
+        #expect(Preferences.shared.values.textSizeAdjustment == 2)
+    }
+
+    @Test
+    func aModifiedSidewaysScrollNeverSwitchesPresentation() throws {
+        let controller = DocumentWindowController()
+        defer { controller.close() }
+        controller.window?.setFrame(NSRect(x: 0, y: 0, width: 900, height: 700), display: false)
+        controller.window?.layoutIfNeeded()
+        controller.primaryContainer.layoutSubtreeIfNeeded()
+
+        // Exactly the gesture that switches Document↔Source, with ⌘ held. The
+        // zoom takes it, and the swipe has to stand down on its own account
+        // rather than trust that it was asked second.
+        _ = controller.documentScrollGestures.handle(
+            try scroll(phase: .began, modifiers: .command, at: 0))
+        for step in 1...12 {
+            let event = try scroll(
+                deltaX: -20, modifiers: .command, at: TimeInterval(step) * 0.008
+            )
+            #expect(controller.documentScrollGestures.handle(event))
+        }
+        _ = controller.documentScrollGestures.handle(
+            try scroll(phase: .ended, modifiers: .command, at: 0.12))
+
+        #expect(controller.presentationSegment == 0)
+        #expect(!controller.presentationSwipe.isTracking)
+    }
+}

--- a/Tests/DownrightAppTests/ShareAndCaptureTests.swift
+++ b/Tests/DownrightAppTests/ShareAndCaptureTests.swift
@@ -1,0 +1,451 @@
+import AppKit
+import Foundation
+import MarkdownCore
+import MarkdownRender
+import Testing
+@testable import DownrightApp
+
+/// Share and Continuity Camera: the two places where the document leaves the
+/// app and where something from outside it comes back in.
+///
+/// Both have the same failure mode — they look like they worked.  A share that
+/// sends the file instead of the buffer arrives as a stale document nobody
+/// notices until the receiver reads it, and a capture that writes an
+/// unresolvable path renders as a broken image only after the window is closed.
+/// So these tests are mostly about *which bytes* and *which path*.
+@Suite(.serialized)
+struct ShareAndCaptureTests {
+
+    private func makeTemporaryDirectory() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ShareAndCaptureTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory
+    }
+
+    // MARK: - What Share actually sends
+
+    @Test func savedAndUnmodifiedDocumentSharesItsOwnFile() {
+        let url = URL(fileURLWithPath: "/tmp/notes/design.md")
+        let source = DocumentShareSource.choose(
+            url: url, hasUnsavedChanges: false, displayName: "design"
+        )
+        #expect(source == .documentFile(url))
+    }
+
+    /// The case that would otherwise be a silent lie: AirDropping "the
+    /// document" while the reader is looking at ten minutes of unsaved typing.
+    @Test func modifiedDocumentSharesTheBufferNotTheStaleFile() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let url = directory.appendingPathComponent("design.md")
+        try "on disk\n".write(to: url, atomically: true, encoding: .utf8)
+
+        let source = DocumentShareSource.choose(
+            url: url, hasUnsavedChanges: true, displayName: "design"
+        )
+        #expect(source == .bufferSnapshot(fileName: "design.md"))
+
+        let staged = try DocumentShareStaging.fileURL(
+            for: source, text: "in the buffer\n", fidelity: .default, root: directory
+        )
+        #expect(staged != url)
+        // The receiver sees the document's own filename, not a staging name.
+        #expect(staged.lastPathComponent == "design.md")
+        #expect(try String(contentsOf: staged, encoding: .utf8) == "in the buffer\n")
+        // Share is not a save: the original must be exactly as it was.
+        #expect(try String(contentsOf: url, encoding: .utf8) == "on disk\n")
+    }
+
+    @Test func neverSavedDocumentSharesANamedMarkdownFile() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let source = DocumentShareSource.choose(
+            url: nil, hasUnsavedChanges: true, displayName: "Untitled"
+        )
+        #expect(source == .bufferSnapshot(fileName: "Untitled.md"))
+
+        let staged = try DocumentShareStaging.fileURL(
+            for: source, text: "# Draft\n", fidelity: .default, root: directory
+        )
+        // The whole point of staging a file rather than sharing a string: what
+        // lands in AirDrop is a `.md` the receiver can open.
+        #expect(staged.pathExtension == "md")
+        #expect(FileManager.default.fileExists(atPath: staged.path))
+    }
+
+    /// A shared copy is a copy (§3.1).  A CRLF document that arrives normalised
+    /// to LF is not the document that was shared.
+    @Test func snapshotKeepsTheDocumentsByteFidelity() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let fidelity = ByteFidelity(
+            encoding: .utf8, hasBOM: false, lineEnding: .crlf, hasTrailingNewline: true
+        )
+        let staged = try DocumentShareStaging.fileURL(
+            for: .bufferSnapshot(fileName: "crlf.md"),
+            text: "one\ntwo\n", fidelity: fidelity, root: directory
+        )
+        let data = try Data(contentsOf: staged)
+        #expect(String(decoding: data, as: UTF8.self) == "one\r\ntwo\r\n")
+    }
+
+    /// A display name is arbitrary text.  `/` in it would redirect the write.
+    @Test func stagedNamesCannotEscapeTheStagingDirectory() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let source = DocumentShareSource.choose(
+            url: nil, hasUnsavedChanges: true, displayName: "../../etc/passwd"
+        )
+        #expect(source == .bufferSnapshot(fileName: "etc-passwd.md"))
+        let staged = try DocumentShareStaging.fileURL(
+            for: source, text: "x\n", fidelity: .default, root: directory
+        )
+        #expect(staged.deletingLastPathComponent().deletingLastPathComponent()
+            .lastPathComponent == "Downright-Share")
+
+        let pdf = try DocumentShareStaging.pdfURL(displayName: "notes/../secret", root: directory)
+        #expect(pdf.lastPathComponent == "notes-..-secret.pdf")
+    }
+
+    /// Two shares in the same second must not collide on one path.
+    @Test func everyShareGetsItsOwnStagingDirectory() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let first = try DocumentShareStaging.fileURL(
+            for: .bufferSnapshot(fileName: "a.md"), text: "one\n", fidelity: .default, root: directory
+        )
+        let second = try DocumentShareStaging.fileURL(
+            for: .bufferSnapshot(fileName: "a.md"), text: "two\n", fidelity: .default, root: directory
+        )
+        #expect(first != second)
+        #expect(try String(contentsOf: first, encoding: .utf8) == "one\n")
+        #expect(try String(contentsOf: second, encoding: .utf8) == "two\n")
+    }
+
+    // MARK: - Share in the command table
+
+    @Test @MainActor func shareIsAFileMenuCommandWithItsOwnChord() {
+        _ = NSApplication.shared
+        #expect(Command.share.menu == .file)
+        #expect(Command.shareAsPDF.menu == .file)
+        #expect(KeybindingDefaults.table[.share] == [KeyBinding("s", [.command, .control])])
+        // Save and Save As keep theirs.
+        #expect(KeybindingDefaults.table[.save] == [KeyBinding("s", .command)])
+        #expect(KeybindingDefaults.table[.saveAs] == [KeyBinding("s", [.command, .shift])])
+
+        var found: NSMenuItem?
+        func walk(_ menu: NSMenu) {
+            for item in menu.items {
+                if MainMenu.command(for: item) == .share { found = item }
+                if let submenu = item.submenu { walk(submenu) }
+            }
+        }
+        walk(MainMenu.build())
+        let item = found
+        #expect(item?.title == "Share…")
+        // The chord shown is read back out of the binding store, so a remap
+        // cannot leave the menu advertising a shortcut that does nothing.
+        #expect(item?.keyEquivalent == "s")
+        #expect(item?.keyEquivalentModifierMask == [.command, .control])
+    }
+
+    /// An Untitled window is exactly where a reader most wants Share, so the
+    /// precondition is `.document`, not `.documentWithFile`.
+    @Test func shareIsAvailableBeforeTheDocumentHasEverBeenSaved() {
+        #expect(Command.share.isEnabled(in: CommandContext(hasDocument: true)))
+        #expect(Command.shareAsPDF.isEnabled(in: CommandContext(hasDocument: true)))
+        #expect(!Command.share.isEnabled(in: .applicationOnly(canCheckForUpdates: false)))
+        #expect(!Command.shareAsPDF.isEnabled(in: .applicationOnly(canCheckForUpdates: false)))
+    }
+
+    // MARK: - The Continuity Camera menu host
+
+    /// AppKit substitutes Take Photo / Scan Documents for the placeholder, and
+    /// the identifier is the only thing that marks it.  Lose that and the
+    /// feature disappears with no other symptom.
+    @Test @MainActor func editMenuCarriesTheImportFromDevicePlaceholder() {
+        _ = NSApplication.shared
+        let edit = MainMenu.build().items.compactMap(\.submenu).first { $0.title == "Edit" }
+        let insert = edit?.items.first { $0.title == "Insert" }
+        #expect(insert?.submenu != nil)
+        let placeholder = insert?.submenu?.items.first
+        #expect(placeholder?.identifier == NSMenuItem.importFromDeviceIdentifier)
+        // No action of our own: the substituted items carry theirs, and a
+        // hand-written selector would be a second, wrong answer.
+        #expect(placeholder?.action == nil)
+    }
+
+    // MARK: - Decoding a capture
+
+    private func bitmap(width: Int = 8, height: Int = 8) -> NSBitmapImageRep {
+        let rep = NSBitmapImageRep(
+            bitmapDataPlanes: nil, pixelsWide: width, pixelsHigh: height,
+            bitsPerSample: 8, samplesPerPixel: 4, hasAlpha: true, isPlanar: false,
+            colorSpaceName: .deviceRGB, bytesPerRow: 0, bitsPerPixel: 0
+        )!
+        NSGraphicsContext.saveGraphicsState()
+        NSGraphicsContext.current = NSGraphicsContext(bitmapImageRep: rep)
+        NSColor.systemTeal.setFill()
+        NSRect(x: 0, y: 0, width: width, height: height).fill()
+        NSGraphicsContext.restoreGraphicsState()
+        return rep
+    }
+
+    private func makePasteboard(
+        _ data: Data, type: NSPasteboard.PasteboardType
+    ) -> NSPasteboard {
+        let pasteboard = NSPasteboard(name: NSPasteboard.Name("ShareAndCaptureTests-\(UUID().uuidString)"))
+        pasteboard.clearContents()
+        pasteboard.setData(data, forType: type)
+        return pasteboard
+    }
+
+    @Test func pngCapturesAreWrittenVerbatim() throws {
+        let png = try #require(bitmap().representation(using: .png, properties: [:]))
+        let pasteboard = makePasteboard(png, type: .png)
+        defer { pasteboard.releaseGlobally() }
+        let payload = try #require(CapturedImage.payload(from: pasteboard))
+        #expect(payload.fileExtension == "png")
+        #expect(payload.data == png)
+    }
+
+    /// TIFF is not in `AssetResolutionContext.supportedExtensions`, so passing
+    /// it through would hand the Asset Doctor a diagnostic on arrival.
+    @Test func unsupportedCaptureFormatsAreReencodedAsPNG() throws {
+        let tiff = try #require(bitmap().representation(using: .tiff, properties: [:]))
+        let pasteboard = makePasteboard(tiff, type: .tiff)
+        defer { pasteboard.releaseGlobally() }
+        let payload = try #require(CapturedImage.payload(from: pasteboard))
+        #expect(payload.fileExtension == "png")
+        #expect(NSBitmapImageRep(data: payload.data) != nil)
+        #expect(AssetResolutionContext().supportedExtensions.contains(payload.fileExtension))
+    }
+
+    @Test func nonImagePasteboardsAreDeclined() {
+        let pasteboard = NSPasteboard(name: NSPasteboard.Name("ShareAndCaptureTests-\(UUID().uuidString)"))
+        defer { pasteboard.releaseGlobally() }
+        pasteboard.clearContents()
+        pasteboard.setString("not an image", forType: .string)
+        #expect(CapturedImage.payload(from: pasteboard) == nil)
+        #expect(CapturedImage.acceptsReturnType(.png))
+        #expect(!CapturedImage.acceptsReturnType(.string))
+    }
+
+    // MARK: - Naming the written asset
+
+    /// The written name and the parsed destination have to be the same string.
+    /// `AssetReferenceParser` ends a destination at a space, `#`, or `?`, and
+    /// percent-decodes the rest.
+    @Test func assetNamesSurviveTheDestinationParser() {
+        #expect(CapturedImage.slug("meeting notes") == "meeting-notes")
+        #expect(CapturedImage.slug("q3 #plan (final) 50%") == "q3-plan-final-50")
+        #expect(CapturedImage.slug("Reunión") == "Reunión")
+        #expect(CapturedImage.slug("../etc/passwd") == "etcpasswd")
+        #expect(CapturedImage.slug("   ") == "")
+    }
+
+    @Test func repeatedCapturesNeverOverwriteAnEarlierOne() {
+        var taken: Set<String> = []
+        let first = CapturedImage.uniqueFileName(
+            documentBaseName: "notes", fileExtension: "png"
+        ) { taken.contains($0) }
+        #expect(first == "notes-photo.png")
+        taken.insert(first)
+        let second = CapturedImage.uniqueFileName(
+            documentBaseName: "notes", fileExtension: "png"
+        ) { taken.contains($0) }
+        #expect(second == "notes-photo-2.png")
+        taken.insert(second)
+        let third = CapturedImage.uniqueFileName(
+            documentBaseName: "notes", fileExtension: "jpg"
+        ) { taken.contains($0) }
+        #expect(third == "notes-photo.jpg")
+    }
+
+    // MARK: - The inserted Markdown
+
+    @Test func insertionPadsItselfIntoItsOwnParagraph() {
+        // Mid-paragraph: needs a blank line on both sides.
+        let middle = CapturedImage.insertion(
+            destination: "a.png", altText: "a", in: "one two\n", at: 3
+        )
+        #expect(middle.replacement == "\n\n![a](a.png)\n\n")
+        #expect(middle.caret == 3 + "\n\n![a](a.png)".utf16.count)
+
+        // Already on a blank line between two paragraphs: pad nothing.
+        let blank = CapturedImage.insertion(
+            destination: "a.png", altText: "a", in: "one\n\n\n\ntwo\n", at: 5
+        )
+        #expect(blank.replacement == "![a](a.png)")
+
+        // One newline short on the trailing side: pad exactly that one.
+        let nearlyBlank = CapturedImage.insertion(
+            destination: "a.png", altText: "a", in: "one\n\n\n\ntwo\n", at: 6
+        )
+        #expect(nearlyBlank.replacement == "![a](a.png)\n")
+
+        // Start of an empty document.
+        #expect(CapturedImage.insertion(
+            destination: "a.png", altText: "a", in: "", at: 0
+        ).replacement == "![a](a.png)")
+
+        // End of a document that ends in a single newline.
+        let end = CapturedImage.insertion(
+            destination: "a.png", altText: "a", in: "body\n", at: 5
+        )
+        #expect(end.replacement == "\n![a](a.png)")
+    }
+
+    @Test func insertionClampsAnOutOfRangeCaretRatherThanTrapping() {
+        let insertion = CapturedImage.insertion(
+            destination: "a.png", altText: "a", in: "abc", at: 9_999
+        )
+        #expect(insertion.caret <= ("abc" as NSString).length + insertion.replacement.utf16.count)
+        #expect(insertion.replacement.hasSuffix("![a](a.png)"))
+    }
+
+    /// The reference has to come back out of the parser pointing at the exact
+    /// file that was written, as a *safe relative* asset — anything else needs
+    /// a trust prompt before it will draw.
+    @Test func theInsertedReferenceResolvesBackToTheWrittenFile() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let documentURL = directory.appendingPathComponent("meeting notes.md")
+        let fileName = CapturedImage.uniqueFileName(
+            in: directory, documentBaseName: "meeting notes", fileExtension: "png"
+        )
+        #expect(fileName == "meeting-notes-photo.png")
+        let asset = directory.appendingPathComponent(fileName)
+        try #require(bitmap().representation(using: .png, properties: [:])).write(to: asset)
+
+        let insertion = CapturedImage.insertion(
+            destination: fileName,
+            altText: CapturedImage.altText(forFileNamed: fileName),
+            in: "", at: 0
+        )
+        let text = insertion.replacement
+        let context = AssetResolutionContext(documentURL: documentURL, workspaceRoot: directory)
+        let reference = try #require(
+            AssetDoctor.references(in: MarkdownParser.parse(text), context: context).first
+        )
+        #expect(reference.kind == .relativeLocal)
+        #expect(reference.url?.standardizedFileURL == asset.standardizedFileURL)
+
+        let request = try #require(
+            LocalAssetPolicy.request(raw: reference.source, documentURL: documentURL)
+        )
+        #expect(request.isSafeRelative)
+
+        // And it arrives with no diagnostics of its own — alt text present,
+        // relative, supported format, inside the workspace.
+        let probe = AssetProbe { url in
+            let exists = FileManager.default.fileExists(atPath: url.path)
+            return AssetMetadata(
+                exists: exists, isDirectory: false,
+                byteSize: (try? Data(contentsOf: url)).map { Int64($0.count) },
+                fileExtension: url.pathExtension
+            )
+        }
+        let diagnostics = AssetDoctor.diagnose(
+            MarkdownParser.parse(text), context: context, probe: probe
+        )
+        #expect(diagnostics.isEmpty, "a fresh capture must not arrive pre-diagnosed")
+    }
+
+    // MARK: - The responder chain and the real insertion
+
+    @MainActor
+    private func makeController(text: String, at url: URL) throws -> DocumentWindowController {
+        try text.write(to: url, atomically: true, encoding: .utf8)
+        let controller = DocumentWindowController()
+        try controller.open(url, mode: .live)
+        return controller
+    }
+
+    /// The text view holds Markdown source, not attachments, so it declines
+    /// image return types and the question reaches the controller.  If it ever
+    /// stops reaching it, Continuity Camera silently vanishes from the menu.
+    @Test @MainActor func imageRequestsReachTheWindowControllerThroughTheTextView() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let url = directory.appendingPathComponent("notes.md")
+        let controller = try makeController(text: "# Title\n", at: url)
+        defer { controller.close() }
+        controller.showWindow(nil)
+
+        let textView = controller.primaryContainer.textView
+        #expect(textView.importsGraphics == false)
+        let requestor = textView.validRequestor(forSendType: nil, returnType: .png)
+        #expect(requestor as? DocumentWindowController === controller)
+        // A service that also wants to read a selection out of us gets nothing.
+        #expect(controller.validRequestor(forSendType: .png, returnType: .png) == nil)
+    }
+
+    @Test @MainActor func captureWritesNextToTheDocumentAndInsertsOneUndoableReference() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let url = directory.appendingPathComponent("meeting notes.md")
+        let source = "# Title\n\nBody text.\n"
+        let controller = try makeController(text: source, at: url)
+        defer { controller.close() }
+        controller.containerTextView.setSourceSelectedRanges([
+            NSRange(location: (source as NSString).length, length: 0)
+        ])
+
+        let png = try #require(bitmap().representation(using: .png, properties: [:]))
+        let pasteboard = makePasteboard(png, type: .png)
+        defer { pasteboard.releaseGlobally() }
+
+        #expect(controller.readSelection(from: pasteboard))
+
+        let asset = directory.appendingPathComponent("meeting-notes-photo.png")
+        #expect(FileManager.default.fileExists(atPath: asset.path))
+        #expect(try Data(contentsOf: asset) == png)
+        #expect(controller.markdownDocument.text
+            == source + "\n![meeting-notes-photo](meeting-notes-photo.png)")
+
+        // One explicit boundary, so one Undo puts the document back exactly.
+        controller.markdownDocument.undoManager.undo()
+        #expect(controller.markdownDocument.text == source)
+    }
+
+    /// The capture is triggered on a phone; whatever was selected here is out
+    /// of sight by the time it lands, so it must survive.
+    @Test @MainActor func captureNeverConsumesTheSelection() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let url = directory.appendingPathComponent("notes.md")
+        let source = "# Title\n\nBody text.\n"
+        let controller = try makeController(text: source, at: url)
+        defer { controller.close() }
+        let selection = NSRange(location: 9, length: 4)   // "Body"
+        controller.containerTextView.setSourceSelectedRanges([selection])
+
+        let png = try #require(bitmap().representation(using: .png, properties: [:]))
+        let pasteboard = makePasteboard(png, type: .png)
+        defer { pasteboard.releaseGlobally() }
+        #expect(controller.readSelection(from: pasteboard))
+
+        #expect(controller.markdownDocument.text
+            == "# Title\n\n![notes-photo](notes-photo.png)\n\nBody text.\n")
+        #expect(controller.markdownDocument.text.contains("Body text."))
+    }
+
+    /// The never-saved window: nothing is advertised, so AppKit never offers a
+    /// capture there, and the write path refuses it a second time.
+    @Test @MainActor func anUntitledWindowNeitherAdvertisesNorAcceptsACapture() throws {
+        let controller = DocumentWindowController()
+        defer { controller.close() }
+        #expect(controller.markdownDocument.url == nil)
+        #expect(controller.validRequestor(forSendType: nil, returnType: .png) == nil)
+
+        let png = try #require(bitmap().representation(using: .png, properties: [:]))
+        let pasteboard = makePasteboard(png, type: .png)
+        defer { pasteboard.releaseGlobally() }
+        let before = controller.markdownDocument.text
+        #expect(!controller.readSelection(from: pasteboard))
+        #expect(controller.markdownDocument.text == before)
+    }
+}

--- a/Tests/DownrightAppTests/SyntheticScrollEvents.swift
+++ b/Tests/DownrightAppTests/SyntheticScrollEvents.swift
@@ -1,0 +1,74 @@
+import AppKit
+
+/// Synthetic trackpad and wheel scroll events.
+///
+/// Every scroll gesture over the document surface is decided by reading an
+/// `NSEvent` — its phase, its momentum phase, whether its deltas are precise,
+/// which modifiers are held, and how far it travelled.  That decoding is part
+/// of what the tests are testing, so they drive real `NSEvent`s built from
+/// `CGEvent`s rather than a stand-in that would only ever agree with whatever
+/// the coordinator already believed.
+enum SyntheticScroll {
+    struct Unavailable: Error {}
+
+    /// - Parameters:
+    ///   - precise: `true` for a trackpad, whose deltas are points and whose
+    ///     gestures have phases; `false` for a wheel, whose deltas are lines
+    ///     and which has neither phases nor a momentum tail.
+    static func event(
+        deltaX: CGFloat = 0,
+        deltaY: CGFloat = 0,
+        phase: CGScrollPhase? = .changed,
+        momentum: CGMomentumScrollPhase = CGMomentumScrollPhase.none,
+        precise: Bool = true,
+        modifiers: NSEvent.ModifierFlags = [],
+        at seconds: TimeInterval = 0
+    ) throws -> NSEvent {
+        guard let event = CGEvent(
+            scrollWheelEvent2Source: nil,
+            units: .pixel,
+            wheelCount: 2,
+            wheel1: 0,
+            wheel2: 0,
+            wheel3: 0
+        ) else { throw Unavailable() }
+        event.setIntegerValueField(.scrollWheelEventIsContinuous, value: precise ? 1 : 0)
+        event.setDoubleValueField(.scrollWheelEventPointDeltaAxis1, value: Double(deltaY))
+        event.setDoubleValueField(.scrollWheelEventPointDeltaAxis2, value: Double(deltaX))
+        if !precise {
+            // A wheel's `scrollingDelta` is read out of the line fields, not
+            // the point ones — the difference the whole coarse-device path
+            // turns on, so it has to be real here too.
+            event.setIntegerValueField(
+                .scrollWheelEventDeltaAxis1, value: Int64(deltaY.rounded())
+            )
+            event.setIntegerValueField(
+                .scrollWheelEventDeltaAxis2, value: Int64(deltaX.rounded())
+            )
+        }
+        if let phase {
+            event.setIntegerValueField(.scrollWheelEventScrollPhase, value: Int64(phase.rawValue))
+        }
+        event.setIntegerValueField(
+            .scrollWheelEventMomentumPhase, value: Int64(momentum.rawValue)
+        )
+        // Always set, including to nothing: a `CGEvent` built with no source
+        // is entitled to pick up whatever the keyboard happens to be doing,
+        // and a stray ⌘ on the developer's hand must not decide a test.
+        event.flags = flags(for: modifiers)
+        event.timestamp = UInt64(max(0, seconds) * 1_000_000_000)
+        guard let decoded = NSEvent(cgEvent: event) else { throw Unavailable() }
+        return decoded
+    }
+
+    private static func flags(for modifiers: NSEvent.ModifierFlags) -> CGEventFlags {
+        var flags: CGEventFlags = []
+        if modifiers.contains(.command) { flags.insert(.maskCommand) }
+        if modifiers.contains(.option) { flags.insert(.maskAlternate) }
+        if modifiers.contains(.control) { flags.insert(.maskControl) }
+        if modifiers.contains(.shift) { flags.insert(.maskShift) }
+        if modifiers.contains(.capsLock) { flags.insert(.maskAlphaShift) }
+        if modifiers.contains(.function) { flags.insert(.maskSecondaryFn) }
+        return flags
+    }
+}

--- a/Tests/DownrightAppTests/TrustTests.swift
+++ b/Tests/DownrightAppTests/TrustTests.swift
@@ -76,6 +76,98 @@ struct DocumentTrustTests {
         #expect(DocumentTrust(grants: [grant]).decision(for: remoteImage) == .ask)
     }
 
+    /// One folder-scope approval of an external effect must answer only for
+    /// the exact URL that was approved — never for every future URL of that
+    /// effect under the folder, or a single "always allow" on a vscode:// link
+    /// would silently authorize a later shortcuts:// automation.
+    @Test
+    func folderGrantForAnExternalURLAuthorizesOnlyThatURL() {
+        let document = URL(fileURLWithPath: "/workspace/README.md")
+        let approved = "vscode://file/tmp/note.md"
+        let otherScheme = "shortcuts://run-shortcut?name=Deploy"
+
+        let persistence = InMemoryTrustStorePersistence()
+        let store = TrustStore(persistence: persistence)
+        #expect(store.grant(
+            scope: .folder,
+            path: URL(fileURLWithPath: "/workspace"),
+            effects: [.automationAppIntent],
+            externalURL: approved
+        ))
+
+        let sameURL = TrustRequest(
+            effect: .automationAppIntent,
+            target: TrustTarget(displayName: approved, externalURL: approved),
+            documentURL: document
+        )
+        let differentURL = TrustRequest(
+            effect: .automationAppIntent,
+            target: TrustTarget(displayName: otherScheme, externalURL: otherScheme),
+            documentURL: document
+        )
+        #expect(store.policy().decision(for: sameURL) == .allow)
+        #expect(store.policy().decision(for: differentURL) == .ask)
+    }
+
+    /// Grants persisted before external grants carried their URL must not
+    /// start answering for arbitrary URLs after an upgrade: they fail closed
+    /// for external effects (the next prompt re-records them with their URL)
+    /// while continuing to authorize the local effects they were created for.
+    @Test
+    func legacyExternalGrantFailsClosedForExternalEffectsButKeepsLocalOnes() throws {
+        let document = try #require(DocumentTrust.canonicalFilePath(
+            URL(fileURLWithPath: "/tmp/downright-trust-legacy/notes.md")
+        ))
+        let legacy = TrustGrant(
+            scope: .folder,
+            canonicalPath: document.deletingLastPathComponent().path,
+            effects: [.openExternalLink]
+        )
+        let external = TrustRequest(
+            effect: .openExternalLink,
+            target: TrustTarget(
+                displayName: "https://example.com",
+                externalURL: "https://example.com"
+            ),
+            documentURL: document
+        )
+        let local = TrustRequest(
+            effect: .launchPathOrEditor,
+            target: TrustTarget(
+                displayName: "/tmp/downright-trust-legacy/notes.md",
+                canonicalPath: document.path
+            ),
+            documentURL: document
+        )
+        #expect(DocumentTrust(grants: [legacy]).decision(for: external) == .ask)
+
+        let persistence = InMemoryTrustStorePersistence([legacy])
+        let store = TrustStore(persistence: persistence)
+        #expect(store.grant(
+            scope: .file,
+            path: document,
+            effects: [.launchPathOrEditor]
+        ))
+        #expect(store.policy().decision(for: local) == .allow)
+    }
+
+    @Test
+    func persistedGrantsWithoutTheURLEntryStillDecode() throws {
+        let json = """
+        [
+          {
+            "scope" : "file",
+            "canonicalPath" : "/tmp/downright-trust-decode/notes.md",
+            "effects" : ["readLocalAsset"]
+          }
+        ]
+        """
+        let grants = try JSONDecoder().decode([TrustGrant].self, from: Data(json.utf8))
+        #expect(grants.count == 1)
+        #expect(grants.first?.externalURL == nil)
+        #expect(grants.first?.effects == [.readLocalAsset])
+    }
+
     @Test
     func symlinkResolvesToRealPathAndTraversalStaysOutside() throws {
         let root = URL(fileURLWithPath: NSTemporaryDirectory())

--- a/Tests/DownrightAppTests/UpdateCoordinatorTests.swift
+++ b/Tests/DownrightAppTests/UpdateCoordinatorTests.swift
@@ -408,7 +408,7 @@ struct UpdateCoordinatorFlowTests {
         coordinator.driverDidFindUpdate(sampleMetadata, stage: .downloaded, userInitiated: false) { _ in }
         #expect(coordinator.panelShowCount == 0)
         #expect(coordinator.phase == .available(sampleMetadata, stage: .downloaded))
-        #expect(coordinator.pillModel == .restartToUpdate)
+        #expect(coordinator.pillModel == .updateNow(version: "1.1.0", isReady: true))
 
         coordinator.driverDidFindUpdate(sampleMetadata, stage: .notDownloaded, userInitiated: true) { _ in }
         #expect(coordinator.panelShowCount > 0)
@@ -424,7 +424,7 @@ struct UpdateCoordinatorFlowTests {
         coordinator.driverDidBecomeReadyToRelaunch { _ in }
         #expect(coordinator.panelShowCount == 0)
         #expect(coordinator.phase == .readyToRelaunch)
-        #expect(coordinator.pillModel == .restartToUpdate)
+        #expect(coordinator.pillModel?.offersInstall == true)
     }
 
     /// A background-cycle failure is a non-event: no window, and no warning
@@ -488,11 +488,11 @@ struct UpdateCoordinatorFlowTests {
 
     // MARK: Background downloads
 
-    @Test func backgroundDownloadDrivesRestartPill() {
+    @Test func backgroundDownloadDrivesUpdateNowPill() {
         let (coordinator, engine) = makeCoordinator()
         #expect(coordinator.pillModel == nil)
         engine.completeBackgroundDownload(displayVersion: "1.1.0")
-        #expect(coordinator.pillModel == .restartToUpdate)
+        #expect(coordinator.pillModel == .updateNow(version: "1.1.0", isReady: true))
         #expect(coordinator.downloadedUpdate != nil)
         coordinator.driverDidDismiss()
         #expect(coordinator.downloadedUpdate == nil)
@@ -718,5 +718,373 @@ struct UpdateBuildContractTests {
         let targetText = String(manifest[marker.lowerBound...])
         let appTarget = targetText.prefix { $0 != "}" }
         #expect(appTarget.contains("Sparkle"), "DownrightApp target must link Sparkle")
+    }
+}
+
+// MARK: - Release watch policy
+
+@Suite
+struct ReleaseWatchPolicyTests {
+    @Test func frontmostChecksFarMoreOftenThanBackgrounded() {
+        var policy = ReleaseWatchPolicy()
+        policy.isAppActive = true
+        #expect(policy.interval == ReleaseWatchPolicy.activeInterval)
+        policy.isAppActive = false
+        #expect(policy.interval == ReleaseWatchPolicy.backgroundInterval)
+    }
+
+    /// No network is not a failure state; it is simply nothing to do.
+    @Test func noNetworkSuspendsEntirely() {
+        var policy = ReleaseWatchPolicy(isAppActive: true, isLowPower: false, hasNetwork: false)
+        #expect(policy.interval == nil)
+        policy.hasNetwork = true
+        #expect(policy.interval != nil)
+    }
+
+    /// Low Power Mode is an explicit request to stop doing optional work, and
+    /// polling for a build nobody asked for is exactly that.
+    @Test func lowPowerBacksOffInFrontAndStopsBehind() {
+        var policy = ReleaseWatchPolicy(isAppActive: true, isLowPower: true, hasNetwork: true)
+        #expect(policy.interval == ReleaseWatchPolicy.backgroundInterval)
+        policy.isAppActive = false
+        #expect(policy.interval == nil)
+    }
+}
+
+// MARK: - Release watch
+
+@MainActor
+private final class FakeReleaseFeedProbe: ReleaseFeedProbe {
+    private var results: [ReleaseFeedProbeResult]
+    /// Every validator the watch offered, in order — the evidence that a
+    /// conditional request is actually conditional.
+    private(set) var validators: [String?] = []
+
+    init(_ results: [ReleaseFeedProbeResult]) { self.results = results }
+
+    func probe(feed: URL, validator: String?) async -> ReleaseFeedProbeResult {
+        validators.append(validator)
+        return results.isEmpty ? .unchanged : results.removeFirst()
+    }
+}
+
+@Suite(.serialized)
+@MainActor
+struct ReleaseWatchTests {
+    private let feed = URL(string: "https://example.invalid/appcast.xml")!
+
+    /// The watch hands its work to a `Task`; yield until it has landed rather
+    /// than sleeping for a duration that would only ever be a guess.
+    private func settle(_ watch: ReleaseWatch, probes: Int) async {
+        for _ in 0..<500 where watch.completedProbeCount < probes {
+            await Task.yield()
+        }
+    }
+
+    private func makeWatch(
+        _ results: [ReleaseFeedProbeResult]
+    ) -> (ReleaseWatch, FakeReleaseFeedProbe) {
+        let probe = FakeReleaseFeedProbe(results)
+        return (ReleaseWatch(feed: feed, prober: probe), probe)
+    }
+
+    /// Sparkle's own post-launch check already answers "was something waiting
+    /// when I opened the app". The first probe only learns where to start.
+    @Test func firstProbeEstablishesTheBaselineWithoutFiring() async {
+        let (watch, _) = makeWatch([.changed(validator: "etag:a")])
+        var fired = 0
+        watch.onFeedChanged = { fired += 1 }
+        watch.start(observingSystemEvents: false)
+        await settle(watch, probes: 1)
+        #expect(watch.hasBaseline)
+        #expect(fired == 0)
+        watch.stop()
+    }
+
+    @Test func aMovedFeedFiresOnce() async {
+        let (watch, probe) = makeWatch([.changed(validator: "etag:a"), .changed(validator: "etag:b")])
+        var fired = 0
+        watch.onFeedChanged = { fired += 1 }
+        watch.start(observingSystemEvents: false)
+        await settle(watch, probes: 1)
+        watch.probeNow()
+        await settle(watch, probes: 2)
+        #expect(fired == 1)
+        // The second request carried the first response's validator back.
+        #expect(probe.validators == [nil, "etag:a"])
+        watch.stop()
+    }
+
+    @Test func anUnchangedFeedIsSilent() async {
+        let (watch, _) = makeWatch([.changed(validator: "etag:a"), .unchanged, .unchanged])
+        var fired = 0
+        watch.onFeedChanged = { fired += 1 }
+        watch.start(observingSystemEvents: false)
+        await settle(watch, probes: 1)
+        watch.probeNow()
+        await settle(watch, probes: 2)
+        watch.probeNow()
+        await settle(watch, probes: 3)
+        #expect(fired == 0)
+        watch.stop()
+    }
+
+    /// An unreachable feed must not be mistaken for a baseline, or the first
+    /// successful probe after a flight would look like a brand-new release.
+    @Test func anUnreachableFeedDoesNotEstablishTheBaseline() async {
+        let (watch, _) = makeWatch([.unreachable, .changed(validator: "etag:a")])
+        var fired = 0
+        watch.onFeedChanged = { fired += 1 }
+        watch.start(observingSystemEvents: false)
+        await settle(watch, probes: 1)
+        #expect(!watch.hasBaseline)
+        watch.probeNow()
+        await settle(watch, probes: 2)
+        #expect(watch.hasBaseline)
+        #expect(fired == 0)
+        watch.stop()
+    }
+
+    /// Wake fires activation too, and a held Cmd-Tab flaps it several times a
+    /// second. Without a floor each of those becomes its own request.
+    @Test func coincidingEventsCollapseIntoOneProbe() async {
+        let (watch, _) = makeWatch([.changed(validator: "etag:a")])
+        watch.start(observingSystemEvents: false)
+        await settle(watch, probes: 1)
+        watch.systemDidWake()
+        watch.applicationDidChangeActivation(isActive: true)
+        watch.networkAvailabilityDidChange(hasNetwork: true)
+        await Task.yield()
+        #expect(watch.completedProbeCount == 1)
+        watch.stop()
+    }
+
+    @Test func losingTheNetworkStopsProbing() async {
+        let (watch, _) = makeWatch([.changed(validator: "etag:a")])
+        watch.start(observingSystemEvents: false)
+        await settle(watch, probes: 1)
+        watch.networkAvailabilityDidChange(hasNetwork: false)
+        watch.probeNow()
+        await Task.yield()
+        #expect(watch.completedProbeCount == 1)
+        watch.stop()
+    }
+}
+
+// MARK: - Notes summary
+
+@Suite
+struct UpdateNotesSummaryTests {
+    /// The panel header already names the version, so a leading title line
+    /// would be the same sentence twice.
+    @Test func dropsTheLeadingTitle() {
+        let summary = UpdateNotesSummary.summary(from: "# Downright 1.1.0\n\n- Faster parsing")
+        #expect(!summary.contains("Downright 1.1.0"))
+        #expect(summary.contains("Faster parsing"))
+    }
+
+    @Test func stopsWellShortOfAWallOfText() {
+        let long = (1...60).map { "- change number \($0)" }.joined(separator: "\n")
+        let summary = UpdateNotesSummary.summary(from: long)
+        #expect(summary.contains("change number 1"))
+        #expect(!summary.contains("change number 40"))
+        #expect(summary.hasSuffix("…"), "a trimmed summary has to say that it was trimmed")
+    }
+
+    @Test func handlesNoNotesAtAll() {
+        #expect(UpdateNotesSummary.summary(from: nil).isEmpty)
+        #expect(UpdateNotesSummary.summary(from: "   \n\n  ").isEmpty)
+    }
+
+    @Test func keepsShortNotesWhole() {
+        let summary = UpdateNotesSummary.summary(from: "- one\n- two")
+        #expect(summary == "- one\n- two")
+    }
+}
+
+// MARK: - Update Now (one press installs)
+
+@Suite(.serialized)
+@MainActor
+struct UpdateNowPressTests {
+    private func makeCoordinator() -> (UpdateCoordinator, FakeUpdateEngine) {
+        let engine = FakeUpdateEngine()
+        let coordinator = UpdateCoordinator(engine: engine)
+        coordinator.suppressUIForTesting = true
+        try? engine.start()
+        return (coordinator, engine)
+    }
+
+    @Test func onlyActionableStatesOfferAnInstall() {
+        #expect(UpdatePillModel.updateNow(version: "1.1.0", isReady: false).offersInstall)
+        #expect(UpdatePillModel.restartToUpdate.offersInstall)
+        #expect(!UpdatePillModel.warning.offersInstall)
+        #expect(!UpdatePillModel.progress("Updating…", nil).offersInstall)
+        #expect(!UpdatePillModel.informational("1.2.0").offersInstall)
+    }
+
+    /// The whole point of the control: the press is the decision, so no window
+    /// opens to ask it again.
+    @Test func pressInstallsWithoutOpeningThePanel() {
+        let (coordinator, _) = makeCoordinator()
+        var replies: [UpdateUserChoice] = []
+        coordinator.driverDidFindUpdate(sampleMetadata, stage: .notDownloaded, userInitiated: false) {
+            replies.append($0)
+        }
+        #expect(coordinator.pillModel == .updateNow(version: "1.1.0", isReady: false))
+        coordinator.userDidPressUpdateNow()
+        #expect(replies == [.install])
+        #expect(coordinator.panelShowCount == 0)
+    }
+
+    /// A background download leaves no prompt armed, so the press has to
+    /// re-enter Sparkle — and that cycle must stay as silent as the press.
+    @Test func pressOnABackgroundDownloadReentersSparkleSilently() {
+        let (coordinator, engine) = makeCoordinator()
+        engine.completeBackgroundDownload(displayVersion: "1.1.0")
+        coordinator.userDidPressUpdateNow()
+        #expect(engine.foregroundCheckCount == 1)
+        #expect(coordinator.isExpeditedInstall)
+
+        coordinator.driverDidBeginUserCheck { }
+        #expect(coordinator.panelShowCount == 0, "a press must not open the panel it replaced")
+
+        var replies: [UpdateUserChoice] = []
+        coordinator.driverDidFindUpdate(sampleMetadata, stage: .downloaded, userInitiated: true) {
+            replies.append($0)
+        }
+        #expect(replies == [.install])
+        #expect(coordinator.panelShowCount == 0)
+    }
+
+    @Test func anExpeditedReadyToRelaunchInstallsImmediately() {
+        let (coordinator, engine) = makeCoordinator()
+        engine.completeBackgroundDownload(displayVersion: "1.1.0")
+        coordinator.userDidPressUpdateNow()
+        coordinator.driverDidBeginUserCheck { }
+        coordinator.driverDidFindUpdate(sampleMetadata, stage: .notDownloaded, userInitiated: true) { _ in }
+        coordinator.driverDidBeginDownload { }
+        #expect(coordinator.panelShowCount == 0, "progress belongs on the pill during a press")
+
+        var replies: [UpdateUserChoice] = []
+        coordinator.driverDidBecomeReadyToRelaunch { replies.append($0) }
+        #expect(replies == [.install])
+        #expect(coordinator.panelShowCount == 0)
+    }
+
+    /// A press that could not be honoured owes an explanation, so the failure
+    /// path deliberately drops back to the ordinary panel.
+    @Test func anExpeditedFailureFallsBackToThePanel() {
+        let (coordinator, engine) = makeCoordinator()
+        engine.completeBackgroundDownload(displayVersion: "1.1.0")
+        coordinator.userDidPressUpdateNow()
+        coordinator.driverDidBeginUserCheck { }
+        coordinator.driverDidEncounterError(
+            NSError(domain: "Sparkle", code: 2001, userInfo: [NSLocalizedDescriptionKey: "no"])
+        ) { }
+        #expect(!coordinator.isExpeditedInstall)
+        #expect(coordinator.panelShowCount > 0)
+        #expect(coordinator.pillModel == .warning)
+    }
+
+    /// Once installation has begun only the quit is outstanding, so the pill
+    /// says so and the press retries the quit rather than starting again.
+    @Test func pressWhileWaitingForTerminationRetriesTheQuit() {
+        let (coordinator, _) = makeCoordinator()
+        var retries = 0
+        coordinator.driverDidBeginInstallation(applicationTerminated: false) { retries += 1 }
+        #expect(coordinator.pillModel == .restartToUpdate)
+        coordinator.userDidPressUpdateNow()
+        #expect(retries == 1)
+    }
+
+    /// The phases after `.available` carry no metadata of their own; without
+    /// the cycle keeping hold of it, the tooltip and hover notes go blank
+    /// halfway through the install they are describing.
+    @Test func theVersionSurvivesToReadyToRelaunch() {
+        let (coordinator, _) = makeCoordinator()
+        coordinator.driverDidFindUpdate(sampleMetadata, stage: .notDownloaded, userInitiated: false) { _ in }
+        coordinator.driverDidBeginDownload { }
+        coordinator.driverDidBecomeReadyToRelaunch { _ in }
+        #expect(coordinator.pendingUpdate?.displayVersionString == "1.1.0")
+        #expect(coordinator.pillModel == .updateNow(version: "1.1.0", isReady: true))
+        coordinator.driverDidDismiss()
+        #expect(coordinator.pendingUpdate == nil)
+    }
+}
+
+// MARK: - Release watch → coordinator
+
+@Suite(.serialized)
+@MainActor
+struct ReleaseWatchTriggerTests {
+    private func makeCoordinator() -> (UpdateCoordinator, FakeUpdateEngine) {
+        let engine = FakeUpdateEngine()
+        let coordinator = UpdateCoordinator(engine: engine)
+        coordinator.suppressUIForTesting = true
+        try? engine.start()
+        return (coordinator, engine)
+    }
+
+    /// The full extent of the watch's authority: it asks Sparkle to look.
+    @Test func aMovedFeedAsksSparkleToLook() {
+        let (coordinator, engine) = makeCoordinator()
+        #expect(engine.backgroundCheckCount == 0)
+        coordinator.releaseFeedDidChange()
+        #expect(engine.backgroundCheckCount == 1)
+        #expect(coordinator.releaseWatchTriggerCount == 1)
+    }
+
+    /// The reader is watching a download or reading a prompt; restarting
+    /// underneath them replaces what they are looking at with the same answer.
+    @Test func aLiveCycleIsLeftAlone() {
+        let (coordinator, engine) = makeCoordinator()
+        coordinator.driverDidBeginUserCheck { }
+        coordinator.releaseFeedDidChange()
+        #expect(engine.backgroundCheckCount == 0)
+    }
+
+    @Test func anAlreadyWaitingUpdateIsNotRechecked() {
+        let (coordinator, engine) = makeCoordinator()
+        engine.completeBackgroundDownload(displayVersion: "1.1.0")
+        coordinator.releaseFeedDidChange()
+        #expect(engine.backgroundCheckCount == 0)
+    }
+
+    /// A bundle with no updater has nothing to trigger.
+    @Test func aStoppedEngineIsNeverTriggered() {
+        let engine = FakeUpdateEngine()
+        let coordinator = UpdateCoordinator(engine: engine)
+        coordinator.suppressUIForTesting = true
+        coordinator.releaseFeedDidChange()
+        #expect(engine.backgroundCheckCount == 0)
+        #expect(coordinator.releaseWatchTriggerCount == 0)
+    }
+}
+
+// MARK: - The automatic-check setting governs the watch too
+
+@Suite(.serialized)
+@MainActor
+struct ReleaseWatchSettingTests {
+    /// "Check for updates automatically" has to mean every automatic check.
+    /// A setting that stopped Sparkle's schedule and left the watch polling
+    /// would be a narrower promise than the one the settings pane makes.
+    @Test func turningAutomaticChecksOffSilencesTheWatch() {
+        let engine = FakeUpdateEngine()
+        let coordinator = UpdateCoordinator(engine: engine)
+        coordinator.suppressUIForTesting = true
+        try? engine.start()
+
+        coordinator.releaseFeedDidChange()
+        #expect(engine.backgroundCheckCount == 1)
+
+        coordinator.automaticallyChecksForUpdates = false
+        coordinator.releaseFeedDidChange()
+        #expect(engine.backgroundCheckCount == 1, "the watch must not outlive the setting")
+
+        coordinator.automaticallyChecksForUpdates = true
+        coordinator.releaseFeedDidChange()
+        #expect(engine.backgroundCheckCount == 2)
     }
 }

--- a/Tests/DownrightAppTests/VisualDebuggerTests.swift
+++ b/Tests/DownrightAppTests/VisualDebuggerTests.swift
@@ -95,7 +95,16 @@ struct VisualDebuggerViewTests {
         ))
         #expect(view.accessibilityLabel() == "Visual Debugger")
         #expect(view.summaryTextForTesting().contains("Visual Debugger"))
+
+        // Copy into a named pasteboard: the view must route through the
+        // injectable target, so nothing it does reaches the user's real
+        // clipboard by construction.
+        let scratch = NSPasteboard(name: NSPasteboard.Name("downright.test.visual-debugger"))
+        scratch.clearContents()
+        scratch.setString("sentinel", forType: .string)
+        view.pasteboardForTesting = scratch
+        defer { view.pasteboardForTesting = .general }
         view.copySummaryForTesting()
-        #expect(NSPasteboard.general.string(forType: .string)?.contains("Visual Debugger") == true)
+        #expect(scratch.string(forType: .string)?.contains("Visual Debugger") == true)
     }
 }

--- a/Tests/DownrightAppTests/WindowChromeTests.swift
+++ b/Tests/DownrightAppTests/WindowChromeTests.swift
@@ -46,7 +46,7 @@ struct WindowChromeTests {
             (.edited, "Edited"),
             (.saving, "Saving"),
             (.saved, "Saved"),
-            (.changedOnDisk, "Changed on disk"),
+            (.changedOnDisk, "Changed externally"),
             (.conflict, "Conflict"),
             (.saveFailed, "Save failed"),
         ]
@@ -61,6 +61,13 @@ struct WindowChromeTests {
         identity.documentState = .neutral
         #expect(identity.accessibilityLabel()?.contains("Edited") == false)
         #expect(identity.toolTip == nil)
+
+        identity.documentState = .init(
+            phase: .changedOnDisk, provenance: nil, detail: "File missing"
+        )
+        #expect(identity.accessibilityLabel()?.contains("File missing") == true)
+        #expect(identity.accessibilityLabel()?.contains("Changed externally") == false)
+        #expect(identity.toolTip?.contains("File missing: File missing") == false)
     }
 
     @Test

--- a/Tests/DownrightAppTests/WindowChromeTests.swift
+++ b/Tests/DownrightAppTests/WindowChromeTests.swift
@@ -576,7 +576,8 @@ struct WindowChromeTests {
     }
 
     @Test("Rapid Replace toggles cannot leave a faded ghost row")
-    func replaceBarRapidToggleSettlesVisible() async throws {
+    @MainActor
+    func replaceBarRapidToggleSettlesVisible() throws {
         let style = StyleSheet(
             theme: ThemeStore.shared.current,
             appearance: NSAppearance(named: .darkAqua)!,
@@ -592,7 +593,11 @@ struct WindowChromeTests {
         bar.showsReplace = true
         bar.showsReplace = false
         bar.showsReplace = true
-        try await Task.sleep(for: .milliseconds(350))
+        // Wait for the fade-in to actually settle instead of sleeping a fixed
+        // interval: animation timers coalesce on loaded machines, so any
+        // constant can expire mid-fade and fail a correct implementation.
+        let settled = pumpMainRunLoop(until: { abs(bar.replaceRowAlphaForTesting - 1) < 0.001 })
+        #expect(settled, "the replace row never reached full alpha")
         bar.layoutSubtreeIfNeeded()
 
         #expect(bar.showsReplace)

--- a/Tests/DownrightAppTests/WindowChromeTests.swift
+++ b/Tests/DownrightAppTests/WindowChromeTests.swift
@@ -38,14 +38,11 @@ struct WindowChromeTests {
     }
 
     @Test
-    func documentIdentityNamesEveryNonNeutralStateAccessibly() throws {
+    func documentIdentityShowsOnlyExceptionalStates() throws {
         let controller = DocumentWindowController()
         defer { controller.close() }
         let identity = try #require(controller.toolbarDocumentIdentityView)
         let cases: [(MarkdownDocument.PresentationState.Phase, String)] = [
-            (.edited, "Edited"),
-            (.saving, "Saving"),
-            (.saved, "Saved"),
             (.changedOnDisk, "Changed externally"),
             (.conflict, "Conflict"),
             (.saveFailed, "Save failed"),
@@ -58,9 +55,18 @@ struct WindowChromeTests {
             #expect(identity.accessibilityLabel()?.contains("Paste") == true)
             #expect(identity.toolTip?.contains(label) == true)
         }
-        identity.documentState = .neutral
-        #expect(identity.accessibilityLabel()?.contains("Edited") == false)
-        #expect(identity.toolTip == nil)
+        for phase in [
+            MarkdownDocument.PresentationState.Phase.neutral,
+            .edited,
+            .saving,
+            .saved,
+        ] {
+            identity.documentState = .init(
+                phase: phase, provenance: "Paste", detail: "Example"
+            )
+            #expect(identity.accessibilityLabel()?.contains("Paste") != true)
+            #expect(identity.toolTip?.contains("Paste") != true)
+        }
 
         identity.documentState = .init(
             phase: .changedOnDisk, provenance: nil, detail: "File missing"
@@ -310,7 +316,7 @@ struct WindowChromeTests {
             cluster.arrangedSubviews.first { $0 is ToolbarMenuButton } as? ToolbarMenuButton,
             "the overflow menu is not in the trailing cluster"
         )
-        #expect(overflow.popupMenuItems.contains { MainMenu.command(for: $0) == .documentLens })
+        #expect(!overflow.popupMenuItems.contains { MainMenu.command(for: $0) == .documentLens })
         #expect(overflow.intrinsicContentSize.width == 34)
         #expect(overflow.intrinsicContentSize.height == 34)
         #expect(overflow.popupMenuItems.contains { $0.title == "Document Detail" })

--- a/Tests/DownrightAppTests/WindowChromeTests.swift
+++ b/Tests/DownrightAppTests/WindowChromeTests.swift
@@ -287,14 +287,9 @@ struct WindowChromeTests {
         #expect(find.feedbackInsetY == 0)
         #expect(find.feedbackCornerRadius == 17)
         #expect(!find.isOn, "find should rest unlit with its panel closed")
-        let contents = try #require(
-            cluster.arrangedSubviews.first {
-                ($0 as? ToolbarActionButton)?.accessibilityLabel() == Command.documentLens.title
-            } as? ToolbarActionButton,
-            "contents is not in the trailing cluster"
-        )
-        #expect(contents.toolTip == "Show or hide the document Contents and Outline")
-        #expect(contents.accessibilityHelp() == "Show or hide the document Contents and Outline")
+        #expect(!cluster.arrangedSubviews.contains {
+            ($0 as? ToolbarActionButton)?.accessibilityLabel() == Command.documentLens.title
+        }, "Contents / Outline belongs in menus, not the permanent toolbar")
         #expect(cluster.arrangedSubviews.contains { $0 is ActivityIndicatorView })
         #expect(cluster.arrangedSubviews.contains { $0 is TaskProgressRing })
         let updatePill = try #require(
@@ -314,7 +309,7 @@ struct WindowChromeTests {
         #expect(overflow.popupMenuItems.contains { $0.title == "Document Detail" })
         #expect(overflow.popupMenuItems.contains { $0.title == "Source Focus" || $0.title == "Exit Source Focus" })
         // The cluster leads with the spinner and ends at the menu: activity,
-        // contents, find, ring, pill, overflow — each hidden view costs nothing.
+        // find, ring, pill, overflow — each hidden view costs nothing.
         #expect(cluster.arrangedSubviews.first is ActivityIndicatorView)
         #expect(cluster.arrangedSubviews.last is ToolbarMenuButton)
     }

--- a/Tests/MarkdownCLITests/AgentBridgeTests.swift
+++ b/Tests/MarkdownCLITests/AgentBridgeTests.swift
@@ -224,7 +224,58 @@ struct AgentBridgeTests {
         let object = try JSONSerialization.jsonObject(with: Data(snippet.utf8)) as? [String: Any]
         let postToolUse = (object?["hooks"] as? [String: Any])?["PostToolUse"] as? [[String: Any]]
         let command = (postToolUse?.first?["hooks"] as? [[String: Any]])?.first?["command"] as? String
-        #expect(command == "/usr/local/bin/down notify")
+        // The executable is POSIX single-quoted so no character in an unusual
+        // install path can open a shell expansion context.
+        #expect(command == "'/usr/local/bin/down' notify")
+    }
+
+    @Test("Hook commands cannot smuggle shell expansion through the path")
+    func hookCommandQuotesHostilePaths() {
+        // Inside POSIX single quotes nothing expands: `$`, backticks, double
+        // quotes, and backslashes are all literal.  The only character that
+        // needs care is the single quote itself, escaped the standard way.
+        let hostile = "/opt/My Tools/\"$(touch /tmp/pwned)\"/down"
+        let command = AgentBridge.hookCommand(executable: hostile)
+        #expect(command.hasPrefix("'/opt/My Tools/"))
+        #expect(command.hasSuffix("/down' notify"))
+        #expect(command.contains("\"$(touch /tmp/pwned)\""),
+                "the payload must survive verbatim inside the quotes")
+
+        let tricky = "/opt/o'brien/down"
+        #expect(AgentBridge.hookCommand(executable: tricky) == "'/opt/o'\\''brien/down' notify")
+    }
+
+    /// Hooks written by earlier builds used unquoted or double-quoted paths.
+    /// An upgrade must recognize them as ours — reporting state accurately,
+    /// migrating them to the canonical quoted form instead of appending a
+    /// duplicate that would fire twice per event, and removing them cleanly.
+    @Test("A legacy-format hook is recognized, migrated in place, and removable")
+    func legacyHookIsRecognizedAndMigrated() {
+        let executable = "/usr/local/bin/down"
+        for legacyCommand in ["/usr/local/bin/down notify", "\"/usr/local/bin/down\" notify"] {
+            let seeded: [String: Any] = [
+                "hooks": ["PostToolUse": [[
+                    "matcher": AgentBridge.toolMatcher,
+                    "hooks": [["type": "command", "command": legacyCommand]],
+                ]]],
+            ]
+            // State reporting counts the legacy hook as installed.
+            #expect(AgentBridge.isHookInstalled(in: seeded, executable: executable))
+
+            // Installing migrates it in place rather than appending a twin.
+            let (migrated, changed) = AgentBridge.installingHook(into: seeded, executable: executable)
+            #expect(changed)
+            let postToolUse = (migrated["hooks"] as? [String: Any])?["PostToolUse"] as? [[String: Any]]
+            #expect(postToolUse?.count == 1)
+            #expect((postToolUse?.first?["hooks"] as? [[String: Any]])?.first?["command"] as? String
+                == "'/usr/local/bin/down' notify")
+
+            // A second install is a no-op, and an uninstall removes it.
+            #expect(AgentBridge.installingHook(into: migrated, executable: executable).changed == false)
+            let (removed, removedChanged) = AgentBridge.removingHook(from: migrated, executable: executable)
+            #expect(removedChanged)
+            #expect(removed["hooks"] == nil)
+        }
     }
 
     @Test("Scope decides which settings file is written")

--- a/Tests/MarkdownCLITests/MarkdownCLITests.swift
+++ b/Tests/MarkdownCLITests/MarkdownCLITests.swift
@@ -87,6 +87,25 @@ struct MarkdownCLITests {
         #expect(!html.contains("href=\"javascript/foo:alert(1)\""))
     }
 
+    @Test func htmlExportNeutralizesLineBreakObfuscatedSchemes() {
+        // Browsers strip tab, LF, and CR from anywhere inside a URL before
+        // parsing it, so every destination below would reach the browser as a
+        // live scheme unless the exporter normalizes before analyzing.
+        let html = MarkdownCLI.html(for: """
+        [tab](java\tscript:alert(1)) [newline](ja\nscript:alert(1)) [cr](j\rascript:alert(2))
+        ![pixel](http\t://tracking.example/x.png)
+        """)
+
+        #expect(!html.lowercased().contains("href=\"javascript:"))
+        #expect(!html.contains("\t"), "no raw tab may survive into an emitted URL")
+        #expect(!html.contains("\r"), "no raw carriage return may survive into an emitted URL")
+        #expect(!html.contains("<img "), "an obfuscated remote image source must not become a live img")
+
+        let safe = MarkdownCLI.html(for: "[web](https://example.com) [rel](./a.md)")
+        #expect(safe.contains("href=\"https://example.com\""))
+        #expect(safe.contains("href=\"./a.md\""))
+    }
+
     @Test func checkAndOutlineSupportDoubleDash() throws {
         #expect(try MarkdownCLI.parse(["check", "--", "-notes.md"])
             == .check(json: false, target: nil, paths: ["-notes.md"]))

--- a/Tests/MarkdownCoreTests/ContractTests.swift
+++ b/Tests/MarkdownCoreTests/ContractTests.swift
@@ -126,7 +126,10 @@ import Testing
         let doc = MarkdownParser.parse(text)
         let elapsed = Date().timeIntervalSince(start)
         #expect(doc.length > 0)
-        #expect(elapsed < 1.0, "100KB parse took \(elapsed)s")
+        // A coarse quadratic-behaviour probe, not the §12 benchmark: the
+        // release budget is enforced by drbench, so this ceiling only has to
+        // separate "linear-ish" from "accidentally quadratic" robustly.
+        #expect(elapsed < 5.0, "100KB parse took \(elapsed)s")
     }
 
     @Test func parsingIsDeterministic() {

--- a/Tests/MarkdownCoreTests/DiffTests.swift
+++ b/Tests/MarkdownCoreTests/DiffTests.swift
@@ -298,7 +298,11 @@ import Testing
         let start = Date()
         let result = Myers.diff(old, new)
         #expect(result == nil)
-        #expect(Date().timeIntervalSince(start) < 1.0)
+        // The wall clock here is a coarse bail-out probe, not a benchmark:
+        // building the O(D²) trace takes minutes and gigabytes, while the
+        // correct path returns in microseconds.  A generous ceiling stays
+        // robust on loaded CI machines and still catches the regression.
+        #expect(Date().timeIntervalSince(start) < 5.0)
     }
 
     /// Reordering large shared content stays solvable despite the length: the
@@ -326,6 +330,8 @@ import Testing
         let start = Date()
         let result = Myers.diff(old, new)
         #expect(result == nil)
-        #expect(Date().timeIntervalSince(start) < 1.0)
+        // Same coarse bail-out probe as above: generous enough for loaded
+        // machines, still orders of magnitude below a built trace.
+        #expect(Date().timeIntervalSince(start) < 5.0)
     }
 }

--- a/Tests/MarkdownCoreTests/SafeHTMLTests.swift
+++ b/Tests/MarkdownCoreTests/SafeHTMLTests.swift
@@ -55,6 +55,56 @@ struct SafeHTMLTests {
         }
     }
 
+    /// The cross-block accommodation must answer for *parsed tags*, not raw
+    /// substrings: a mention of the element inside a code span, or in prose,
+    /// must not license hiding a stray literal tag in another block.
+    @Test func detailsMentionsInCodeSpansAndProseDoNotSatisfyTheCrossBlockCheck() throws {
+        for opener in ["`<details>`", "the <details> element is a container"] {
+            let source = """
+            \(opener)
+
+            </details>
+            """
+            let parsed = MarkdownParser.parse(source)
+            let documents = parsed.root.children.compactMap(\.safeHTML)
+            let closing = try #require(documents.last)
+            #expect(!closing.isSafe, "a stray closer with only a textual mention before it stays literal")
+            #expect(closing.annotations.isEmpty)
+            #expect(parsed.text == source)
+        }
+
+        for closer in ["`</details>`", "write </details> to close"] {
+            let source = """
+            <details open>
+
+            \(closer)
+            """
+            let parsed = MarkdownParser.parse(source)
+            let documents = parsed.root.children.compactMap(\.safeHTML)
+            let opening = try #require(documents.first)
+            #expect(!opening.isSafe, "an opener whose only partner is textual mention stays literal")
+            #expect(opening.annotations.isEmpty)
+        }
+    }
+
+    /// The genuine README shape — an opening block, a blank line, the body,
+    /// another blank line, the closing block — keeps its cross-block pairing.
+    @Test func splitDetailsAcrossBlankLinesStillPairsUp() throws {
+        let source = """
+        <details open>
+        <summary>More</summary>
+
+        Body text across the boundary.
+
+        </details>
+        """
+        let parsed = MarkdownParser.parse(source)
+        let documents = parsed.root.children.compactMap(\.safeHTML)
+        let annotations = documents.flatMap(\.annotations)
+        #expect(annotations.contains { if case .details = $0.kind { true } else { false } })
+        #expect(annotations.contains { if case .detailsClosing = $0.kind { true } else { false } })
+    }
+
     @Test func remoteImagesStayVisibleButInertInsideSafeParents() throws {
         let source = #"<p align="center"><img src="https://tracker.example/pixel.png" alt="remote"></p>"#
         let parsed = MarkdownParser.parse(source)

--- a/Tests/MarkdownRenderTests/ClipboardSemanticHTMLTests.swift
+++ b/Tests/MarkdownRenderTests/ClipboardSemanticHTMLTests.swift
@@ -70,7 +70,11 @@ struct ClipboardSemanticHTMLTests {
         let pasteboard = NSPasteboard(name: .init("DownrightClipboardTests.\(UUID())"))
         pasteboard.clearContents()
         pasteboard.setData(rtf, forType: .rtf)
-        guard case .html(let richHTML, let fallback) = MarkdownSmartPaste.payload(from: pasteboard) else {
+        #expect(MarkdownSmartPaste.payload(from: pasteboard) == .text("Rich text"))
+        guard case .html(let richHTML, let fallback) = MarkdownSmartPaste.payload(
+            from: pasteboard,
+            mode: .markdown
+        ) else {
             Issue.record("RTF should retain semantic HTML when AppKit can convert it")
             return
         }

--- a/Tests/MarkdownRenderTests/DensityRailTests.swift
+++ b/Tests/MarkdownRenderTests/DensityRailTests.swift
@@ -29,6 +29,7 @@ struct DensityRailTests {
         #expect(DensityGutterView.hoverActivationSlop == 22)
         #expect(DensityGutterView.hoverDismissalSlop == 4)
         #expect(DensityGutterView.previewExitDelay == 0.06)
+        #expect(DensityGutterView.detentInterval == 0.05)
         #expect(DensityGutterView.proximityRadius == 36)
         #expect(DensityGutterView.magneticPull == 1.5)
         #expect(DensityGutterView.scrubVelocityPull == 2.0)
@@ -602,5 +603,120 @@ struct DensityRailTests {
         #expect(DensityGutterView.shouldBeginScrub(
             from: origin, to: NSPoint(x: 20, y: 104)
         ))
+    }
+
+    // MARK: - Detents
+
+    @Test("Arriving at a mark taps; leaving the stack does not")
+    func detentFiresOnArrivalAndCrossingOnly() {
+        // Arrival and hand-over: both are the pointer taking up a new position
+        // the rail actually depicts.
+        #expect(DensityGutterView.isDetentCrossing(from: nil, to: 0))
+        #expect(DensityGutterView.isDetentCrossing(from: 0, to: 1))
+
+        // Standing still is not a crossing, however many pointer moves arrive.
+        #expect(!DensityGutterView.isDetentCrossing(from: 1, to: 1))
+
+        // Leaving is silent.  The rail is against the window edge, so this
+        // transition fires on pointer travel that never meant to touch it.
+        #expect(!DensityGutterView.isDetentCrossing(from: 0, to: nil))
+        #expect(!DensityGutterView.isDetentCrossing(from: nil, to: nil))
+    }
+
+    /// The rail is a control you read by dragging along it, so the tap has to
+    /// survive a scrub without becoming a buzz — and the landing punch has to
+    /// stay audible to the hand rather than merging with the detent that
+    /// preceded it by a millisecond.
+    /// Pinned rather than inherited: a runner with Reduce Motion set silences
+    /// the rail, and a tap-counting test would then pass by measuring nothing.
+    @MainActor
+    private func rail(reduceMotion: Bool) -> DensityGutterView {
+        let rail = DensityGutterView(styleSheet: StyleSheet(
+            theme: ThemeStore.shared.current,
+            appearance: NSApp.effectiveAppearance,
+            reduceMotionOverride: reduceMotion
+        ))
+        rail.frame = NSRect(x: 0, y: 0, width: DensityGutterView.width, height: 600)
+        rail.bands = (0..<40).map { index in
+            DensityBand(
+                kind: .heading(level: 1),
+                startFraction: CGFloat(index) / 40,
+                endFraction: CGFloat(index + 1) / 40
+            )
+        }
+        rail.layoutSubtreeIfNeeded()
+        return rail
+    }
+
+    @Test("A sweep across the stack thins to a rhythm instead of buzzing")
+    @MainActor
+    func detentsAreRateLimitedAcrossAScrub() throws {
+        let rail = self.rail(reduceMotion: false)
+        var taps = 0
+        rail.performHapticFeedback = { taps += 1 }
+
+        // One unbroken sweep from one end of the track to the other.  Every
+        // mark is crossed, so an ungated rail taps ~40 times in the handful of
+        // milliseconds this loop takes.
+        var crossings = 0
+        var previous: Int?
+        let positions = rail.markPositionsForTesting
+        for step in 0...600 {
+            let y = CGFloat(step)
+            let next = DensityGutterView.nextHoveredBandIndex(
+                at: y,
+                positions: positions,
+                currentIndex: previous,
+                activationSlop: DensityGutterView.hoverActivationSlop,
+                dismissalSlop: DensityGutterView.dismissalSlop(for: positions)
+            )
+            if DensityGutterView.isDetentCrossing(from: previous, to: next) { crossings += 1 }
+            previous = next
+            rail.driveHoverForTesting(toY: y)
+        }
+
+        #expect(crossings > 20, "the sweep did not actually cross the stack")
+        #expect(taps > 0, "a sweep across the stack produced no detent at all")
+        // The claim is a ratio, not a count: however fast the machine runs the
+        // loop, the taps are bounded by the clock and not by the marks.
+        #expect(taps < crossings / 4,
+                "\(taps) taps for \(crossings) crossings — the rail is buzzing, not ticking")
+
+        // Suppression must not wedge it: once the floor has passed, the very
+        // next crossing taps again.  Aim at a drawn mark rather than at the
+        // end of the track — the stack is inset, so the extremes resolve to no
+        // mark at all and would cross nothing.
+        let before = taps
+        Thread.sleep(forTimeInterval: DensityGutterView.detentInterval * 2)
+        rail.driveHoverForTesting(toY: try #require(positions.first))
+        #expect(taps > before, "the rail stopped tapping after its first detent")
+    }
+
+    /// Reduce Motion already parks the rail's springs, so a rail that kept
+    /// tapping would answer movement the reader asked not to have.
+    @Test("Reduce Motion silences the rail's detents and its landing punch")
+    @MainActor
+    func reduceMotionSilencesTheRail() throws {
+        let quiet = rail(reduceMotion: true)
+        var taps = 0
+        quiet.performHapticFeedback = { taps += 1 }
+        let positions = quiet.markPositionsForTesting
+
+        for step in 0...600 {
+            quiet.driveHoverForTesting(toY: CGFloat(step))
+        }
+        #expect(taps == 0, "the rail tapped \(taps) times with Reduce Motion set")
+
+        // The same sweep on a rail that has not been asked for less motion is
+        // what proves the silence above came from the setting and not from a
+        // stack the pointer never crossed.
+        let loud = rail(reduceMotion: false)
+        var loudTaps = 0
+        loud.performHapticFeedback = { loudTaps += 1 }
+        #expect(loud.markPositionsForTesting == positions)
+        for step in 0...600 {
+            loud.driveHoverForTesting(toY: CGFloat(step))
+        }
+        #expect(loudTaps > 0)
     }
 }

--- a/Tests/MarkdownRenderTests/DropAndQuickLookTests.swift
+++ b/Tests/MarkdownRenderTests/DropAndQuickLookTests.swift
@@ -1,0 +1,501 @@
+import AppKit
+import Foundation
+import MarkdownCore
+import Testing
+
+@testable import MarkdownRender
+
+/// A drag hovering over the text, and a force click on it.
+///
+/// The whole feature turns on one number.  A drop point is a screen point,
+/// `characterIndexForInsertion(at:)` answers in TextKit's hybrid space, and
+/// only `DisplayMap` can turn one into a source offset.  What makes that easy
+/// to get wrong is that the two are usually the *same* number: the layout map
+/// pads hidden marker runs out with zero-width joiners so hit testing stays
+/// aligned, so a drop that skipped the conversion would behave perfectly on
+/// almost every document and then quietly land mid-word on one that has a
+/// footnote in the paragraph.  The fixture below is built specifically to be
+/// that document, so the mistake fails loudly instead.
+@Suite("Document drops and Quick Look", .serialized)
+@MainActor
+struct DropAndQuickLookTests {
+
+    // MARK: - Harness
+
+    @MainActor
+    private final class Delegate: NSObject, MarkdownTextViewDelegate {
+        var accepts = true
+        var askedToAccept: [Int] = []
+        var drops: [Int] = []
+        var quickLooks: [ContextTarget] = []
+        var handlesQuickLook = true
+
+        func markdownTextView(_ view: MarkdownTextView, canAcceptDrop drop: DocumentDrop) -> Bool {
+            askedToAccept.append(drop.sourceOffset)
+            return accepts
+        }
+
+        func markdownTextView(_ view: MarkdownTextView, didAcceptDrop drop: DocumentDrop) -> Bool {
+            drops.append(drop.sourceOffset)
+            return accepts
+        }
+
+        func markdownTextView(_ view: MarkdownTextView, wantsQuickLookFor target: ContextTarget) -> Bool {
+            quickLooks.append(target)
+            return handlesQuickLook
+        }
+    }
+
+    /// A minimal `NSDraggingInfo`.  AppKit only ever hands the real one to a
+    /// destination mid-gesture, so the only way to exercise the destination
+    /// methods at all is to stand one up.
+    nonisolated private final class SyntheticDrag: NSObject, NSDraggingInfo {
+        var draggingPasteboard: NSPasteboard
+        var draggingLocation: NSPoint
+        var draggingDestinationWindow: NSWindow? { nil }
+        var draggingSourceOperationMask: NSDragOperation { [.copy, .generic] }
+        var draggedImageLocation: NSPoint { draggingLocation }
+        var draggedImage: NSImage? { nil }
+        var draggingSource: Any? { nil }
+        var draggingSequenceNumber: Int { 1 }
+        var numberOfValidItemsForDrop: Int = 1
+        var draggingFormation: NSDraggingFormation = .default
+        var animatesToDestination: Bool = false
+        var springLoadingHighlight: NSSpringLoadingHighlight { .none }
+
+        init(pasteboard: NSPasteboard, location: NSPoint) {
+            self.draggingPasteboard = pasteboard
+            self.draggingLocation = location
+        }
+
+        func slideDraggedImage(to screenPoint: NSPoint) {}
+        func resetSpringLoading() {}
+        func enumerateDraggingItems(
+            options enumOpts: NSDraggingItemEnumerationOptions,
+            for view: NSView?,
+            classes classArray: [AnyClass],
+            searchOptions: [NSPasteboard.ReadingOptionKey: Any],
+            using block: (NSDraggingItem, Int, UnsafeMutablePointer<ObjCBool>) -> Void
+        ) {}
+    }
+
+    /// Deliberately built so the drop point's source offset and its TextKit
+    /// offset are *different numbers*.
+    ///
+    /// That takes more than dense Markdown.  Hidden markers do not shift the
+    /// two apart: `layoutSubstitution` pads every hidden run out with
+    /// zero-width joiners exactly so hit testing stays aligned, and
+    /// `DisplayMap` scopes conversions to a paragraph, so a length-changing
+    /// substitution in an *earlier* paragraph does not move anything either.
+    /// What does shift them is a substitution that changes length inside the
+    /// same paragraph as the drop — and a footnote reference is one: `[^a]`
+    /// (four source characters) is drawn as the single superscript `ᵃ`.  Three
+    /// of them put the drop point nine characters away from where the raw
+    /// TextKit index says it is.
+    nonisolated private static func document() -> String {
+        var lines: [String] = ["# A Title With Markers", ""]
+        // Long enough to have real geometry, short enough that eight full
+        // layout passes do not sit on the main actor while the rest of the
+        // suite's timing-sensitive tests are trying to drain their own work.
+        for index in 0..<6 {
+            lines.append("## Section \(index)")
+            lines.append("")
+            lines.append(
+                "Paragraph \(index) carries **strong emphasis** and _light emphasis_ "
+                + "plus `inline code` and a [link](https://example.com/some/long/path) "
+                + "before the rest of the sentence runs on to the end of the line."
+            )
+            lines.append("")
+        }
+        lines.append(
+            "The very last paragraph[^1][^2][^3], which has a TARGETWORD in it."
+        )
+        lines.append("")
+        for identifier in ["1", "2", "3"] {
+            lines.append("[^\(identifier)]: A footnote definition.")
+        }
+        lines.append("")
+        return lines.joined(separator: "\n")
+    }
+
+    /// The container is part of the harness, not scaffolding: the text view's
+    /// geometry comes from the scroll view it sits in, and letting ARC free the
+    /// container makes `rect(forOffset:)` answer for a layout nothing is
+    /// driving.  Tests that dropped it passed for the wrong reason.
+    private struct Harness {
+        var container: MarkdownContainerView
+        var view: MarkdownTextView
+        var delegate: Delegate
+        var text: String
+    }
+
+    private static func harness(
+        mode: RenderMode = .live,
+        text: String = document()
+    ) -> Harness {
+        let storage = NSTextStorage(string: text)
+        let sheet = StyleSheet(
+            theme: .fallback, appearance: NSAppearance(named: .aqua) ?? .currentDrawing()
+        )
+        let container = MarkdownContainerView(storage: storage, styleSheet: sheet)
+        container.frame = NSRect(x: 0, y: 0, width: 900, height: 600)
+        container.layoutSubtreeIfNeeded()
+        let view = container.textView
+        view.mode = mode
+        let delegate = Delegate()
+        view.markdownDelegate = delegate
+        view.update(document: MarkdownParser.parse(text), dirty: .wholesale)
+        container.layoutSubtreeIfNeeded()
+        // Deliberately no `resizeToFitContent()`: that lays the whole document
+        // out eagerly, and nothing here needs it — `rect(forOffset:)` and the
+        // pointer hit test each resolve the band they are asked about.  The
+        // suite runs beside `TypingInvalidationTests`, which drains chunked
+        // work against a wall-clock deadline on the same main actor, so a
+        // full-document layout pass per test is load with no assertion behind
+        // it.
+        return Harness(container: container, view: view, delegate: delegate, text: text)
+    }
+
+    private func filePasteboard(_ url: URL) -> NSPasteboard {
+        let pasteboard = NSPasteboard(name: NSPasteboard.Name("DropTests-\(UUID().uuidString)"))
+        pasteboard.clearContents()
+        pasteboard.writeObjects([url as NSURL])
+        return pasteboard
+    }
+
+    private func textPasteboard(_ string: String) -> NSPasteboard {
+        let pasteboard = NSPasteboard(name: NSPasteboard.Name("DropTests-\(UUID().uuidString)"))
+        pasteboard.clearContents()
+        pasteboard.setString(string, forType: .string)
+        return pasteboard
+    }
+
+    /// A point inside the glyphs of `offset`, expressed the way AppKit hands a
+    /// drop location over: in the window's coordinate space.
+    private func dragLocation(for offset: Int, in view: MarkdownTextView) throws -> NSPoint {
+        let rect = try #require(view.rect(forOffset: offset), "no geometry for offset \(offset)")
+        let inside = NSPoint(x: rect.minX + 1, y: rect.midY)
+        return view.convert(inside, to: nil)
+    }
+
+    // MARK: - The conversion this whole feature rests on
+
+    @Test("a drop reports the source offset under the pointer, not the display offset")
+    func dropReportsSourceCoordinates() throws {
+        let harness = Self.harness()
+        let view = harness.view
+        let ns = harness.text as NSString
+        let target = ns.range(of: "TARGETWORD").location
+        let location = try dragLocation(for: target, in: view)
+        let viewPoint = view.convert(location, from: nil)
+
+        // The premise, asserted rather than assumed: at this point the two
+        // coordinate spaces really have come apart.  If a future change makes
+        // them coincide here, every assertion below goes quiet and stops
+        // testing anything, so the fixture has to fail loudly instead.
+        let displayOffset = view.characterIndexForInsertion(at: viewPoint)
+        let sourceOffset = view.sourceOffset(at: viewPoint)
+        #expect(
+            displayOffset != sourceOffset,
+            "the fixture no longer shifts the two spaces apart, so this test proves nothing"
+        )
+
+        let drag = SyntheticDrag(pasteboard: filePasteboard(URL(fileURLWithPath: "/tmp/a.png")),
+                                 location: location)
+        #expect(view.draggingEntered(drag) == .copy)
+        #expect(view.performDragOperation(drag))
+
+        let reported = try #require(harness.delegate.drops.last)
+        #expect(reported == sourceOffset)
+        #expect(reported != displayOffset, "the drop reported a TextKit offset as a source offset")
+        // And the offset really does point at the word the pointer was over,
+        // in the *source* string — the check that would catch a conversion
+        // that is merely self-consistent.
+        #expect(ns.substring(with: NSRange(location: reported, length: 10)) == "TARGETWORD")
+    }
+
+    /// Every hop through the drag lifecycle has to convert independently.  The
+    /// hover indicator reading source coordinates while the drop read display
+    /// coordinates would be invisible until the image landed in the wrong
+    /// paragraph.
+    @Test("the hover indicator and the drop agree about where the drag is")
+    func hoverAndDropUseTheSameCoordinateSpace() throws {
+        let harness = Self.harness()
+        let view = harness.view
+        let ns = harness.text as NSString
+        let target = ns.range(of: "TARGETWORD").location
+        let location = try dragLocation(for: target, in: view)
+        let drag = SyntheticDrag(pasteboard: filePasteboard(URL(fileURLWithPath: "/tmp/a.png")),
+                                 location: location)
+
+        _ = view.draggingEntered(drag)
+        let hovered = try #require(view.dropInsertionOffset)
+        #expect(view.draggingUpdated(drag) == .copy)
+        #expect(view.dropInsertionOffset == hovered)
+        #expect(view.performDragOperation(drag))
+        #expect(harness.delegate.drops.last == hovered)
+        #expect(harness.delegate.askedToAccept == [hovered], "the claim must be asked exactly once per drag")
+    }
+
+    /// AppKit coalesces drag updates, so the release can land past the last
+    /// position the caret was drawn at.  The drop resolves the release point.
+    @Test("the drop uses the release point, not the last hover point")
+    func dropResolvesTheReleasePoint() throws {
+        let harness = Self.harness()
+        let view = harness.view
+        let ns = harness.text as NSString
+        let first = ns.range(of: "Paragraph 2 carries").location
+        let second = ns.range(of: "TARGETWORD").location
+        let pasteboard = filePasteboard(URL(fileURLWithPath: "/tmp/a.png"))
+
+        let hover = SyntheticDrag(pasteboard: pasteboard, location: try dragLocation(for: first, in: view))
+        _ = view.draggingEntered(hover)
+        let hovered = try #require(view.dropInsertionOffset)
+
+        hover.draggingLocation = try dragLocation(for: second, in: view)
+        #expect(view.performDragOperation(hover))
+        let dropped = try #require(harness.delegate.drops.last)
+        #expect(dropped != hovered)
+        #expect(ns.substring(with: NSRange(location: dropped, length: 10)) == "TARGETWORD")
+    }
+
+    @Test("a drop past the end of an empty document lands at zero")
+    func emptyDocumentDropsAtZero() throws {
+        let harness = Self.harness(text: "")
+        let view = harness.view
+        let location = view.convert(NSPoint(x: harness.container.bounds.midX, y: 40), to: nil)
+        let drag = SyntheticDrag(pasteboard: filePasteboard(URL(fileURLWithPath: "/tmp/a.png")),
+                                 location: location)
+        #expect(view.draggingEntered(drag) == .copy)
+        #expect(view.performDragOperation(drag))
+        #expect(harness.delegate.drops == [0])
+    }
+
+    // MARK: - Which drags the surface claims
+
+    @Test("an editable surface registers for files and image bytes")
+    func editableSurfaceRegistersDropTypes() {
+        let harness = Self.harness()
+        let view = harness.view
+        for type in MarkdownTextView.documentDropTypes {
+            #expect(view.registeredDraggedTypes.contains(type), "\(type.rawValue) is not registered")
+        }
+        // Idempotent: AppKit calls this whenever editability changes, and a
+        // registration that grew its own list every time would eventually be
+        // a few hundred copies of `public.png`.
+        let before = view.registeredDraggedTypes
+        view.updateDragTypeRegistration()
+        #expect(view.registeredDraggedTypes == before)
+    }
+
+    /// A registration that only ever *added* would leave a read-only surface
+    /// holding the types the mode before it registered.
+    @Test("switching to a read-only mode gives the drop types back")
+    func readOnlyModeUnregistersDropTypes() {
+        let harness = Self.harness()
+        #expect(harness.view.registeredDraggedTypes.contains(.fileURL))
+        harness.view.mode = .read
+        #expect(!harness.view.registeredDraggedTypes.contains(.fileURL))
+        harness.view.mode = .live
+        #expect(harness.view.registeredDraggedTypes.contains(.fileURL))
+    }
+
+    /// A drop is a source mutation, so a read-only surface takes none.  This is
+    /// the same door `super.updateDragTypeRegistration` closes, re-checked
+    /// because re-adding our types after it would open it again.
+    @Test("a read-only surface claims nothing")
+    func readOnlySurfaceClaimsNothing() throws {
+        let harness = Self.harness(mode: .read)
+        let view = harness.view
+        let text = harness.text
+        #expect(!view.isEditable)
+        #expect(!view.registeredDraggedTypes.contains(.fileURL))
+        // Belt and braces: even handed a drag directly, it takes nothing.
+
+        let location = try dragLocation(for: (text as NSString).range(of: "TARGETWORD").location, in: view)
+        let drag = SyntheticDrag(pasteboard: filePasteboard(URL(fileURLWithPath: "/tmp/a.png")),
+                                 location: location)
+        _ = view.draggingEntered(drag)
+        #expect(harness.delegate.askedToAccept.isEmpty)
+        #expect(view.dropInsertionOffset == nil)
+    }
+
+    /// Text dragged in from another app is `NSTextView`'s business and must
+    /// keep working exactly as it did.  Claiming it would turn every text drag
+    /// into a no-op the moment the host declined it.
+    @Test("a plain text drag is left to NSTextView")
+    func textDragsAreNotClaimed() throws {
+        let harness = Self.harness()
+        let view = harness.view
+        let location = try dragLocation(
+            for: (harness.text as NSString).range(of: "TARGETWORD").location, in: view
+        )
+        let drag = SyntheticDrag(pasteboard: textPasteboard("some words"), location: location)
+        harness.delegate.accepts = false
+        _ = view.draggingEntered(drag)
+        #expect(!view.claimsActiveDrag)
+        #expect(view.dropInsertionOffset == nil)
+        #expect(harness.delegate.drops.isEmpty)
+    }
+
+    @Test("the drop indicator is cleared when the drag leaves or lands")
+    func indicatorIsAlwaysCleared() throws {
+        let harness = Self.harness()
+        let view = harness.view
+        let location = try dragLocation(
+            for: (harness.text as NSString).range(of: "TARGETWORD").location, in: view
+        )
+        let pasteboard = filePasteboard(URL(fileURLWithPath: "/tmp/a.png"))
+
+        let leaving = SyntheticDrag(pasteboard: pasteboard, location: location)
+        _ = view.draggingEntered(leaving)
+        #expect(view.dropInsertionOffset != nil)
+        view.draggingExited(leaving)
+        #expect(view.dropInsertionOffset == nil)
+        #expect(!view.claimsActiveDrag)
+
+        let landing = SyntheticDrag(pasteboard: pasteboard, location: location)
+        _ = view.draggingEntered(landing)
+        #expect(view.performDragOperation(landing))
+        #expect(view.dropInsertionOffset == nil)
+        #expect(!view.claimsActiveDrag)
+    }
+
+    // MARK: - Quick Look targets
+
+    private static let linkedDocument = """
+    # Notes
+
+    See [the design](design.md) and `src/auth/session.ts` for the details.
+
+    ![A diagram](diagram.png)
+
+    An ordinary sentence with an unremarkable word in it.
+    """
+
+    private func linkedHarness() -> Harness { Self.harness(text: Self.linkedDocument) }
+
+    @Test("a force click on a link, a path, or an image resolves to that target")
+    func forceClickResolvesPreviewableTargets() throws {
+        let harness = linkedHarness()
+        let view = harness.view
+        let ns = harness.text as NSString
+
+        let linkPoint = view.convert(try dragLocation(for: ns.range(of: "the design").location, in: view), from: nil)
+        guard case .link(let destination)? = view.quickLookTarget(at: linkPoint)?.kind else {
+            Issue.record("a force click on link text must resolve to a link")
+            return
+        }
+        #expect(destination == "design.md")
+
+        let pathPoint = view.convert(
+            try dragLocation(for: ns.range(of: "src/auth/session.ts").location + 4, in: view), from: nil
+        )
+        guard case .pathToken(let token)? = view.quickLookTarget(at: pathPoint)?.kind else {
+            Issue.record("a force click on a path token must resolve to a path token")
+            return
+        }
+        #expect(token.rawPath == "src/auth/session.ts")
+    }
+
+    /// The half that is easy to lose: force-clicking a word has to keep
+    /// reaching `NSTextView`, which is what gives macOS's Look Up popover.
+    @Test("a force click on an ordinary word is not claimed")
+    func forceClickOnAWordFallsThrough() throws {
+        let harness = linkedHarness()
+        let view = harness.view
+        let point = view.convert(
+            try dragLocation(
+                for: (harness.text as NSString).range(of: "unremarkable").location + 3, in: view
+            ),
+            from: nil
+        )
+        #expect(view.quickLookTarget(at: point) == nil)
+    }
+
+    @Test("a heading, a code fence, and bare prose are not Quick Look targets")
+    func nonFileTargetsAreRefused() throws {
+        let harness = linkedHarness()
+        let view = harness.view
+        let heading = view.convert(
+            try dragLocation(for: (harness.text as NSString).range(of: "Notes").location, in: view),
+            from: nil
+        )
+        #expect(view.quickLookTarget(at: heading) == nil)
+    }
+
+    // MARK: - Space
+
+    private func spaceEvent() throws -> NSEvent {
+        try #require(NSEvent.keyEvent(
+            with: .keyDown, location: .zero, modifierFlags: [], timestamp: 0,
+            windowNumber: 0, context: nil, characters: " ",
+            charactersIgnoringModifiers: " ", isARepeat: false, keyCode: 49
+        ))
+    }
+
+    /// The one that matters more than the feature does.  Space is a character
+    /// on an editable surface, and no amount of "the selection happens to be a
+    /// link" may change that.
+    @Test("Space never previews while the surface is editable")
+    func spaceNeverPreviewsWhileEditing() throws {
+        let harness = linkedHarness()
+        let view = harness.view
+        #expect(view.isEditable)
+        view.setSourceSelectedRanges([(harness.text as NSString).range(of: "the design")])
+        #expect(view.quickLookTargetAtSelection() != nil, "the selection is on a link")
+        #expect(!view.handleQuickLookSpace(try spaceEvent()))
+        #expect(harness.delegate.quickLooks.isEmpty)
+    }
+
+    @Test("Space previews a selected link on a read-only surface")
+    func spacePreviewsOnAReadOnlySurface() throws {
+        let harness = Self.harness(mode: .read, text: Self.linkedDocument)
+        let view = harness.view
+        view.setSourceSelectedRanges([(harness.text as NSString).range(of: "the design")])
+        #expect(view.handleQuickLookSpace(try spaceEvent()))
+        guard case .link(let destination)? = harness.delegate.quickLooks.last?.kind else {
+            Issue.record("Space on a selected link must report a link target")
+            return
+        }
+        #expect(destination == "design.md")
+    }
+
+    /// With nothing selected, Space has to stay Space — a page-down in a
+    /// read-only view.  A collapsed selection at offset zero is the state a
+    /// document is in before anybody touches it, and previewing whatever
+    /// happens to be there is not a feature.
+    @Test("Space with no selection is left alone")
+    func spaceWithoutASelectionFallsThrough() throws {
+        let harness = Self.harness(mode: .read, text: Self.linkedDocument)
+        #expect(harness.view.sourceSelectedRange.length == 0)
+        #expect(!harness.view.handleQuickLookSpace(try spaceEvent()))
+        #expect(harness.delegate.quickLooks.isEmpty)
+    }
+
+    @Test("a modified Space is never a preview")
+    func modifiedSpaceIsNotAPreview() throws {
+        let harness = Self.harness(mode: .read, text: Self.linkedDocument)
+        let view = harness.view
+        view.setSourceSelectedRanges([(harness.text as NSString).range(of: "the design")])
+        let option = try #require(NSEvent.keyEvent(
+            with: .keyDown, location: .zero, modifierFlags: [.option], timestamp: 0,
+            windowNumber: 0, context: nil, characters: " ",
+            charactersIgnoringModifiers: " ", isARepeat: false, keyCode: 49
+        ))
+        #expect(!view.handleQuickLookSpace(option))
+        #expect(harness.delegate.quickLooks.isEmpty)
+    }
+
+    @Test("the caret on a link is a Quick Look target; the caret in prose is not")
+    func selectionTargetsFollowTheCaret() throws {
+        let harness = linkedHarness()
+        let view = harness.view
+        let ns = harness.text as NSString
+        view.setSourceSelectedRanges([NSRange(location: ns.range(of: "the design").location + 2, length: 0)])
+        #expect(view.quickLookTargetAtSelection() != nil)
+
+        view.setSourceSelectedRanges([NSRange(location: ns.range(of: "unremarkable").location + 3, length: 0)])
+        #expect(view.quickLookTargetAtSelection() == nil)
+    }
+}

--- a/Tests/MarkdownRenderTests/SmartPasteIntegrationTests.swift
+++ b/Tests/MarkdownRenderTests/SmartPasteIntegrationTests.swift
@@ -27,7 +27,7 @@ struct SmartPasteIntegrationTests {
         return view
     }
 
-    @Test("pasteboard priority prefers URL over HTML and plain text")
+    @Test("ordinary paste prefers visible text; Markdown paste prefers rich structure")
     func pasteboardPriority() {
         let pasteboard = isolatedPasteboard()
         pasteboard.clearContents()
@@ -36,10 +36,15 @@ struct SmartPasteIntegrationTests {
         pasteboard.setString("fallback", forType: .string)
 
         let payload = MarkdownSmartPaste.payload(from: pasteboard)
-        #expect(payload == .url("www.example.com"))
+        #expect(payload == .text("fallback"))
         #expect(MarkdownSmartPaste.replacement(
-            for: payload!, selection: "title", context: .markdown)
-            == "[title](https://www.example.com)")
+            for: payload!, selection: "title", context: .markdown) == "fallback")
+
+        let markdownPayload = MarkdownSmartPaste.payload(from: pasteboard, mode: .markdown)
+        #expect(markdownPayload == .html("<p>Browser title</p>", fallback: "fallback"))
+        #expect(MarkdownSmartPaste.replacement(
+            for: markdownPayload!, selection: "", context: .markdown, mode: .markdown)
+            == "Browser title")
         #expect(MarkdownSmartPaste.replacement(
             for: .url("javascript://alert(1)"), selection: "title", context: .markdown)
             == "javascript://alert(1)")
@@ -116,7 +121,7 @@ struct SmartPasteIntegrationTests {
             for: payload!, selection: "", context: .markdown) == "**Only HTML**")
     }
 
-    @Test("Safari public.html keeps rich structure ahead of flattened fallback")
+    @Test("Paste as Markdown keeps Safari structure ahead of flattened fallback")
     func safariHTMLRoundTrip() {
         let pasteboard = isolatedPasteboard()
         pasteboard.clearContents()
@@ -129,12 +134,14 @@ struct SmartPasteIntegrationTests {
         """
         pasteboard.setString(html, forType: .html)
         // Safari advertises several rich aliases and a flattened public.text
-        // fallback. Normal Paste must consume public.html, not the fallback.
+        // fallback. Explicit Markdown conversion consumes public.html.
         pasteboard.setString("Heading Intro bold and link. first nested code second Name Count Ada 1", forType: .string)
         pasteboard.setData(Data([0x00, 0x01]), forType: .rtf)
         pasteboard.setData(Data([0x02, 0x03]), forType: .appleWebArchive)
 
-        let payload = MarkdownSmartPaste.payload(from: pasteboard)
+        #expect(MarkdownSmartPaste.payload(from: pasteboard)
+            == .text("Heading Intro bold and link. first nested code second Name Count Ada 1"))
+        let payload = MarkdownSmartPaste.payload(from: pasteboard, mode: .markdown)
         guard let payload else {
             Issue.record("Safari-style clipboard did not expose a payload")
             return

--- a/Tests/MarkdownRenderTests/ThemeTests.swift
+++ b/Tests/MarkdownRenderTests/ThemeTests.swift
@@ -4,7 +4,7 @@ import MarkdownCore
 import Testing
 @testable import MarkdownRender
 
-@Suite("Theming, typography and colour (§11.1, §11.2)")
+@Suite("Theming, typography and colour (§11.1, §11.2)", .serialized)
 final class ThemeTests {
 
     @Test func readerProfileCanOnlyAddReducedMotion() {
@@ -23,19 +23,18 @@ final class ThemeTests {
     private let aqua = NSAppearance(named: .aqua)!
     private let darkAqua = NSAppearance(named: .darkAqua)!
 
-    /// `select(named:)` persists to `UserDefaults` by design, so each test puts
-    /// the user's real preference back when it finishes.
-    private let savedSelection = UserDefaults.standard.string(forKey: ThemeStore.selectionDefaultsKey)
+    /// `select(named:)` persists to `UserDefaults` by design, so every store
+    /// here runs against an isolated suite — a test run must never read or
+    /// rewrite the user's real theme selection.
+    private static let isolatedDefaults = UserDefaults(
+        suiteName: "downright.tests.themes"
+    )!
 
     deinit {
-        if let savedSelection {
-            UserDefaults.standard.set(savedSelection, forKey: ThemeStore.selectionDefaultsKey)
-        } else {
-            UserDefaults.standard.removeObject(forKey: ThemeStore.selectionDefaultsKey)
-        }
+        Self.isolatedDefaults.removePersistentDomain(forName: "downright.tests.themes")
     }
 
-    private func store() -> ThemeStore { ThemeStore() }
+    private func store() -> ThemeStore { ThemeStore(defaults: Self.isolatedDefaults) }
 
     private func bundled() -> [Theme] {
         let names = Set(ThemeTests.bundledNames)

--- a/npm/downright-installer/bin/downright-install.mjs
+++ b/npm/downright-installer/bin/downright-install.mjs
@@ -1,8 +1,17 @@
 #!/usr/bin/env node
 
+import { createHash } from "node:crypto";
 import { spawnSync } from "node:child_process";
 
 const installerURL = process.env.DOWNRIGHT_INSTALLER_URL ?? "https://downright.cc/install";
+
+// The installer endpoint serves the repository's Scripts/install-release.sh.
+// Piping a fetched script straight into bash would make any compromise of
+// that endpoint arbitrary code execution at user privileges, so the expected
+// SHA-256 is pinned here and verified before a single byte runs.  Update this
+// constant in the same commit that changes install-release.sh.
+const INSTALLER_SHA256 =
+  "f16cc08d8c3048c9e37b2aeaac1adfd84b0059036986ef009d9c03dda1d2b0f2";
 
 if (process.platform !== "darwin") {
   console.error("Downright is currently available through this installer on macOS only.");
@@ -20,8 +29,11 @@ try {
   }
 
   const script = await response.text();
-  if (!script.startsWith("#!/usr/bin/env bash") || !script.includes("DMG checksum verified")) {
-    throw new Error("installer endpoint did not return the expected Downright installer");
+  const digest = createHash("sha256").update(script).digest("hex");
+  if (digest !== INSTALLER_SHA256) {
+    throw new Error(
+      `installer script failed integrity check (expected ${INSTALLER_SHA256}, got ${digest})`,
+    );
   }
 
   const result = spawnSync("/bin/bash", ["-s", "downright-release-installer"], {


### PR DESCRIPTION
## Summary

One linear stack over `origin/main` (22 commits), consolidated for release.

**Previously committed on `main` (4):**
- fix: simplify recent document features; clarify external change status; remove contents toolbar button
- docs: clarify installation methods

**Updater + density rail (2):**
- feat: offer a new build the same sitting it ships
- feat: give the density rail detents

**Reliability / security audit batch (15):**
- security: pin external trust grants to the approved URL
- fix(cli): neutralize line-break-obfuscated schemes in `down export`; quote agent hook commands and migrate legacy hooks
- fix(updater): If-Modified-Since fallback when a host serves no ETag
- fix(core): flush the replacement generation before the atomic swap
- fix(app): never write a buffer the user chose to discard; context-menu path actions stay inert for missing paths; reveal execution-capable link targets instead of running them
- fix(core): anchor safe-HTML details pairing to real block shapes
- fix(app): file-watcher own-write suppression is state-based
- chore(gate): validation gates fail closed, tighter CI; tests keep off real user state, deflaked wall-clock asserts
- docs: npm installer script pinning, BIN_DEST, changelog entries

**New in this PR (1):**
- feat: two-finger Document↔Source swipe with per-gesture render budget, File ▸ Share / Share as PDF, Insert from iPhone/iPad (Continuity Camera), drag-and-drop reference insertion with live drop caret, force-click/⌘Y Quick Look with lightbox, single-pass Source-mode attributes (~2–3× faster switching)

## Validation

- `Scripts/check.sh` on the integrated tip: build ok, spotlight importer ok, **1325 tests in 116 suites passed**, contrast sanity pass, bench within budgets (typing p95 0.97 ms vs 8 ms).

## Note for reviewers

Merging this to `main` triggers the signed release workflow.