### PR TITLE
Audit remediation: correctness, data-integrity, installer-chain, and updater fixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -166,6 +166,10 @@ jobs:
         run: |
           set -euo pipefail
           BUILD="${BUILD:?release build number was not derived in the validation step}"
+          # Explicit parity with the local bundling path, which pins
+          # DEBUG_INFORMATION_FORMAT too: without it the archive depends on
+          # the runner preset, and a preset change would surface as a
+          # missing-dSYMs failure.
           xcodebuild \
             -project Downright.xcodeproj \
             -scheme Downright \
@@ -173,6 +177,7 @@ jobs:
             -derivedDataPath .build-release \
             -archivePath .build-release/Downright.xcarchive \
             ARCHS="arm64 x86_64" ONLY_ACTIVE_ARCH=NO \
+            DEBUG_INFORMATION_FORMAT=dwarf-with-dsym \
             MARKETING_VERSION="$MARKETING_VERSION" \
             CURRENT_PROJECT_VERSION="$BUILD" \
             DEVELOPMENT_TEAM="" \
@@ -459,10 +464,11 @@ jobs:
           # (Sparkle's own convention) and never match the full-archive regex,
           # so they cannot be mistaken for update archives.
           curl -fsSL -H "Authorization: Bearer $GITHUB_TOKEN" \
+             --connect-timeout 15 --max-time 60 \
             "https://api.github.com/repos/${{ github.repository }}/releases?per_page=10" \
-            | jq -r '.[] | select(.prerelease == false) | .assets[]? | select(.name | test("^Downright-[0-9]+\\.[0-9]+\\.[0-9]+(-[0-9]+-[0-9a-f]+)?\\.zip$")) | .browser_download_url' \
-            | head -3 | while read -r url; do
-                curl -fsSL -L -O --output-dir /tmp/appcast-input "$url"
+            | jq -r '[.[] | select(.prerelease == false) | .assets[]? | select(.name | test("^Downright-[0-9]+\\.[0-9]+\\.[0-9]+(-[0-9]+-[0-9a-f]+)?\\.zip$")) | .browser_download_url][:3][]' \
+            | while read -r url; do
+                curl -fsSL -L --connect-timeout 15 --max-time 600 -O --output-dir /tmp/appcast-input "$url"
               done
           ls -la /tmp/appcast-input/
         env:
@@ -549,15 +555,15 @@ jobs:
         run: |
           set -euo pipefail
           URL="https://github.com/${{ github.repository }}/releases/download/$RELEASE_TAG/Downright-$TAG.zip"
-          HTTP=$(curl -sIL -o /dev/null -w '%{http_code}' "$URL")
+          HTTP=$(curl -sIL --connect-timeout 15 --max-time 60 -o /dev/null -w '%{http_code}' "$URL")
           [ "$HTTP" = "200" ] || [ "$HTTP" = "302" ] || { echo "asset not reachable: $HTTP"; exit 1; }
-          PUBLISHED_SHA="$(curl -fsSL "$URL" | shasum -a 256 | awk '{print $1}')"
+          PUBLISHED_SHA="$(curl -fsSL --connect-timeout 15 --max-time 900 "$URL" | shasum -a 256 | awk '{print $1}')"
           LOCAL_SHA="$(cat artifacts/Downright-$TAG.zip.sha256 | awk '{print $1}')"
           [ "$PUBLISHED_SHA" = "$LOCAL_SHA" ] || { echo "checksum mismatch after publish"; exit 1; }
           DMG_URL="https://github.com/${{ github.repository }}/releases/download/$RELEASE_TAG/Downright-$TAG.dmg"
-          DMG_HTTP=$(curl -sIL -o /dev/null -w '%{http_code}' "$DMG_URL")
+          DMG_HTTP=$(curl -sIL --connect-timeout 15 --max-time 60 -o /dev/null -w '%{http_code}' "$DMG_URL")
           [ "$DMG_HTTP" = "200" ] || [ "$DMG_HTTP" = "302" ] || { echo "dmg not reachable: $DMG_HTTP"; exit 1; }
-          PUBLISHED_DMG_SHA="$(curl -fsSL "$DMG_URL" | shasum -a 256 | awk '{print $1}')"
+          PUBLISHED_DMG_SHA="$(curl -fsSL --connect-timeout 15 --max-time 900 "$DMG_URL" | shasum -a 256 | awk '{print $1}')"
           LOCAL_DMG_SHA="$(cat artifacts/Downright-$TAG.dmg.sha256 | awk '{print $1}')"
           [ "$PUBLISHED_DMG_SHA" = "$LOCAL_DMG_SHA" ] || { echo "dmg checksum mismatch after publish"; exit 1; }
           # Delta assets referenced by the appcast must also be reachable at
@@ -566,16 +572,16 @@ jobs:
             [ -f "$delta" ] || continue
             BASE=$(basename "$delta")
             DELTA_URL="https://github.com/${{ github.repository }}/releases/download/$RELEASE_TAG/$BASE"
-            DH=$(curl -sIL -o /dev/null -w '%{http_code}' "$DELTA_URL")
+            DH=$(curl -sIL --connect-timeout 15 --max-time 60 -o /dev/null -w '%{http_code}' "$DELTA_URL")
             [ "$DH" = "200" ] || [ "$DH" = "302" ] || { echo "delta not reachable: $DH $BASE"; exit 1; }
-            DL=$(curl -fsSL "$DELTA_URL" | shasum -a 256 | awk '{print $1}')
+            DL=$(curl -fsSL --connect-timeout 15 --max-time 300 "$DELTA_URL" | shasum -a 256 | awk '{print $1}')
             LL=$(shasum -a 256 "$delta" | awk '{print $1}')
             [ "$DL" = "$LL" ] || { echo "delta checksum mismatch: $BASE"; exit 1; }
           done
           STABLE_DMG_URL="https://github.com/${{ github.repository }}/releases/latest/download/Downright.dmg"
           STABLE_DMG_SHA="$(cat artifacts/Downright.dmg.sha256 | awk '{print $1}')"
           for attempt in $(seq 1 30); do
-            STABLE_HTTP=$(curl -sIL -o /dev/null -w '%{http_code}' "$STABLE_DMG_URL" || true)
+            STABLE_HTTP=$(curl -sIL --connect-timeout 15 --max-time 60 -o /dev/null -w '%{http_code}' "$STABLE_DMG_URL" || true)
             if [ "$STABLE_HTTP" = "200" ] || [ "$STABLE_HTTP" = "302" ]; then
               break
             fi
@@ -585,7 +591,7 @@ jobs:
             echo "stable DMG not reachable: $STABLE_HTTP"
             exit 1
           }
-          PUBLISHED_STABLE_SHA="$(curl -fsSL "$STABLE_DMG_URL" | shasum -a 256 | awk '{print $1}')"
+          PUBLISHED_STABLE_SHA="$(curl -fsSL --connect-timeout 15 --max-time 900 "$STABLE_DMG_URL" | shasum -a 256 | awk '{print $1}')"
           [ "$PUBLISHED_STABLE_SHA" = "$STABLE_DMG_SHA" ] || {
             echo "stable DMG checksum mismatch"
             exit 1
@@ -601,6 +607,9 @@ jobs:
   deploy:
     needs: release
     runs-on: ubuntu-latest
+    # A Pages deployment is seconds of work; an unbounded default (360
+    # minutes) would hold the pipeline open for hours if the runner hung.
+    timeout-minutes: 10
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,6 +157,10 @@ every release; Sparkle orders updates by it.
 - `down check` prints conventional `file:line:` diagnostics with real line
   numbers instead of UTF-16 offsets.
 
+- **Indenting and outdenting now renumber ordered lists**, as §6.4 always
+  promised: outdenting a nested item into its parent list repairs duplicate
+  and stale numbers in the same keystroke, inside the same undo group.
+
 - **A discarded buffer can no longer reach disk.** Choosing Discard in the
   close or quit prompt used to leave the document dirty while queued autosave
   work and window-occlusion saves stayed armed: the write could land while the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,29 @@ every release; Sparkle orders updates by it.
 
 ### Fixed
 
+- **Restructuring a heading inside a quote or list no longer eats the next
+  line.** Demoting `> ## Deep` used to take the setext-normalization path,
+  which consumed the *following* line as an underline — the quoted body
+  vanished. Level changes now require a genuinely two-line setext shape, keep
+  the container marker in front of the hashes, and Heading to Body Text stops
+  stripping `> `/`- ` off nested headings. List continuation on Return keeps
+  a nested item's own `*`/`+` bullet instead of falling back to `-`.
+- **An external atomic save is not reported as a deletion.** A write observed
+  inside the brief unlink→rename window could surface "the file is gone";
+  a tentative removal now waits out one short re-probe and reports what the
+  path became.
+- **A corrupt version-timeline index is left alone.** Recording a new version
+  used to overwrite an unreadable history index and let the next prune sweep
+  every object it referenced; the store now refuses to touch an index it
+  cannot decode.
+- **Installers cannot destroy the app they replace.** An interruption during
+  the swap used to delete the only copy of the installed app along with its
+  staging directory; the previous installation is now restored or preserved
+  on every exit path, and the local installer closes Downright refusal-first
+  instead of killing it silently.
+- `down check` prints conventional `file:line:` diagnostics with real line
+  numbers instead of UTF-16 offsets.
+
 - **A discarded buffer can no longer reach disk.** Choosing Discard in the
   close or quit prompt used to leave the document dirty while queued autosave
   work and window-occlusion saves stayed armed: the write could land while the

--- a/Docs/PERFORMANCE.md
+++ b/Docs/PERFORMANCE.md
@@ -7,18 +7,25 @@ pipeline. Do not replace a failed measurement with a claim.
 
 | Metric | Target | Method | Pass condition |
 |---|---:|---|---|
-| Cold launch to first rendered pixel, 100 KB | <250 ms | App launch capture | p95 below target |
-| Keystroke response, 5,000-line file | <8 ms | Source edit, paragraph map, dirty decoration | p95 below target |
-| Scroll | 120 fps on ProMotion | Long-document scroll trace | No sustained frame drop |
-| Structural zoom | <300 ms | Level 1–5 transition trace | Anchor stays fixed; no dropped frames |
+| Cold launch to first rendered pixel, 100 KB | <250 ms | App launch capture | p95 below target · *manual release gate* |
+| Keystroke response, 5,000-line file | <8 ms | Source edit, paragraph map, dirty decoration (`drbench`, release) | p95 below target |
+| Scroll | 120 fps on ProMotion | Long-document scroll trace | No sustained frame drop · *manual release gate* |
+| Structural zoom | <300 ms | Level 1–5 transition trace | Anchor stays fixed; no dropped frames · *manual release gate* |
 | Document↔Source swipe, engage and abandon (give path) | <8 ms | `PresentationSwipeBudgetTests`, 2,000-line file | Below target; nothing rendered inside the gesture |
 | Document↔Source swipe, engage (drag path) | <50 ms | `PresentationSwitchBudget`, documents under its line budget | Below target; measured 6 ms at 240 lines, 26 ms at 950 |
 | Document↔Source swipe, per tracking frame | <1 ms | `PresentationSwipeBudgetTests` | Below target |
-| Quick Look preview | <400 ms | Preview extension render | p95 below target |
+| Quick Look preview | <400 ms | Preview extension render | p95 below target · *no automated measurement yet — manual* |
 | Quick Look peak memory | <60 MB | Resident memory polling | Never exceeds target |
-| 1 MB document memory | <150 MB | App open and idle measurement | Peak below target |
+| 1 MB document memory | <150 MB | App open and idle measurement | Peak below target · *manual release gate* |
 | Quick Look safety fallback | 60 MB | Memory guard | Plain text fallback above guard |
 | Large Quick Look file | 2 MB | Preview policy | Initial blocks plus Open in App |
+
+Rows marked *manual release gate* have no automated enforcement vehicle in
+the repository today. They are claims to re-measure at release time, not
+gates a CI run proves; do not cite them as enforced. The memory-guard and
+policy rows are asserted by unit tests, the swipe rows by dedicated budget
+suites, and the keystroke/convergence rows by `drbench` with
+`RUN_DRBENCH=1`.
 
 The swipe budgets exist because the obvious implementation misses them by an
 order of magnitude. Dragging the Source presentation in under the fingers

--- a/Scripts/install-release.sh
+++ b/Scripts/install-release.sh
@@ -17,6 +17,10 @@ CHECKSUM_PATH="$WORK_DIR/Downright.dmg.sha256"
 STAGED_APP="$WORK_DIR/Downright.app"
 BACKUP_APP="$WORK_DIR/previous.app"
 DEVICE=""
+# Set once the staged app is verified in place. Until then the backup is
+# the only copy of the user's installed Downright, so every exit path must
+# preserve or restore it rather than delete it.
+INSTALL_FINALIZED=0
 
 log() {
     printf '==> %s\n' "$*"
@@ -34,7 +38,21 @@ cleanup() {
     if [ -n "$DEVICE" ]; then
         hdiutil detach "$DEVICE" -force >/dev/null 2>&1 || true
     fi
-    rm -rf "$WORK_DIR"
+    if [ "${INSTALL_FINALIZED:-0}" != "1" ] && [ -e "$BACKUP_APP" ]; then
+        # The staged app never took over. Put the previous installation
+        # back; if that is impossible, keep it on disk and say where it is
+        # instead of deleting it with the work directory.
+        if move_into_app_parent "$BACKUP_APP" "$APP_DEST" 2>/dev/null; then
+            printf 'The previous Downright.app was restored.\n' >&2
+        else
+            printf 'warning: the previous app could not be restored automatically.\n' >&2
+            printf 'It is preserved at: %s\n' "$BACKUP_APP" >&2
+            WORK_DIR=""
+        fi
+    fi
+    if [ -n "$WORK_DIR" ]; then
+        rm -rf "$WORK_DIR"
+    fi
     exit "$status"
 }
 
@@ -56,8 +74,10 @@ fi
 
 mkdir -p "$MOUNT_DIR"
 log "Downloading the latest Downright release"
-curl -fsSL --retry 3 --retry-delay 1 "$RELEASE_BASE_URL/Downright.dmg" -o "$DMG_PATH"
-curl -fsSL --retry 3 --retry-delay 1 "$RELEASE_BASE_URL/Downright.dmg.sha256" -o "$CHECKSUM_PATH"
+curl -fsSL --retry 3 --retry-delay 1 --connect-timeout 15 --max-time 600 \
+    "$RELEASE_BASE_URL/Downright.dmg" -o "$DMG_PATH"
+curl -fsSL --retry 3 --retry-delay 1 --connect-timeout 15 --max-time 60 \
+    "$RELEASE_BASE_URL/Downright.dmg.sha256" -o "$CHECKSUM_PATH"
 
 EXPECTED_SHA="$(awk 'NF { print tolower($1); exit }' "$CHECKSUM_PATH")"
 ACTUAL_SHA="$(shasum -a 256 "$DMG_PATH" | awk '{ print tolower($1) }')"
@@ -91,11 +111,13 @@ if [ -e "$APP_DEST" ]; then
 fi
 
 if ! move_into_app_parent "$STAGED_APP" "$APP_DEST"; then
-    if [ -e "$BACKUP_APP" ]; then
-        move_into_app_parent "$BACKUP_APP" "$APP_DEST" || true
-    fi
+    # cleanup() restores the backup on the way out; if even that fails it
+    # preserves the backup and prints its location.
     fail "could not install the application in $APP_DEST"
 fi
+
+codesign --verify --deep --strict "$APP_DEST" >/dev/null
+INSTALL_FINALIZED=1
 
 if [ -e "$BACKUP_APP" ]; then
     if [ -w "$WORK_DIR" ]; then
@@ -104,8 +126,6 @@ if [ -e "$BACKUP_APP" ]; then
         sudo rm -rf "$BACKUP_APP"
     fi
 fi
-
-codesign --verify --deep --strict "$APP_DEST" >/dev/null
 
 if [ "${DOWNRIGHT_SKIP_SYSTEM_INTEGRATION:-0}" != "1" ]; then
     LSREGISTER="/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister"

--- a/Scripts/install.sh
+++ b/Scripts/install.sh
@@ -35,24 +35,66 @@ fi
 echo "==> Installing to $APP_DEST"
 DEST_PARENT="$(dirname "$APP_DEST")"
 STAGE_ROOT="$(mktemp -d "$DEST_PARENT/.downright-install.XXXXXX")"
-STAGED_APP="$STAGE_ROOT/Downright.app"
-BACKUP_APP="$STAGE_ROOT/previous.app"
-trap 'rm -rf "$STAGE_ROOT"' EXIT
+# The backup of the outgoing app deliberately lives OUTSIDE the staging tree
+# the exit trap deletes. Between "old app moved aside" and "new app in
+# place", the backup is the only copy of the user's installed Downright; an
+# interruption there used to destroy it along with the staging directory and
+# leave /Applications empty.
+BACKUP_ROOT="$(mktemp -d "$DEST_PARENT/.downright-previous.XXXXXX")"
+BACKUP_APP="$BACKUP_ROOT/Downright.app"
+SWAPPED_IN=0
+
+finish() {
+    local status=$?
+    trap - EXIT INT TERM
+    rm -rf "$STAGE_ROOT"
+    if [ "$SWAPPED_IN" != "1" ] && [ -d "$BACKUP_APP" ]; then
+        if mv "$BACKUP_APP" "$APP_DEST" 2>/dev/null; then
+            rm -rf "$BACKUP_ROOT"
+            echo "The previous Downright.app was restored." >&2
+        else
+            # Never delete the backup when the restore failed: it is the
+            # only copy left. Say where it is instead.
+            echo "error: install did not finish and the previous app could not be restored." >&2
+            echo "       It is preserved at: $BACKUP_APP" >&2
+            BACKUP_ROOT=""
+        fi
+    fi
+    if [ -n "$BACKUP_ROOT" ]; then
+        rm -rf "$BACKUP_ROOT"
+    fi
+    exit "$status"
+}
+trap finish EXIT
+trap 'exit 130' INT TERM
 cp -R "$APP_SOURCE" "$STAGED_APP"
 codesign --verify --deep --strict "$STAGED_APP"
 
-# A running old process can keep Finder extensions and window state pinned to
-# deleted code. Stop only this exact installed bundle before the atomic swap.
-pkill -f "^$APP_DEST/Contents/MacOS/Downright$" 2>/dev/null || true
-if [ -d "$APP_DEST" ]; then mv "$APP_DEST" "$BACKUP_APP"; fi
-if ! mv "$STAGED_APP" "$APP_DEST"; then
-    if [ -d "$BACKUP_APP" ]; then mv "$BACKUP_APP" "$APP_DEST"; fi
+# A running app would be killed silently here, losing unsaved edits; the
+# public installer refuses instead, so do the same and let the user close
+# the document they have open.
+if pgrep -f "^$APP_DEST/Contents/MacOS/Downright$" >/dev/null 2>&1; then
+    echo "error: Downright is running; close it and run this installer again." >&2
     exit 1
 fi
-rm -rf "$BACKUP_APP"
+if [ -d "$APP_DEST" ]; then mv "$APP_DEST" "$BACKUP_APP"; fi
+if ! mv "$STAGED_APP" "$APP_DEST"; then
+    if [ -d "$BACKUP_APP" ]; then
+        mv "$BACKUP_APP" "$APP_DEST" \
+            || { echo "error: could not restore the previous app; it is preserved at $BACKUP_APP" >&2; false; }
+    fi
+    exit 1
+fi
+SWAPPED_IN=1
+rm -rf "$BACKUP_ROOT"
 
 echo "==> Linking CLI into $BIN_DEST"
-mkdir -p "$BIN_DEST"
+if ! mkdir -p "$BIN_DEST" 2>/dev/null; then
+    # Not fatal: the app itself is installed. The default destination needs
+    # write access to /usr/local; BIN_DEST points somewhere writable when
+    # that is not available.
+    echo "    warning: could not create $BIN_DEST — skipping the CLI links" >&2
+else
 DOWN_TARGET="$APP_DEST/Contents/MacOS/down"
 if [ "$(readlink "$BIN_DEST/down" 2>/dev/null || true)" != "$DOWN_TARGET" ]; then
     ln -sf "$DOWN_TARGET" "$BIN_DEST/down" \
@@ -63,6 +105,7 @@ fi
 if ! command -v md >/dev/null 2>&1; then
     ln -sf "$DOWN_TARGET" "$BIN_DEST/md" \
         || echo "    warning: could not create $BIN_DEST/md"
+fi
 fi
 
 /System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister \

--- a/Scripts/report-download-counts.sh
+++ b/Scripts/report-download-counts.sh
@@ -51,9 +51,27 @@ done
 command -v curl >/dev/null || { echo "curl is required" >&2; exit 1; }
 command -v jq >/dev/null || { echo "jq is required" >&2; exit 1; }
 
+# Temporary files removed on exit. A single handler because the pagination
+# loop below re-points nothing: every consumer appends here.
+CLEANUP_FILES=()
+cleanup() {
+    local file
+    for file in "${CLEANUP_FILES[@]:-}"; do
+        [ -n "$file" ] && rm -f "$file"
+    done
+}
+trap cleanup EXIT
+
 CURL_ARGS=(-fsSL -H 'Accept: application/vnd.github+json')
 if [ -n "${GITHUB_TOKEN:-}" ]; then
-    CURL_ARGS+=(-H "Authorization: Bearer $GITHUB_TOKEN")
+    # The token goes through a curl config file rather than the command
+    # line: arguments are world-readable in `ps` output for as long as the
+    # request runs, and this report can run on developer machines.
+    CURL_CONFIG="$(mktemp)"
+    chmod 600 "$CURL_CONFIG"
+    CLEANUP_FILES+=("$CURL_CONFIG")
+    printf 'header = "Authorization: Bearer %s"\n' "$GITHUB_TOKEN" > "$CURL_CONFIG"
+    CURL_ARGS+=(--config "$CURL_CONFIG")
 fi
 
 REMOTE="$(git -C "$ROOT" config --get remote.origin.url || true)"
@@ -67,7 +85,7 @@ if [ "$ALL" = "1" ]; then
     # The releases endpoint defaults to 30 results. Keep following pages so
     # the README counter remains cumulative as the project grows.
     RELEASES_FILE="$(mktemp)"
-    trap 'rm -f "$RELEASES_FILE"' EXIT
+    CLEANUP_FILES+=("$RELEASES_FILE")
     PAGE=1
     while :; do
         RESPONSE="$(curl "${CURL_ARGS[@]}" \

--- a/Sources/DownrightApp/AI/FileWatcher.swift
+++ b/Sources/DownrightApp/AI/FileWatcher.swift
@@ -91,6 +91,15 @@ final class FileWatcher {
     private var suppressionBaseline: Snapshot?
     private var expectedOwnSnapshot: Snapshot?
     private var ownWriteGeneration: UInt64 = 0
+    /// A tentative removal waits out one bounded re-probe before being
+    /// delivered. External atomic saves pass through a window where the path
+    /// does not exist (unlink, then rename into place); our own writes filter
+    /// that transient through suppression state, and an external writer gets
+    /// this probe instead of a phantom "the file is gone".
+    private var pendingRemovalProbe: DispatchWorkItem?
+    /// Shorter than the document layer's quiet period, longer than any local
+    /// unlink→rename gap, so a genuine deletion is reported promptly.
+    private var removalProbeInterval: TimeInterval = 0.35
     /// Metadata is the cheap path for ordinary polls. Every few polls we
     /// still hash unchanged metadata so an in-place rewrite that preserves
     /// inode, size, and timestamps is detected even on filesystems whose
@@ -159,6 +168,8 @@ final class FileWatcher {
         pollTimer = nil
         coalesceWorkItem?.cancel()
         coalesceWorkItem = nil
+        pendingRemovalProbe?.cancel()
+        pendingRemovalProbe = nil
         forceContentDigestOnNextCheck = false
     }
 
@@ -414,6 +425,12 @@ final class FileWatcher {
         onQueue { ownWriteWatchdogDeadline = .distantPast }
     }
 
+    /// Runs the tentative-removal resolution synchronously, so race tests can
+    /// pin both outcomes of the removal grace without waiting out its interval.
+    func resolveRemovalProbeForTesting() {
+        onQueue { resolveTentativeRemoval() }
+    }
+
     /// Drives directory-watch event matching directly, without depending on
     /// FSEvents delivery timing.
     func deliverDirectoryEventForTesting(paths: [String]) {
@@ -467,6 +484,47 @@ final class FileWatcher {
             return
         }
 
+        guard now != lastSnapshot else { return }
+        let previous = lastSnapshot
+
+        if now.size < 0, previous.size >= 0 {
+            // Rename following stays immediate — the old inode is findable
+            // right now, and deferring it would stall Save As / rename UX.
+            if previous.inode != 0,
+               let relocated = FileWatcher.locate(previous, in: url.deletingLastPathComponent()) {
+                retarget(to: relocated)
+                let newURL = url
+                deliver(.renamed(to: newURL))
+                return
+            }
+            scheduleRemovalReprobe()
+            return
+        }
+
+        pendingRemovalProbe?.cancel()
+        pendingRemovalProbe = nil
+        lastSnapshot = now
+        deliver(event(for: now, previous: previous))
+    }
+
+    /// One bounded re-probe before committing a removal. When the probe runs,
+    /// the same snapshot-and-classify logic decides: the file came back (an
+    /// external atomic replacement) and is reported as the change it became,
+    /// or it is still gone and `.removed` is delivered.
+    private func scheduleRemovalReprobe() {
+        guard pendingRemovalProbe == nil else { return }
+        let gen = generation
+        let item = DispatchWorkItem { [weak self] in
+            guard let self, self.generation == gen else { return }
+            self.pendingRemovalProbe = nil
+            self.resolveTentativeRemoval()
+        }
+        pendingRemovalProbe = item
+        queue.asyncAfter(deadline: .now() + removalProbeInterval, execute: item)
+    }
+
+    private func resolveTentativeRemoval() {
+        let now = FileWatcher.snapshot(of: url, includeContentDigest: true)
         guard now != lastSnapshot else { return }
         let previous = lastSnapshot
         lastSnapshot = now

--- a/Sources/DownrightApp/AI/MarkdownDocument.swift
+++ b/Sources/DownrightApp/AI/MarkdownDocument.swift
@@ -899,7 +899,13 @@ final class MarkdownDocument: NSObject {
         return true
     }
 
-    func apply(_ edits: [TextEdit], actionName: String) {
+    /// Applies structural-command edits as one explicit transaction.
+    ///
+    /// When `tidyRules` is given, the transaction follows the documented
+    /// sequence — apply edit, reparse, plan tidy rules, apply tidy edit — all
+    /// inside the *same* undo group, so ⌘Z undoes the command and its
+    /// automatic repair together (§6.4: indenting renumbers ordered lists).
+    func apply(_ edits: [TextEdit], actionName: String, tidyRules: Set<TidyRule>? = nil) {
         guard !edits.isEmpty else { return }
         // Back to front so earlier offsets stay valid, matching
         // `[TextEdit].applied(to:)`.
@@ -920,6 +926,21 @@ final class MarkdownDocument: NSObject {
         undoManager.beginUndoGrouping()
         for edit in accepted {
             replace(edit.range, with: edit.replacement, actionName: nil)
+        }
+        if let tidyRules, !tidyRules.isEmpty {
+            // Reparse silently mid-batch: the plan must see the tree as the
+            // landed edits shape it, and the trailing `reparseNow()` below
+            // remains the single notification point.
+            reparseSynchronously(notifying: false, wholesale: false)
+            var tidyLastStart = Int.max
+            for edit in TidyDocument.plan(parsed, rules: tidyRules)
+                .sorted(by: { $0.range.location > $1.range.location }) {
+                guard edit.range.upperBound <= tidyLastStart,
+                      edit.range.upperBound <= storage.length
+                else { continue }
+                tidyLastStart = edit.range.location
+                replace(edit.range, with: edit.replacement, actionName: nil)
+            }
         }
         undoManager.setActionName(actionName)
         undoManager.endUndoGrouping()

--- a/Sources/DownrightApp/AI/MarkdownDocument.swift
+++ b/Sources/DownrightApp/AI/MarkdownDocument.swift
@@ -250,6 +250,11 @@ final class MarkdownDocument: NSObject {
     /// undo/redo consume its own callback instead of leaving a stale token
     /// behind for the next real edit.
     private var ignoredExternalStorageCallbackTexts: [String] = []
+    /// Upper bound on unconsumed suppression tokens. Each one holds a
+    /// whole-document string; the bound keeps a run of unmatched callbacks
+    /// from accumulating unbounded state and keeps the exact-match scan in
+    /// `handleTextStorageEdit` cheap.
+    private static let maximumIgnoredExternalCallbackTexts = 8
     private var isApplyingBatch = false
     private var suppressReparse = false
     private let parseCoordinator: MarkdownParseCoordinator
@@ -791,6 +796,11 @@ final class MarkdownDocument: NSObject {
         // Discard change marks owned by a torn-down document so they cannot
         // leak across to the next file opened in the same window.
         changes.reset()
+        // Undo registrations target `self`, so every entry retains the whole
+        // document (storage, parsed tree, watcher reference). A closed
+        // document can never serve another undo, and without this the stack
+        // keeps it — and everything it holds — un-deallocable.
+        undoManager.removeAllActions()
         enqueueParseControl { await $0.suspend() }
         watcher?.stop()
         watcher = nil
@@ -1469,7 +1479,14 @@ final class MarkdownDocument: NSObject {
         undoManager.endUndoGrouping()
 
         isApplyingExternalChange = true
+        // Bounded: a token whose callback never arrives (a racing local edit
+        // changed the post-edit text before delivery) must not retain a
+        // whole-document copy forever, and the oldest entries are precisely
+        // the ones whose transactions are already over.
         ignoredExternalStorageCallbackTexts.append(incoming)
+        if ignoredExternalStorageCallbackTexts.count > Self.maximumIgnoredExternalCallbackTexts {
+            ignoredExternalStorageCallbackTexts.removeFirst()
+        }
         storage.beginEditing()
         if let hunks, !hunks.isEmpty {
             let incomingText = incoming as NSString

--- a/Sources/DownrightApp/AI/MarkdownParseWorker.swift
+++ b/Sources/DownrightApp/AI/MarkdownParseWorker.swift
@@ -88,8 +88,21 @@ actor MarkdownParseCoordinator {
     /// non-cancellable cmark parse. Actor reentrancy permits the Sendable worker
     /// operation to overlap the stale request; the document revision gate still
     /// decides which result may commit.
+    ///
+    /// A coordinator that is suspended or shut down must not spend a parse on
+    /// this request. The returned placeholder carries the request's own text,
+    /// so the document's `document.text == text` gate rejects it — same
+    /// contract as a result that raced a newer edit.
     func runImmediately(_ request: MarkdownParseRequest) async -> MarkdownParseResult {
-        await worker.run(
+        guard !isSuspended, !isShutdown else {
+            return MarkdownParseResult(
+                revision: request.revision,
+                text: request.text,
+                document: ParsedDocument.empty,
+                dirty: DirtySet(ranges: [], isWholesale: false)
+            )
+        }
+        return await worker.run(
             text: request.text,
             previous: request.previous,
             revision: request.revision

--- a/Sources/DownrightApp/AI/SnapshotStore.swift
+++ b/Sources/DownrightApp/AI/SnapshotStore.swift
@@ -144,7 +144,9 @@ final class SnapshotStore: @unchecked Sendable {
 
         var state = stateByDocument[documentKey] ?? DocumentState()
         if !state.isLoaded {
-            state.newestHash = loadIndex(for: url).versions.last?.hash
+            if case .loaded(let existing) = loadIndexState(for: url) {
+                state.newestHash = existing.versions.last?.hash
+            }
             state.isLoaded = true
         }
         guard state.newestHash != hash else {
@@ -159,10 +161,20 @@ final class SnapshotStore: @unchecked Sendable {
 
         queue.async { [self] in
             writeObjectIfNeeded(hash: hash, data: data)
-            var idx = loadIndex(for: url)
-            guard idx.versions.last?.hash != hash else { return }
-            idx.versions.append(record)
-            saveIndex(idx, for: url)
+            // The object above is safe regardless of index health: while any
+            // present-but-undecodable index exists, pruning fails closed and
+            // will not treat it as unreferenced. The index itself is only
+            // rewritten when it is readable or genuinely absent.
+            switch loadIndexState(for: url) {
+            case .loaded(var idx):
+                guard idx.versions.last?.hash != hash else { return }
+                idx.versions.append(record)
+                saveIndex(idx, for: url)
+            case .missing:
+                saveIndex(Index(path: url.path, versions: [record]), for: url)
+            case .unreadable:
+                break
+            }
             pruneIfDue()
         }
         return record
@@ -171,7 +183,8 @@ final class SnapshotStore: @unchecked Sendable {
     // MARK: - Reading
 
     func versions(for url: URL) -> [VersionRecord] {
-        loadIndex(for: url).versions
+        if case .loaded(let index) = loadIndexState(for: url) { return index.versions }
+        return []
     }
 
     func text(for record: VersionRecord) -> String? {
@@ -315,11 +328,24 @@ final class SnapshotStore: @unchecked Sendable {
         indexDirectory.appendingPathComponent(Self.documentKey(for: url) + ".json")
     }
 
-    private func loadIndex(for url: URL) -> Index {
-        guard let data = try? Data(contentsOf: indexURL(for: url)),
+    /// The three answers an index file can give. "Absent" and "present but
+    /// undecodable" must stay distinct: overwriting the latter replaces every
+    /// version it references with a one-entry index, and the following prune
+    /// garbage-collects those now-unreferenced objects — permanent history
+    /// loss caused by a repairable bit of corruption.
+    private enum IndexLoad {
+        case loaded(Index)
+        case missing
+        case unreadable
+    }
+
+    private func loadIndexState(for url: URL) -> IndexLoad {
+        let fileURL = indexURL(for: url)
+        guard fm.fileExists(atPath: fileURL.path) else { return .missing }
+        guard let data = try? Data(contentsOf: fileURL),
               let index = try? JSONDecoder.snapshotDecoder.decode(Index.self, from: data)
-        else { return Index(path: url.path, versions: []) }
-        return index
+        else { return .unreadable }
+        return .loaded(index)
     }
 
     private func saveIndex(_ index: Index, for url: URL) {
@@ -465,7 +491,12 @@ final class SnapshotStore: @unchecked Sendable {
         for indexFile in indexes where indexFile.pathExtension == "json" {
             guard let data = try? Data(contentsOf: indexFile),
                   let index = try? JSONDecoder.snapshotDecoder.decode(Index.self, from: data)
-            else { continue }
+            else {
+                // An index that cannot be decoded may be the only thing
+                // referencing its objects. Same fail-closed rule as prune():
+                // with incomplete reference knowledge, delete nothing.
+                return
+            }
             referenced.formUnion(index.versions.map(\.hash))
         }
         for object in objectInventory() where !referenced.contains(object.hash) {

--- a/Sources/DownrightApp/App/DocumentWindowController+Commands.swift
+++ b/Sources/DownrightApp/App/DocumentWindowController+Commands.swift
@@ -481,7 +481,14 @@ extension DocumentWindowController: CommandResponder {
         let line = (markdownDocument.text as NSString).lineRange(for: selectionRange())
         let edits = ListEditing.indent(markdownDocument.parsed, lineRange: line, outdent: outdent)
         guard !edits.isEmpty else { return false }
-        markdownDocument.apply(edits, actionName: outdent ? "Outdent" : "Indent")
+        // §6.4: indent and outdent renumber ordered lists automatically. The
+        // rule only touches markers that genuinely disagree with their
+        // position in their own list.
+        markdownDocument.apply(
+            edits,
+            actionName: outdent ? "Outdent" : "Indent",
+            tidyRules: [.orderedListNumbers]
+        )
         return true
     }
 

--- a/Sources/DownrightApp/Panels/UpdateWindowController.swift
+++ b/Sources/DownrightApp/Panels/UpdateWindowController.swift
@@ -623,26 +623,70 @@ final class UpdateNotesView: NSView {
         return textView
     }
 
-    /// Linked release notes arrive as HTML.  A web view is out of proportion
-    /// for a small panel; convert to a readable attributed string instead.
+    /// Linked release notes arrive as arbitrary HTML from the update
+    /// channel's host. `NSAttributedString`'s html document type runs the
+    /// WebKit content engine over it — remote subresource fetches included —
+    /// which is out of proportion for a small panel and outside the network
+    /// surface the app documents. Reduce the page to readable text instead;
+    /// Downright's own pipeline embeds Markdown in the appcast, so this path
+    /// only ever serves third-party-shaped notes.
     static func releaseNotesTextView(for data: Data, sheet: StyleSheet) -> NSTextView {
         let sample = String(data: data.prefix(1_024), encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        if sample.hasPrefix("<"),
-            let attributed = try? NSAttributedString(
-                data: data,
-                options: [.documentType: NSAttributedString.DocumentType.html],
-                documentAttributes: nil
-            ) {
-            let textView = NSTextView(frame: .zero)
-            textView.textStorage?.setAttributedString(attributed)
-            textView.isEditable = false
-            textView.isSelectable = true
-            textView.drawsBackground = false
-            textView.textContainerInset = NSSize(width: 4, height: 8)
-            return textView
+        if sample.hasPrefix("<") {
+            return markdownTextView(for: Self.textFromHTML(data), sheet: sheet)
         }
         // Not HTML — treat as plain text (or Markdown that Sparkle fetched raw).
         return markdownTextView(for: String(data: data, encoding: .utf8) ?? "", sheet: sheet)
+    }
+
+    /// Reduces an HTML page to plain text without a web engine. Block-level
+    /// boundaries become line breaks, script/style content is dropped whole,
+    /// and the handful of entities a release page actually uses are decoded.
+    static func textFromHTML(_ data: Data) -> String {
+        var text = String(data: data, encoding: .utf8) ?? ""
+        for (pattern, replacement) in [
+            ("<script[^>]*>.*?</script>", ""),
+            ("<style[^>]*>.*?</style>", ""),
+            ("<br\\s*/?>", "\n"),
+            ("</(p|div|h[1-6]|li|tr|blockquote|pre)>", "\n"),
+            ("<(p|div|h[1-6]|li|tr|blockquote|pre)[^>]*>", "\n"),
+            ("</?[a-zA-Z][^>]*>", ""),
+        ] {
+            text = text.replacingOccurrences(
+                of: pattern, with: replacement,
+                options: [.regularExpression, .caseInsensitive]
+            )
+        }
+        let entities = [
+            "&amp;": "&", "&lt;": "<", "&gt;": ">", "&quot;": "\"",
+            "&apos;": "'", "&#39;": "'",
+        ]
+        for (entity, character) in entities {
+            text = text.replacingOccurrences(of: entity, with: character)
+        }
+        if let numeric = try? NSRegularExpression(
+            pattern: "&#(x?)([0-9a-fA-F]+);", options: [.caseInsensitive]
+        ) {
+            // Replace right to left so earlier ranges stay valid.
+            for match in numeric.matches(
+                in: text, range: NSRange(location: 0, length: (text as NSString).length)
+            ).reversed() {
+                let usesHex = match.range(at: 1).location != NSNotFound
+                    && (text as NSString).substring(with: match.range(at: 1)).lowercased() == "x"
+                let digits = match.range(at: 2)
+                guard digits.location != NSNotFound,
+                      let value = UInt32((text as NSString).substring(with: digits), radix: usesHex ? 16 : 10),
+                      let scalar = Unicode.Scalar(value),
+                      value >= 0x20
+                else { continue }
+                text = (text as NSString).replacingCharacters(
+                    in: match.range, with: String(Character(scalar))
+                )
+            }
+        }
+        return text
+            .replacingOccurrences(of: "\\n{3,}", with: "\n\n", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
     }
 }
 

--- a/Sources/MarkdownCore/DocumentIO.swift
+++ b/Sources/MarkdownCore/DocumentIO.swift
@@ -69,15 +69,42 @@ public enum DocumentIO {
     /// UTF-8 scalar, so trailing bytes are trimmed until the head decodes.
     /// Returns `nil` when the file cannot be opened or its head cannot be
     /// decoded at all.
+    ///
+    /// Encoding detection matches a full `decode`, so a UTF-16/32 file's head
+    /// comes back as its real text instead of NUL-riddled mojibake: the
+    /// bounded surfaces must agree with what opening the file in the app
+    /// shows.
     public static func readHead(contentsOf url: URL, limit: Int) -> String? {
         guard let handle = try? FileHandle(forReadingFrom: url) else { return nil }
         defer { try? handle.close() }
-        guard let data = try? handle.read(upToCount: limit) else { return nil }
-        if let text = String(data: data, encoding: .utf8) { return text }
-        for drop in 1...3 where data.count > drop {
-            if let text = String(data: data.dropLast(drop), encoding: .utf8) { return text }
+        guard let data = try? handle.read(upToCount: limit), !data.isEmpty else { return nil }
+
+        let bom = detectBOM(data)
+        let body = data.dropFirst(bom?.length ?? 0)
+        let encoding: TextEncodingKind
+        if let bom {
+            encoding = bom.encoding
+        } else if let guessed = sniffBOMlessUTF16or32(body) {
+            encoding = guessed
+        } else if String(data: body, encoding: .utf8) != nil {
+            encoding = .utf8
+        } else {
+            encoding = .latin1
         }
-        return String(data: data, encoding: .isoLatin1)
+        if encoding.codeUnitWidth > 1 {
+            if let text = String(data: body, encoding: encoding.stringEncoding) { return text }
+            let trimmed = adjustTruncation(body, encoding: encoding)
+            if let text = String(data: trimmed, encoding: encoding.stringEncoding) { return text }
+        } else {
+            // A torn multi-byte UTF-8 tail: trim up to three bytes before
+            // the never-failing Latin-1 fallback hides the problem.
+            for drop in 0...3 where drop == 0 || data.count > drop {
+                if let text = String(data: data.dropLast(drop), encoding: .utf8) { return text }
+            }
+            return String(data: body, encoding: .isoLatin1)
+        }
+        // Corrupt beyond either repair path.
+        return String(data: body, encoding: .isoLatin1)
     }
 
     public static func write(_ text: String, to url: URL, fidelity: ByteFidelity) throws {

--- a/Sources/MarkdownCore/Hashing.swift
+++ b/Sources/MarkdownCore/Hashing.swift
@@ -3,11 +3,17 @@ import Foundation
 // MARK: - Subtree hashing (§3.5)
 //
 // FNV-1a over the block kind, its source bytes and its children's hashes.  Not
-// cryptographic and doesn't need to be: a collision costs one redundant
-// re-decoration, and 64 bits over a document's worth of blocks makes even that
-// vanishingly unlikely.  It is chosen over SipHash because it is seedless and
-// therefore stable across launches, which is what lets a hash be compared with
-// one computed by the previous parse.
+// cryptographic and doesn't need to be: 64 bits over a document's worth of
+// blocks makes a collision vanishingly unlikely.  It is chosen over SipHash
+// because it is seedless and therefore stable across launches, which is what
+// lets a hash be compared with one computed by the previous parse.
+//
+// Be honest about the failure mode if you touch this: equal hashes are read as
+// "unchanged" by every consumer, so a collision does not cost redundant work —
+// it *misses* a restyle (ASTDiff treats the pair as equal) or replays a stale
+// attribute program (the decoration program cache keys on this hash). FNV-1a
+// is linear and seedless, so collisions are constructible by an adversary who
+// controls document bytes; accidental ones are not a realistic concern.
 
 enum FNV {
     static let offsetBasis: UInt64 = 0xcbf2_9ce4_8422_2325

--- a/Sources/MarkdownCore/ListEditing.swift
+++ b/Sources/MarkdownCore/ListEditing.swift
@@ -57,7 +57,12 @@ public enum ListEditing {
             let punctuation = markerText.contains(")") ? ")" : "."
             next += "\(ordinal + 1)\(punctuation) "
         } else {
-            let bullet = markerText.dropFirst(indent.count).first.map(String.init) ?? "-"
+            // `markerRange` is parser-owned and excludes the container
+            // indentation, so the bullet character is just the marker's first
+            // non-whitespace character. (Stripping `indent` off the front of
+            // the marker text used to eat into `*`/`+` markers and fall back
+            // to `-`.)
+            let bullet = markerText.trimmingCharacters(in: .whitespaces).first.map(String.init) ?? "-"
             next += bullet + " "
         }
         if checkbox != nil { next += "[ ] " }

--- a/Sources/MarkdownCore/Restructure.swift
+++ b/Sources/MarkdownCore/Restructure.swift
@@ -65,14 +65,20 @@ public enum Restructure {
             )]
         }
 
-        let source = doc.substring(firstLine)
-        let indent = source.leadingIndent
-        let markerStart = firstLine.location + indent.utf16.count
-        guard heading.contentRange.location >= markerStart else { return [] }
+        // Anchor at the parser-owned block start. For a plain ATX line that
+        // sits just past the leading indent; for a heading inside a
+        // blockquote or list item it sits past the container marker, which
+        // must survive the conversion instead of being stripped away.
+        let markerLocation = heading.range.location
+        guard markerLocation >= firstLine.location,
+              markerLocation <= firstLine.upperBound,
+              heading.contentRange.location >= markerLocation,
+              heading.contentRange.location <= firstLine.upperBound
+        else { return [] }
         var edits = [TextEdit(
             range: NSRange(
-                location: markerStart,
-                length: heading.contentRange.location - markerStart
+                location: markerLocation,
+                length: heading.contentRange.location - markerLocation
             ),
             replacement: "",
             summary: "Heading to body text"
@@ -118,22 +124,45 @@ public enum Restructure {
         _ doc: ParsedDocument, _ heading: HeadingNode, to level: Int
     ) -> TextEdit? {
         let line = doc.range(ofLine: doc.line(at: heading.range.location))
-        let source = doc.substring(line)
-        let indent = source.leadingIndent
-        let hashes = source.dropFirst(indent.count).prefix { $0 == "#" }
-        if hashes.count != heading.level {
+
+        // A setext heading's block spans its underline line; an ATX heading
+        // is always confined to its own source line. Only a genuine setext
+        // shape may consume a second line. (A heading nested in a blockquote
+        // or list item also fails the naive "line starts with N hashes"
+        // probe below, because the container marker sits in front — it must
+        // never fall into the two-line path.)
+        let isSetext = heading.range.upperBound > line.upperBound
+
+        if isSetext {
             // Setext can express only H1/H2. The direct picker still promises
             // H1...H6, so normalize this heading to ATX while preserving the
-            // title's exact source bytes, indentation, and original line
-            // ending.  The *source* span, not `heading.title`: the parsed
-            // title is plain text, and rebuilding from it would strip the
-            // emphasis and code markers the line carries.
+            // container prefix before the block start, the title's exact
+            // source bytes, and the original line ending.  The *source*
+            // span, not `heading.title`: the parsed title is plain text, and
+            // rebuilding from it would strip the emphasis and code markers
+            // the line carries.
             let titleLineNumber = doc.line(at: line.location)
             guard titleLineNumber < doc.lineStarts.count else { return nil }
+            // A setext underline always sits on the immediately following
+            // source line. (The block range itself cannot be trusted for
+            // this: inside a list item cmark reports an end past the
+            // container's next sibling.) `lineStarts` is indexed by 0-based
+            // line, so the 1-based number of a line indexes the *following*
+            // line's start.
             let underlineStart = doc.lineStarts[titleLineNumber]
             let removalEnd = titleLineNumber + 1 < doc.lineStarts.count
                 ? doc.lineStarts[titleLineNumber + 1]
                 : doc.length
+            // Defensive shape check: only consume the second line when it
+            // really is an underline (`=` / `-` runs). Anything else must
+            // never be deleted by a level change.
+            let underlineText = doc.substring(
+                NSRange(location: underlineStart, length: removalEnd - underlineStart)
+            ).trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !underlineText.isEmpty, underlineText.allSatisfy({ $0 == "=" || $0 == "-" })
+            else { return nil }
+            let prefixLength = max(0, min(heading.range.location - line.location, line.length))
+            let prefix = doc.substring(NSRange(location: line.location, length: prefixLength))
             let separator = line.upperBound < underlineStart
                 ? doc.substring(NSRange(
                     location: line.upperBound,
@@ -143,12 +172,21 @@ public enum Restructure {
             let rawTitle = doc.substring(heading.contentRange)
             return TextEdit(
                 range: NSRange(location: line.location, length: removalEnd - line.location),
-                replacement: "\(indent)\(String(repeating: "#", count: level)) \(rawTitle)\(separator)",
+                replacement: "\(prefix)\(String(repeating: "#", count: level)) \(rawTitle)\(separator)",
                 summary: "H\(heading.level) → H\(level): \(heading.title)"
             )
         }
+
+        // ATX: replace exactly the `#` run at the parser-owned block start.
+        // For a plain line that equals the old leading-indent position; for a
+        // nested heading the run sits behind the container marker.
+        let nsSource = doc.substring(line) as NSString
+        let columnInLine = heading.range.location - line.location
+        guard columnInLine >= 0, columnInLine <= nsSource.length else { return nil }
+        let hashes = nsSource.substring(from: columnInLine).prefix { $0 == "#" }
+        guard hashes.utf16.count == heading.level else { return nil }
         return TextEdit(
-            range: NSRange(location: line.location + indent.utf16.count, length: hashes.count),
+            range: NSRange(location: heading.range.location, length: hashes.utf16.count),
             replacement: String(repeating: "#", count: level),
             summary: "H\(heading.level) → H\(level): \(heading.title)"
         )

--- a/Sources/MarkdownRender/Engine/DisplayMap.swift
+++ b/Sources/MarkdownRender/Engine/DisplayMap.swift
@@ -355,6 +355,15 @@ public struct DisplaySubstitution: Equatable {
         DisplaySubstitution(sourceRange: range, displayLength: 0, replacement: nil, isHidden: true)
     }
 
+    /// Builds an expanding substitution. Invariant every consumer of
+    /// `sourceOffset(forTextKit:)` silently relies on: `displayLength` must
+    /// never exceed `sourceRange.length`. The TextKit→source router treats a
+    /// TextKit offset as a source offset inside the substitution's paragraph,
+    /// which is only sound while display space stays numerically ≤ source
+    /// space. Every current producer uses `hide`, same-length
+    /// `replaceHidden`, or single-glyph math attachments; if you ever need a
+    /// true expansion, the router has to grow real per-substitution mapping
+    /// first.
     public static func replace(_ range: NSRange, with string: NSAttributedString) -> DisplaySubstitution {
         DisplaySubstitution(sourceRange: range, displayLength: string.length, replacement: string)
     }

--- a/Sources/MarkdownRender/Theme/PreviewAppearance.swift
+++ b/Sources/MarkdownRender/Theme/PreviewAppearance.swift
@@ -1,10 +1,10 @@
 import AppKit
 import Foundation
 
-/// Appearance and theme names shared by the app and its sandboxed Quick Look
-/// extension.  Quick Look is a separate process, so the ordinary app defaults
-/// domain is not visible there; the small app-group store keeps this setting
-/// explicit instead of making the extension guess from the last document.
+/// Appearance and theme names shared by the host app and its Quick Look
+/// extension.  See `PreviewAppearanceStore` below for how the names actually
+/// travel between processes — not an app group, despite what the type name
+/// might suggest.
 public enum PreviewAppearance: String, CaseIterable, Codable, Sendable {
     case system
     case light
@@ -30,7 +30,10 @@ public enum PreviewAppearance: String, CaseIterable, Codable, Sendable {
 /// Deliberately tiny bridge between the host app and Quick Look. Quick Look is
 /// sandboxed and a local/ad-hoc build cannot carry an App Group without a
 /// provisioning profile, so these namespaced values live in the macOS global
-/// preferences domain. Missing or malformed values mean System.
+/// preferences domain (`kCFPreferencesAnyApplication`). Missing or malformed
+/// values mean System. Whether a sandboxed `.appex` can read this domain is
+/// runtime-dependent; the packaged acceptance surface, not unit tests, owns
+/// proving the setting actually reaches the extension.
 public enum PreviewAppearanceStore {
     public static let appearanceKey = "com.ezzy.downright.quickLook.appearance"
     public static let lightThemeKey = "com.ezzy.downright.quickLook.lightTheme"

--- a/Sources/MarkdownRender/Theme/ThemeStore.swift
+++ b/Sources/MarkdownRender/Theme/ThemeStore.swift
@@ -121,6 +121,12 @@ public final class ThemeStore {
         return decode(contents.filter { $0.pathExtension.lowercased() == "json" })
     }
 
+    /// A theme is a palette, not a data set. Bound every read so a runaway
+    /// file in the hot-reloaded user folder cannot turn each reload event —
+    /// one per editor save burst in that directory — into an unbounded
+    /// allocation on the watch queue.
+    private static let maximumThemeFileBytes = 8 * 1024 * 1024
+
     /// A theme that fails to decode is skipped rather than surfaced: with hot
     /// reload the file is very often half-written, and the next event brings
     /// the good version a moment later.
@@ -130,7 +136,14 @@ public final class ThemeStore {
             .filter { !$0.lastPathComponent.hasPrefix(".") }
             .sorted { $0.lastPathComponent < $1.lastPathComponent }
             .compactMap { url in
-                guard let data = try? Data(contentsOf: url) else { return nil }
+                let values = try? url.resourceValues(
+                    forKeys: [.isRegularFileKey, .fileSizeKey]
+                )
+                guard values?.isRegularFile == true,
+                      let size = values?.fileSize,
+                      size > 0, size <= maximumThemeFileBytes,
+                      let data = try? Data(contentsOf: url)
+                else { return nil }
                 return try? decoder.decode(Theme.self, from: data)
             }
     }
@@ -281,6 +294,12 @@ final class DirectoryWatcher {
     private let url: URL
     private let onChange: () -> Void
     private let queue = DispatchQueue(label: "com.downright.theme-watch")
+    /// Watch state is touched from three threads: `start()` runs on the
+    /// constructing thread, source events and restarts run on `queue`, and
+    /// `deinit` can land anywhere. Lock-guarded rather than queue-confined —
+    /// `queue.sync` from `deinit` could deadlock if the last release ever
+    /// happened inside a queue block.
+    private let stateLock = NSLock()
     private var source: DispatchSourceFileSystemObject?
     private var descriptor: CInt = -1
     private var pending: DispatchWorkItem?
@@ -294,10 +313,10 @@ final class DirectoryWatcher {
     deinit { stop() }
 
     private func start() {
-        descriptor = open(url.path, O_EVTONLY)
-        guard descriptor >= 0 else { return }
+        let opened = open(url.path, O_EVTONLY)
+        guard opened >= 0 else { return }
         let source = DispatchSource.makeFileSystemObjectSource(
-            fileDescriptor: descriptor,
+            fileDescriptor: opened,
             eventMask: [.write, .extend, .attrib, .rename, .delete],
             queue: queue
         )
@@ -311,9 +330,12 @@ final class DirectoryWatcher {
             }
             self.scheduleReload()
         }
-        source.setCancelHandler { [descriptor] in close(descriptor) }
+        source.setCancelHandler { [opened] in close(opened) }
+        stateLock.lock()
+        descriptor = opened
         self.source = source
         source.resume()
+        stateLock.unlock()
     }
 
     private func restart() {
@@ -322,17 +344,25 @@ final class DirectoryWatcher {
     }
 
     private func stop() {
-        source?.cancel()
-        source = nil
+        stateLock.lock()
+        let source = self.source
+        self.source = nil
         descriptor = -1
+        // Cancelling inside the lock keeps stop atomic against a racing
+        // start(): the cancel handler closes exactly the descriptor that was
+        // current when the decision to stop was made.
+        source?.cancel()
+        stateLock.unlock()
     }
 
     /// One save produces a burst of events; coalescing keeps the reload — and
     /// therefore the full redecorate it triggers — to one per burst.
     private func scheduleReload() {
+        stateLock.lock()
         pending?.cancel()
         let work = DispatchWorkItem { [weak self] in self?.onChange() }
         pending = work
+        stateLock.unlock()
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.15, execute: work)
     }
 }

--- a/Sources/MarkdownRender/View/MarkdownTextView.swift
+++ b/Sources/MarkdownRender/View/MarkdownTextView.swift
@@ -688,7 +688,15 @@ public final class MarkdownTextView: NSTextView {
         parsedDocument = document
         hoveredLinkRange = nil
         updateGeneration &+= 1
-        if isWholesaleUpdate { pathExistence.removeAll(keepingCapacity: true) }
+        if isWholesaleUpdate {
+            pathExistence.removeAll(keepingCapacity: true)
+            // Collapse overrides are keyed by bare source offsets. After a
+            // wholesale rewrite those offsets belong to different blocks, so
+            // remembered open/closed choices would attach themselves to
+            // unrelated content; fall back to the parsed default instead.
+            codeCollapseOverrides.removeAll(keepingCapacity: true)
+            fragmentContext.collapseOverrides = codeCollapseOverrides
+        }
         fragmentContext.frontMatterFields = (document.frontMatter?.fields ?? []).map { ($0.key, $0.value) }
         fragmentContext.documentHasH1 = document.headings.contains { $0.level == 1 }
         // Text changed, so any table geometry cached for a previous revision

--- a/Sources/down/main.swift
+++ b/Sources/down/main.swift
@@ -66,8 +66,31 @@ func expandedMarkdownPaths(_ paths: [String]) -> [String] {
     return results.sorted()
 }
 
-func stdinFile() -> URL? {
-    guard isatty(FileHandle.standardInput.fileDescriptor) == 0 else { return nil }
+/// 1-based source line containing the UTF-16 `offset`, with the same
+/// line-ending semantics as MarkdownCore's line index (LF, CRLF, lone CR).
+/// Diagnostics print in the conventional `file:line:` shape, so an offset
+/// must never be shown in the line-number position.
+func lineNumber(at offset: Int, in text: String) -> Int {
+    let ns = text as NSString
+    let clamped = max(0, min(offset, ns.length))
+    var line = 1
+    var i = 0
+    while i < clamped {
+        let c = ns.character(at: i)
+        if c == 0x0A {
+            line += 1
+            i += 1
+        } else if c == 0x0D {
+            line += 1
+            i += (i + 1 < clamped && ns.character(at: i + 1) == 0x0A) ? 2 : 1
+        } else {
+            i += 1
+        }
+    }
+    return line
+}
+
+func stdinFile() -> URL? {    guard isatty(FileHandle.standardInput.fileDescriptor) == 0 else { return nil }
     let data = FileHandle.standardInput.readDataToEndOfFile()
     guard !data.isEmpty else { return nil }
     let directory = FileManager.default.temporaryDirectory.appendingPathComponent("Downright", isDirectory: true)
@@ -211,9 +234,11 @@ case .check(let json, let target, let paths):
             guard let data = try? JSONSerialization.data(withJSONObject: values, options: [.sortedKeys]) else { writeError("cannot encode JSON", status: 70) }
             FileHandle.standardOutput.write(data); FileHandle.standardOutput.write(Data("\n".utf8))
         } else {
-            for diagnostic in diagnostics { print("\(path):\(diagnostic.range.location + 1): \(diagnostic.severity.rawValue): \(diagnostic.message) [\(diagnostic.id)]") }
+            for diagnostic in diagnostics {
+                print("\(path):\(lineNumber(at: diagnostic.range.location, in: content)): \(diagnostic.severity.rawValue): \(diagnostic.message) [\(diagnostic.id)]")
+            }
             for diagnostic in compatibility {
-                print("\(path):\(diagnostic.range.location + 1): warning: \(diagnostic.title) [target:\(target?.rawValue ?? "unknown")]")
+                print("\(path):\(lineNumber(at: diagnostic.range.location, in: content)): warning: \(diagnostic.title) [target:\(target?.rawValue ?? "unknown")]")
             }
         }
     }

--- a/Tests/DownrightAppTests/AppLayerTests.swift
+++ b/Tests/DownrightAppTests/AppLayerTests.swift
@@ -260,6 +260,68 @@ struct AppLayerTests {
         #expect(store.content(for: record) == .text(text))
     }
 
+    /// Regression: a present-but-undecodable index used to be treated as an
+    /// empty one, so the next record overwrote it with a single-entry index
+    /// and the following prune garbage-collected every object the old index
+    /// referenced — one corrupt file became permanent history loss.
+    @Test func recordNeverOverwritesAnUnreadableIndex() async throws {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("downright-record-unreadable-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let historyDirectory = root.appendingPathComponent("history", isDirectory: true)
+        let store = SnapshotStore(historyDirectory: historyDirectory)
+        let document = root.appendingPathComponent("document.md")
+        let file = snapshotIndexFile(for: document, historyDirectory: historyDirectory)
+
+        let first = "first version\n"
+        #expect(store.record(first, for: document, kind: .baseline) != nil)
+        await store.waitForPendingWrites()
+        let versionsBefore = store.versions(for: document)
+        #expect(versionsBefore.count == 1)
+
+        try Data("not json".utf8).write(to: file, options: .atomic)
+        let corruptedBytes = try Data(contentsOf: file)
+
+        // Recording after corruption must not replace the unreadable index.
+        #expect(store.record("second version\n", for: document, kind: .external) != nil)
+        await store.waitForPendingWrites()
+        #expect(try Data(contentsOf: file) == corruptedBytes,
+                "the undecodable index file must be left exactly as it was")
+        #expect(store.content(forHash: versionsBefore[0].hash) == .text(first),
+                "the recorded object must survive a prune that fails closed")
+    }
+
+    /// The `forget` sweep shares prune's rule: with an undecodable index in
+    /// play, reference knowledge is incomplete and nothing may be deleted.
+    @Test func forgetDoesNotSweepObjectsBehindAnUnreadableIndex() async throws {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("downright-forget-unreadable-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let historyDirectory = root.appendingPathComponent("history", isDirectory: true)
+        let store = SnapshotStore(historyDirectory: historyDirectory)
+
+        let kept = root.appendingPathComponent("kept.md")
+        let keptText = "kept behind a corrupt index\n"
+        #expect(store.record(keptText, for: kept, kind: .baseline) != nil)
+        await store.waitForPendingWrites()
+
+        let forgotten = root.appendingPathComponent("forgotten.md")
+        #expect(store.record("forgotten\n", for: forgotten, kind: .baseline) != nil)
+        await store.waitForPendingWrites()
+
+        // Corrupt the *kept* document's index, then forget the other one.
+        let keptIndex = snapshotIndexFile(for: kept, historyDirectory: historyDirectory)
+        try Data("not json".utf8).write(to: keptIndex, options: .atomic)
+
+        store.forget(forgotten)
+        await store.waitForPendingWrites()
+
+        let keptVersions = store.versions(for: kept)
+        #expect(keptVersions.isEmpty, "the corrupt index reads as no versions")
+        #expect(store.content(forHash: SnapshotStore.hash(keptText)) == .text(keptText),
+                "its objects must not be swept while its index is unreadable")
+    }
+
     @Test func pruneKeepsOldHistoryForLiveDocument() async throws {
         let root = URL(fileURLWithPath: NSTemporaryDirectory())
             .appendingPathComponent("downright-prune-\(UUID().uuidString)", isDirectory: true)

--- a/Tests/DownrightAppTests/AppLayerTests.swift
+++ b/Tests/DownrightAppTests/AppLayerTests.swift
@@ -338,6 +338,68 @@ struct AppLayerTests {
         #expect(FileManager.default.fileExists(atPath: file.path))
     }
 
+    /// The per-document size budget trims a document's own history oldest
+    /// first and never drops its newest version.
+    @Test func perDocumentByteCapEvictsOldestFirstAndKeepsNewest() async throws {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("downright-cap-perdoc-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let historyDirectory = root.appendingPathComponent("history", isDirectory: true)
+        let store = SnapshotStore(historyDirectory: historyDirectory)
+        let document = root.appendingPathComponent("document.md")
+        // Any real text exceeds this budget, so every recorded version is
+        // trimmable except the newest, which retention always keeps.
+        store.maximumBytesPerDocument = 8
+
+        let first = "first version of the document body\n"
+        let second = "second version of the document body, revised\n"
+        let third = "third version of the document body, revised again\n"
+        #expect(store.record(first, for: document, kind: .baseline) != nil)
+        #expect(store.record(second, for: document, kind: .external) != nil)
+        #expect(store.record(third, for: document, kind: .external) != nil)
+        await store.waitForPendingWrites()
+
+        await runSnapshotPrune(store)
+
+        let versions = store.versions(for: document)
+        #expect(versions.count == 1, "the per-document budget sheds older versions")
+        #expect(store.text(for: versions[0]) == third,
+                "the newest version survives the budget")
+    }
+
+    /// The global backstop must shed history fairly: no single document may
+    /// lose its newest version, whatever its neighbours have been doing.
+    @Test func globalByteCapKeepsEveryDocumentsNewestVersion() async throws {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("downright-cap-global-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let historyDirectory = root.appendingPathComponent("history", isDirectory: true)
+        let store = SnapshotStore(historyDirectory: historyDirectory)
+        // A zero-byte backstop forces the global pass to shed everything it
+        // legitimately can while retention rules hold.
+        store.maximumBytes = 0
+
+        for name in ["a.md", "b.md"] {
+            let url = root.appendingPathComponent(name)
+            for index in 0..<3 {
+                #expect(store.record(
+                    "version \(index) of \(name)\n", for: url,
+                    kind: index == 0 ? .baseline : .external
+                ) != nil)
+            }
+        }
+        await store.waitForPendingWrites()
+
+        await runSnapshotPrune(store)
+
+        for name in ["a.md", "b.md"] {
+            let url = root.appendingPathComponent(name)
+            let versions = store.versions(for: url)
+            #expect(versions.count == 1, "\(name) keeps exactly its newest version")
+            #expect(store.text(for: versions[0]) == "version 2 of \(name)\n")
+        }
+    }
+
     @Test func pruneDoesNotRewriteUnchangedIndex() async throws {
         let root = URL(fileURLWithPath: NSTemporaryDirectory())
             .appendingPathComponent("downright-prune-\(UUID().uuidString)", isDirectory: true)

--- a/Tests/DownrightAppTests/DocumentTrustStateTests.swift
+++ b/Tests/DownrightAppTests/DocumentTrustStateTests.swift
@@ -223,6 +223,32 @@ struct DocumentTrustStateTests {
         document.close()
     }
 
+    /// §6.4: indent/outdent renumber ordered lists automatically, and the
+    /// renumbering lands in the SAME undo group as the indentation — one ⌘Z
+    /// restores the original text exactly.
+    @Test @MainActor
+    func outdentingAnOrderedListRenumbersInOneUndoGroup() throws {
+        let fixture = try Fixture(text: "1. one\n   1. child\n2. two\n")
+        defer { fixture.remove() }
+        let document = MarkdownDocument()
+        try document.open(fixture.url)
+
+        // Outdent the nested item: the raw edit only removes its indent.
+        document.ensureParsedCurrent()
+        let line = (document.text as NSString).lineRange(for: NSRange(location: 7, length: 0))
+        let edits = ListEditing.indent(document.parsed, lineRange: line, outdent: true)
+        #expect(!edits.isEmpty)
+        document.apply(edits, actionName: "Outdent", tidyRules: [.orderedListNumbers])
+
+        #expect(document.text == "1. one\n2. child\n3. two\n",
+                "the outdented list is renumbered automatically")
+
+        // One undo step removes the renumber and the indent together.
+        document.undoManager.undo()
+        #expect(document.text == "1. one\n   1. child\n2. two\n")
+        document.close()
+    }
+
     /// The Discard composition, end to end: whatever implicit save work was
     /// already queued when the user pressed Discard must find a clean buffer
     /// afterwards and leave the declined bytes off disk.

--- a/Tests/DownrightAppTests/DocumentTrustStateTests.swift
+++ b/Tests/DownrightAppTests/DocumentTrustStateTests.swift
@@ -223,6 +223,34 @@ struct DocumentTrustStateTests {
         document.close()
     }
 
+    /// The Discard composition, end to end: whatever implicit save work was
+    /// already queued when the user pressed Discard must find a clean buffer
+    /// afterwards and leave the declined bytes off disk.
+    @Test @MainActor
+    func lateImplicitSaveAfterDiscardWritesNothing() throws {
+        let fixture = try Fixture(text: "on disk\n")
+        defer { fixture.remove() }
+        let document = MarkdownDocument()
+        try document.open(fixture.url)
+        #expect(document.replace(
+            NSRange(location: 0, length: document.storage.length),
+            with: "declined\n", actionName: "Paste"
+        ))
+        let diskBefore = try Data(contentsOf: fixture.url)
+
+        // The alert handler's action for "Discard Changes".
+        document.discardUnsavedChanges()
+        #expect(!document.isDirty)
+
+        guard case .success = document.saveIfNeeded() else {
+            Issue.record("a discarded buffer must read as clean to implicit saves")
+            return
+        }
+        #expect(try Data(contentsOf: fixture.url) == diskBefore,
+                "the declined edits must not reach disk through any later save")
+        document.close()
+    }
+
     @Test @MainActor
     func byteOnlyExternalRewriteUpdatesFidelityBeforeSaving() throws {
         let fixture = try Fixture(text: "one\ntwo\n")

--- a/Tests/DownrightAppTests/FileWatcherTests.swift
+++ b/Tests/DownrightAppTests/FileWatcherTests.swift
@@ -173,6 +173,53 @@ struct FileWatcherTests {
         #expect(events.isRestored(at: 2))
     }
 
+    /// Regression: an external atomic save observed inside its unlink→rename
+    /// gap used to be delivered as `.removed` — the sibling scan looks for
+    /// the *old* inode, which the replacement does not have. A tentative
+    /// removal now waits out one bounded re-probe.
+    @Test("an external atomic replacement observed mid-gap is a change, not a removal")
+    func atomicReplacementObservedMidGapIsNotARemoval() async throws {
+        let fixture = try Fixture(contents: "document")
+        defer { fixture.remove() }
+        let events = EventCollector()
+        let watcher = FileWatcher(url: fixture.url) { events.append($0) }
+        defer { watcher.stop() }
+
+        watcher.checkNowForTesting()
+
+        // The unlink phase of an external atomic save: the watched path is
+        // missing and the old inode is gone (a parked sibling would make
+        // this an ordinary rename, which follows immediately).
+        try FileManager.default.removeItem(at: fixture.url)
+        watcher.checkNowForTesting()
+        #expect(events.count == 0, "the transient gap must not be reported")
+
+        // The rename phase lands new content at the path before the probe.
+        try Data("rewritten".utf8).write(to: fixture.url)
+        watcher.resolveRemovalProbeForTesting()
+
+        try await expectEventCount(events, 1)
+        #expect(events.isChanged(at: 0), "the replacement must arrive as a change")
+    }
+
+    @Test("a genuine removal is still delivered once the re-probe resolves")
+    func trueRemovalIsStillDelivered() async throws {
+        let fixture = try Fixture(contents: "document")
+        defer { fixture.remove() }
+        let events = EventCollector()
+        let watcher = FileWatcher(url: fixture.url) { events.append($0) }
+        defer { watcher.stop() }
+
+        watcher.checkNowForTesting()
+        try FileManager.default.removeItem(at: fixture.url)
+        watcher.checkNowForTesting()
+        #expect(events.count == 0, "the probe has not resolved yet")
+        watcher.resolveRemovalProbeForTesting()
+
+        try await expectEventCount(events, 1)
+        #expect(events.isRemoved(at: 0))
+    }
+
     private func settle() async throws {
         try await Task.sleep(nanoseconds: 350_000_000)
     }

--- a/Tests/DownrightAppTests/UpdateCoordinatorTests.swift
+++ b/Tests/DownrightAppTests/UpdateCoordinatorTests.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Foundation
+import MarkdownRender
 import Testing
 @testable import DownrightApp
 
@@ -1086,5 +1087,40 @@ struct ReleaseWatchSettingTests {
         coordinator.automaticallyChecksForUpdates = true
         coordinator.releaseFeedDidChange()
         #expect(engine.backgroundCheckCount == 2)
+    }
+}
+
+/// Linked release notes must never reach the WebKit-backed html document
+/// type: the update channel's host is outside the app's documented network
+/// surface, and a web engine would fetch remote subresources. The reduction
+/// keeps the text, drops the machinery.
+@Suite struct UpdateReleaseNotesReductionTests {
+    @Test @MainActor func stripsTagsAndKeepsReadableText() {
+        let html = """
+        <html><head><style>body { color: red }</style>​<script>alert(1)</script></head>
+        <body><h1>Downright 1.0.17</h1><p>First &amp; second &#8212; line</p>
+        <ul><li>one</li><li>two</li></ul><p>Bye<br/>now</p></body></html>
+        """
+        let text = UpdateNotesView.textFromHTML(Data(html.utf8))
+        #expect(text.contains("Downright 1.0.17"))
+        #expect(text.contains("First & second — line"))
+        #expect(text.contains("one") && text.contains("two"))
+        #expect(text.contains("Bye\nnow"))
+        #expect(!text.lowercased().contains("alert"), "script content is dropped whole")
+        #expect(!text.contains("{ color"), "style content is dropped whole")
+        #expect(!text.contains("<"), "no tags survive")
+    }
+
+    @Test @MainActor func nonHTMLDataPassesThroughAsText() {
+        let markdown = "## Notes\n- plain"
+        let view = UpdateNotesView.releaseNotesTextView(
+            for: Data(markdown.utf8),
+            sheet: StyleSheet(
+                theme: ThemeStore.shared.current,
+                appearance: NSAppearance.current,
+                reduceMotionOverride: false
+            )
+        )
+        #expect(view.string.contains("Notes"))
     }
 }

--- a/Tests/MarkdownCoreTests/DocumentIOTests.swift
+++ b/Tests/MarkdownCoreTests/DocumentIOTests.swift
@@ -140,6 +140,28 @@ import Testing
         #expect(head?.utf8.count == 28)
     }
 
+    /// The bounded head must agree with a full decode about the encoding.
+    /// It used to sniff only UTF-8, so a UTF-16 file's head came back as
+    /// NUL-riddled mojibake in thumbnails and Spotlight while the app itself
+    /// opened the same file correctly.
+    @Test func readHeadMatchesFullDecodeForWideEncodings() throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let text = "# Título\n\nContenido — con acentos.\n"
+        for (name, data) in [
+            ("bom16.md", text.data(using: .utf16)!),
+            ("bomless16.md", text.data(using: .utf16LittleEndian)!),
+            ("bom8.md", Data([0xEF, 0xBB, 0xBF]) + Data(text.utf8)),
+            ("plain8.md", Data(text.utf8)),
+        ] {
+            let url = directory.appendingPathComponent(name)
+            try data.write(to: url)
+            let full = try DocumentIO.decodeSnapshot(data, sourceURL: url).text
+            let head = try #require(DocumentIO.readHead(contentsOf: url, limit: 64 * 1024))
+            #expect(head == full, "\(name): head must decode like a full read")
+        }
+    }
+
     @Test func readHeadReturnsNilForMissingFile() {
         #expect(DocumentIO.readHead(
             contentsOf: URL(fileURLWithPath: "/nonexistent/\(UUID().uuidString).md"),

--- a/Tests/MarkdownCoreTests/EditingTests.swift
+++ b/Tests/MarkdownCoreTests/EditingTests.swift
@@ -30,6 +30,15 @@ import Testing
         #expect(pressReturn("- top\n  - nested\n", at: 16) == "- top\n  - nested\n  - \n")
     }
 
+    /// Regression: `markerRange` excludes the container indentation, so
+    /// dropping the indentation from the front of the *marker text* stripped
+    /// into the bullet itself; `*`/`+` items fell through to a `-`.
+    @Test func continuesNestedItemsWithTheirOwnMarkerCharacter() {
+        #expect(pressReturn("* top\n  * nested\n", at: 16) == "* top\n  * nested\n  * \n")
+        #expect(pressReturn("+ top\n  + nested\n", at: 16) == "+ top\n  + nested\n  + \n")
+        #expect(pressReturn("- top\n  * nested\n", at: 16) == "- top\n  * nested\n  * \n")
+    }
+
     /// §6.4: "outdent-and-exit on an empty item."
     @Test func emptyItemAtTopLevelExitsTheList() {
         #expect(pressReturn("- one\n- \n", at: 8) == "- one\n\n")

--- a/Tests/MarkdownCoreTests/RestructureTests.swift
+++ b/Tests/MarkdownCoreTests/RestructureTests.swift
@@ -75,6 +75,54 @@ import Testing
         ) == "Title\n\nBody\n")
     }
 
+    // MARK: Headings inside containers (blockquote markers, list items)
+
+    /// Regression: a heading nested in a blockquote or list item does not
+    /// begin with `#` after its leading whitespace — the container marker
+    /// sits in front — so it used to take the setext-normalization branch,
+    /// which consumed the *following* line as an underline and silently
+    /// deleted the quoted body.
+    @Test func demoteInsideBlockquoteKeepsTheQuotedBody() {
+        let text = "# Top\n> ## Deep\n> hidden secret\n"
+        let doc = MarkdownParser.parse(text)
+        let out = apply(text, Restructure.demoteHeading(doc, headingIndex: 1))
+        #expect(out == "# Top\n> ### Deep\n> hidden secret\n")
+    }
+
+    @Test func promoteInsideListItemKeepsTheMarker() {
+        let text = "- intro\n- ## Deep\n- tail\n"
+        let doc = MarkdownParser.parse(text)
+        let out = apply(text, Restructure.promoteHeading(doc, headingIndex: 0))
+        #expect(out == "- intro\n- # Deep\n- tail\n")
+    }
+
+    /// A setext heading inside a list item normalizes to ATX while keeping
+    /// the item marker and consuming exactly its own underline line.
+    @Test func setextInsideListItemNormalizesWithoutStrayUnderline() {
+        let text = "- Title\n  =====\n- tail\n"
+        let doc = MarkdownParser.parse(text)
+        let out = apply(text, Restructure.setHeadingLevel(doc, headingIndex: 0, level: 2))
+        #expect(out == "- ## Title\n- tail\n")
+    }
+
+    /// The old setext branch bailed out entirely when the heading was the
+    /// document's final line (no next line to index), so demote silently
+    /// did nothing.
+    @Test func rewriteLevelWorksWithoutATrailingNewline() {
+        for text in ["## Deep", "# Top\n## Deep"] {
+            let doc = MarkdownParser.parse(text)
+            let out = apply(text, Restructure.demoteHeading(doc, headingIndex: doc.headings.count - 1))
+            #expect(out == text.replacingOccurrences(of: "## Deep", with: "### Deep"))
+        }
+    }
+
+    @Test func headingToBodyTextKeepsContainerMarkers() {
+        let text = "> # Title\n> body\n"
+        let doc = MarkdownParser.parse(text)
+        let out = apply(text, Restructure.headingToBodyText(doc, headingIndex: 0))
+        #expect(out == "> Title\n> body\n")
+    }
+
     @Test func clampsAtTheEnds() {
         let top = MarkdownParser.parse("# A\n\n## B\n")
         #expect(Restructure.promoteHeading(top, headingIndex: 0).isEmpty)

--- a/npm/downright-installer/bin/downright-install.mjs
+++ b/npm/downright-installer/bin/downright-install.mjs
@@ -11,7 +11,7 @@ const installerURL = process.env.DOWNRIGHT_INSTALLER_URL ?? "https://downright.c
 // SHA-256 is pinned here and verified before a single byte runs.  Update this
 // constant in the same commit that changes install-release.sh.
 const INSTALLER_SHA256 =
-  "f16cc08d8c3048c9e37b2aeaac1adfd84b0059036986ef009d9c03dda1d2b0f2";
+  "2a78e36dd43fb2e21e62153536e1efaf00239f3441f8f2cd11cc3c49add9e869";
 
 if (process.platform !== "darwin") {
   console.error("Downright is currently available through this installer on macOS only.");

--- a/npm/downright-installer/package.json
+++ b/npm/downright-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "downright-installer",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Install the signed Downright macOS app from its latest release",
   "type": "module",
   "bin": {
@@ -9,6 +9,9 @@
   "engines": {
     "node": ">=18"
   },
+  "os": [
+    "darwin"
+  ],
   "files": [
     "bin",
     "README.md"


### PR DESCRIPTION
Full-repository audit and remediation (authorized defensive work). Baseline: `Scripts/check.sh` green at `17bbaf4` (1325 tests). Final gate on this branch: green, 1342 tests. Every behavioral fix ships with a regression test; the four highest-risk ones were proven to fail against HEAD by restoring the old file.

## Data loss / corruption
- **Heading restructure in containers** (`abfde8f`): demoting a heading inside a blockquote/list item took the setext-normalization path and consumed the *following* source line — `> ## Deep` deleted its quoted body. Also: heading→body stripped container markers; nested `*`/`+` list continuation inserted `-`.
- **Snapshot store** (`b95441c`): an undecodable history index was silently overwritten by the next record, then prune garbage-collected every object it referenced. Three-state index loading; forget() sweep now fails closed like prune.
- **Installers** (`c460624`): both installers kept the backup of the outgoing app inside the directory their exit trap deletes — SIGTERM mid-swap left /Applications empty. Backup now survives every exit path; local installer refuses to run over a live app instead of silently pkilling it; BIN_DEST failure warns instead of aborting post-install. Swap semantics sandbox-proven (fresh / TERM mid-swap / failed swap).
- **Watcher** (`211df14`): an external atomic save observed inside its unlink→rename window was delivered as `.removed`. One bounded re-probe before committing a removal; rename-following stays immediate.

## Correctness
- Bounded reads (thumbnails/Spotlight) decode UTF-16/32 heads exactly like full reads (`4f0810e`); `down check` prints real line numbers (`58869c9`).
- Documented indent/outdent renumbering actually implemented, inside one undo group (`3b46505`).
- Closed documents release their undo stack (retention leak); external-write suppression tokens bounded; priority parses respect suspend/shutdown gates (`06d1f01`).

## Security / privacy
- Linked release notes no longer rendered through the WebKit-backed html document type (remote subresource fetches) — reduced to text via Downright's own renderer (`a6c5a5e`).
- Theme hot-reload reads are size-bounded and regular-file-only (`58869c9`).

## Ops
- Release workflow: deploy job timeout; publish-verification curls bounded; delta listing limits inside jq (SIGPIPE footgun); archive pins `dwarf-with-dsym`; download-count report passes its token via config file instead of argv (`ff29638`).
- npm launcher: darwin-only `os`, version 0.1.2, pin re-set per same-commit contract (`ff29638`). **Publishing 0.1.2 is a follow-up action.**

## Docs
Honest failure-mode comments where they promised better (hash collisions, DisplaySubstitution invariants, PreviewAppearance store); PERFORMANCE.md rows without enforcement vehicles marked manual gates.

## Validation
`SCRATCH=.build-audit-final TEST_SCRATCH=.build-audit-final-test ./Scripts/check.sh` → exit 0, 1342 tests, all gates pass. SwiftLint clean on changed files. Installer swap harness: fresh install, SIGTERM mid-swap, failed swap all leave exactly one good installation.